### PR TITLE
Throw readable error if bag doesnt have a static tf

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -46,9 +46,9 @@ We have three dataloaders available currently: rosbag (both ROS1 and ROS2), raw,
 By default, the dataloader is detected from the provided path, but you can explicitly specify it using the `-d` flag.
 
 The system uses three key frames:
-- **IMU sensor frame**
-- **LiDAR sensor frame**
-- **Robot base frame**
+- IMU sensor frame
+- LiDAR sensor frame
+- Robot base frame
 
 The extrinsic transformations
 - `extrinsic_imu2base_quat_xyzw_xyz`

--- a/python/rko_lio/dataloaders/utils/static_tf_tree.py
+++ b/python/rko_lio/dataloaders/utils/static_tf_tree.py
@@ -33,6 +33,8 @@ def create_static_tf_tree(bag):
         dict: { child_frame_id: (parent_frame_id, transform) }
     """
     tf_tree = {}
+    if not "/tf_static" in bag.topics:
+        return tf_tree
 
     tf_static_connections = [
         conn for conn in bag.connections if (conn.topic == "/tf_static")


### PR DESCRIPTION
If the bag doesnt contain a tf tree, it throws a harder to understand error with 'key missing'. we detect that and throw a more readable 'bad doesnt have tf tree' error.