### PR TITLE
Add macOS and Windows support/builds/wheels

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -3,16 +3,18 @@ on:
   release:
     types: [published]
   push:
-    branches: ["master"]
+    branches: ["workflows_part2"]
   pull_request:
     branches: ["master"]
 jobs:
   cibuildwheel:
     name: Build wheels on ${{ matrix.os }}
+    env:
+      GIT_LFS_SKIP_SMUDGE: 1
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest] # windows and macos will be added later
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, macos-15]
     steps:
       - uses: actions/checkout@v5
       - name: Build test wheels (only PRs)

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -3,12 +3,12 @@ on:
   release:
     types: [published]
   push:
-    branches: ["workflows_part2"]
+    branches: ["master"]
   pull_request:
     branches: ["master"]
 jobs:
   cibuildwheel:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build py wheels on ${{ matrix.os }}
     env:
       GIT_LFS_SKIP_SMUDGE: 1
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/python_bindings.yaml
+++ b/.github/workflows/python_bindings.yaml
@@ -6,11 +6,12 @@ on:
     branches: ["workflows_part2"]
 jobs:
   python_bindings:
+    name: Build python bindings on different platforms
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         # os: [ubuntu-24.04, ubuntu-22.04, windows-2022, macos-14, macos-15]
-        os: [macos-14, macos-15]
+        os: [windows-2022]
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python3

--- a/.github/workflows/python_bindings.yaml
+++ b/.github/workflows/python_bindings.yaml
@@ -16,12 +16,14 @@ jobs:
       - uses: actions/checkout@v5
       - name: Set up Python3
         uses: actions/setup-python@v6
+        with:
+          python-version: 3.10
       - name: Install pip
         run: |
           python -m pip install --upgrade pip
       - name: Build with pip
         run: |
-          python -m pip install --verbose ./python/
-      - name: Test entrypoint
+          python -m pip install --verbose ./python/ pytest
+      - name: Run pytest
         run: |
-          rko_lio --help
+          pytest python/

--- a/.github/workflows/python_bindings.yaml
+++ b/.github/workflows/python_bindings.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python3
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.os == 'windows-11-arm' && '3.11' || '3.10' }}
       - name: Install pip
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python_bindings.yaml
+++ b/.github/workflows/python_bindings.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python3
         uses: actions/setup-python@v6
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install pip
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python_bindings.yaml
+++ b/.github/workflows/python_bindings.yaml
@@ -1,20 +1,20 @@
 name: Python Bindings
 on:
   push:
-    branches: ["master"]
+    branches: ["workflows_part2"]
   pull_request:
-    branches: ["master"]
+    branches: ["workflows_part2"]
 jobs:
   python_bindings:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # os: [ubuntu-24.04, ubuntu-22.04, windows-2022, macos-14, macos-15] 
-        os: [ubuntu-24.04, ubuntu-22.04]
+        # os: [ubuntu-24.04, ubuntu-22.04, windows-2022, macos-14, macos-15]
+        os: [macos-14, macos-15]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Set up Python3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
       - name: Install pip
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python_bindings.yaml
+++ b/.github/workflows/python_bindings.yaml
@@ -1,12 +1,12 @@
 name: Python Bindings
 on:
   push:
-    branches: ["workflows_part2"]
+    branches: ["master"]
   pull_request:
-    branches: ["workflows_part2"]
+    branches: ["master"]
 jobs:
   python_bindings:
-    name: Build python bindings on different platforms
+    name: Build python and run pytest on ${{ matrix.os }}
     env:
       GIT_LFS_SKIP_SMUDGE: 1
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/python_bindings.yaml
+++ b/.github/workflows/python_bindings.yaml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-24.04-arm, ubuntu-22.04-arm, macos-15, macos-14, windows-2022, windows-11-arm]
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-24.04-arm, ubuntu-22.04-arm, macos-15, macos-14, windows-2022]
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python3
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.os == 'windows-11-arm' && '3.11' || '3.10' }}
+          python-version: "3.10"
       - name: Install pip
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python_bindings.yaml
+++ b/.github/workflows/python_bindings.yaml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # os: [ubuntu-24.04, ubuntu-22.04, windows-2022, macos-14, macos-15]
-        os: [windows-2022]
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-24.04-arm, ubuntu-22.04-arm, macos-15, macos-14, windows-2022, windows-11-arm]
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python3

--- a/.github/workflows/python_bindings.yaml
+++ b/.github/workflows/python_bindings.yaml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-24.04-arm, ubuntu-22.04-arm, macos-15, macos-14, windows-2022]
+        # targetting the older versions here, and the newer versions for the pypi workflow
+        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-14, windows-2022]
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python3

--- a/.github/workflows/python_bindings.yaml
+++ b/.github/workflows/python_bindings.yaml
@@ -7,6 +7,8 @@ on:
 jobs:
   python_bindings:
     name: Build python bindings on different platforms
+    env:
+      GIT_LFS_SKIP_SMUDGE: 1
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -7,6 +7,7 @@ on:
     branches: ["master"]
 jobs:
   ros_build:
+    name: ROS build for ${{ matrix.ros_distro }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -1,4 +1,3 @@
-# We dont do a rolling build for now, because i'm sure thats gonna break often
 name: ROS Build
 on:
   push:
@@ -13,6 +12,7 @@ jobs:
       matrix:
         ros_distro: [jazzy, kilted]
         # ros_distro: [humble, jazzy, kilted]
+        # no rolling build for now, because i'm sure thats gonna break often
     container:
       image: osrf/ros:${{ matrix.ros_distro }}-desktop
     steps:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can install RKO_LIO by simply
 pip install rko_lio
 ```
 
-We provide wheels for Linux, Mac OS, and Windows.
+We provide wheels for Linux, macOS, and Windows.
 
 <details>
 <summary>Optional dependencies</summary>

--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@ rko_lio -v /path/to/rosbag
 
 and you should be good to go! For quick details on further options, check `rko_lio --help`.
 
-Note that for `pip install`-ing our package, as above, we currently only support Linux systems (python >= 3.9).
-Support for Windows and Mac-OS will be added soon!
-
 For detailed install and usage instructions, please refer to the [python bindings readme](python#rko_lio---python-bindings).
 
 ## Setup
@@ -71,14 +68,13 @@ If you encounter any issues, please check [build.md](docs/build.md) for further 
 
 The python interface to our system can be convenient to investigate recorded data offline as you don't need to setup a ROS environment first.
 
-Our PyPI release currently supports only Linux (python >= 3.9) systems.
-We will add support for Windows and Mac-OS soon!
-
 You can install RKO_LIO by simply
 
 ```bash
 pip install rko_lio
 ```
+
+We provide wheels for Linux, Mac OS, and Windows.
 
 <details>
 <summary>Optional dependencies</summary>

--- a/docs/build.md
+++ b/docs/build.md
@@ -31,7 +31,7 @@ Our dependency management is opt-in and you can pass `-DRKO_LIO_FETCH_CONTENT_DE
 
 ## The python bindings
 
-The python build uses `scikit-build-core` and all you need to provide is a python version >=3.9 and `pip` (or other build frontend).
+The python build uses `scikit-build-core` and all you need to provide is a python version >=3.10 and `pip` (or other build frontend).
 
 Then you can do `cd python && pip install .` and you don't even need to provide CMake or ninja or anything else.
 By default we fetch the core library dependencies, which you can change [here](python/pyproject.toml#L66).

--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,7 @@
 # RKO_LIO - Python Bindings
 
 The python interface/wrapper is a convenience tool to run the odometry offline on recorded data.
+We provide PyPI wheels for Linux, macOS, and Windows.
 
 ## Setup
 

--- a/python/pybind/helipr_file_reader_pybind.cpp
+++ b/python/pybind/helipr_file_reader_pybind.cpp
@@ -68,40 +68,52 @@ SensorType parse_sensor_type_and_variant(const std::string& sensor, const std::s
   throw std::runtime_error("Unknown sensor: " + sensor);
 }
 
-// #pragma pack can make this more portable apparently
-// as the following is gcc/clang only
-struct HeLiPR_velodyne {
+// thanks to https://stackoverflow.com/a/79177816
+// basically i dont want any padding on the structs due to alignment
+// that much i get, but what do the msvc macros mean? i dont know man
+// but really this is incredibly ugly, and i dont want to maintain it, helipr goes away in the first major release
+#ifdef __GNUC__
+#define PACK__
+#define __PACK __attribute__((__packed__))
+#endif
+
+#ifdef _MSC_VER
+#define PACK__ __pragma(pack(push, 1))
+#define __PACK __pragma(pack(pop))
+#endif
+
+PACK__ struct HeLiPR_velodyne {
   float x, y, z, intensity;
   uint16_t ring;
   float time;
-} __attribute__((packed));
+} __PACK;
 
-struct HeLiPR_ouster {
+PACK__ struct HeLiPR_ouster {
   float x, y, z, intensity;
   uint32_t t;
   uint16_t reflectivity;
   uint16_t ring;
   uint16_t ambient;
-} __attribute__((packed));
+} __PACK;
 
-struct HeLiPR_avia {
+PACK__ struct HeLiPR_avia {
   float x, y, z;
   uint8_t reflectivity, tag, line;
   uint32_t offset_time;
-} __attribute__((packed));
+} __PACK;
 
-struct HeLiPR_aeva {
+PACK__ struct HeLiPR_aeva {
   float x, y, z, reflectivity, velocity;
   int32_t time_offset_ns;
   uint8_t line_index;
-} __attribute__((packed));
+} __PACK;
 
-struct HeLiPR_aeva_new {
+PACK__ struct HeLiPR_aeva_new {
   float x, y, z, reflectivity, velocity;
   int32_t time_offset_ns;
   uint8_t line_index;
   float intensity;
-} __attribute__((packed));
+} __PACK;
 
 // makes a few things easier through templating
 template <SensorType sensor_type>

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -42,7 +42,8 @@ Homepage = "https://github.com/PRBonn/rko_lio"
 all = [
   "open3d",
   "rerun-sdk",
-  "rosbags"
+  "rosbags",
+  "pytest"
 ]
 
 [project.scripts]
@@ -73,3 +74,8 @@ manylinux-x86_64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
+
+[tool.pytest.ini_options]
+testpaths = [
+  "tests"
+]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "License :: OSI Approved :: MIT License",
   "Operating System :: Unix",
 ]
@@ -68,5 +69,7 @@ RKO_LIO_FETCH_CONTENT_DEPS = "ON"
 [tool.cibuildwheel]
 archs = ["auto64"]
 skip = ["*-musllinux*",  "pp*", "cp38-*"]
-
 manylinux-x86_64-image = "manylinux_2_28"
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "rko_lio"
-version = "0.0.1"
+version = "0.0.2"
 description = "A Robust Approach for LiDAR-Inertial Odometry Without Sensor-Specific Modelling"
 dependencies = ["numpy", "typer", "pyyaml", "scipy", "tqdm"]
 authors = [{ name = "Meher Malladi", email = "rm.meher97@gmail.com" }]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -66,8 +66,9 @@ CMAKE_POSITION_INDEPENDENT_CODE = "ON"
 RKO_LIO_FETCH_CONTENT_DEPS = "ON"
 
 [tool.cibuildwheel]
+environment = { GIT_LFS_SKIP_SMUDGE = "1" }
 archs = ["auto64"]
-skip = ["*-musllinux*",  "pp*", "cp38-*", "cp39-*"]
+skip = ["*-musllinux*", "pp*", "cp38-*", "cp39-*"]
 manylinux-x86_64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.macos]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,7 @@ description = "A Robust Approach for LiDAR-Inertial Odometry Without Sensor-Spec
 dependencies = ["numpy", "typer", "pyyaml", "scipy", "tqdm"]
 authors = [{ name = "Meher Malladi", email = "rm.meher97@gmail.com" }]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "MIT" }
 classifiers = [
   "Intended Audience :: Developers",
@@ -18,7 +18,6 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Programming Language :: C++",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -69,7 +68,7 @@ RKO_LIO_FETCH_CONTENT_DEPS = "ON"
 
 [tool.cibuildwheel]
 archs = ["auto64"]
-skip = ["*-musllinux*",  "pp*", "cp38-*"]
+skip = ["*-musllinux*",  "pp*", "cp38-*", "cp39-*"]
 manylinux-x86_64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.macos]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -72,6 +72,7 @@ skip = ["*-musllinux*", "pp*", "cp38-*", "cp39-*"]
 manylinux-x86_64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.macos]
+environment = "MACOSX_DEPLOYMENT_TARGET=11.0"
 archs = ["x86_64", "arm64"]
 
 [tool.pytest.ini_options]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: Unix",
 ]
 keywords = [

--- a/python/tests/test_imports.py
+++ b/python/tests/test_imports.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pytest
+
+
+def test_package_importable():
+    import rko_lio
+
+    assert rko_lio is not None
+
+
+def test_rko_lio_pybind_import():
+    from rko_lio import rko_lio_pybind
+
+    assert rko_lio_pybind is not None
+
+
+def test_helipr_pybind_import():
+    from rko_lio.dataloaders import helipr_file_reader_pybind
+
+    assert hasattr(helipr_file_reader_pybind, "read_lidar_bin")

--- a/python/tests/test_lio_pipeline.py
+++ b/python/tests/test_lio_pipeline.py
@@ -1,0 +1,83 @@
+import numpy as np
+import pytest
+
+from rko_lio.lio import LIOConfig
+from rko_lio.lio_pipeline import LIOPipeline
+
+
+@pytest.fixture
+def simple_point_cloud():
+    # 10x10x10 uniform grid = 1000 points
+    x = y = z = np.linspace(0, 1, 10)
+    X, Y, Z = np.meshgrid(x, y, z, indexing="ij")
+    points = np.stack([X.ravel(), Y.ravel(), Z.ravel()], axis=1)
+    return points.astype(np.float32)
+
+
+@pytest.fixture
+def identity_extrinsics():
+    return np.eye(4)
+
+
+def create_lidar_timestamps(n):
+    return np.linspace(0, 0.1, n).astype(np.float32)
+
+
+def test_pipeline_creation(identity_extrinsics):
+    config = LIOConfig()
+    pipeline = LIOPipeline(config, identity_extrinsics, identity_extrinsics)
+    assert pipeline is not None
+
+
+def test_add_imu_sequence(identity_extrinsics):
+    config = LIOConfig()
+    pipeline = LIOPipeline(config, identity_extrinsics, identity_extrinsics)
+
+    pipeline.add_imu(0.0, np.zeros(3), np.zeros(3))
+    pipeline.add_imu(0.01, np.zeros(3), np.zeros(3))
+    assert len(pipeline.imu_buffer) == 2
+
+
+def test_add_lidar_points(identity_extrinsics, simple_point_cloud):
+    config = LIOConfig()
+    pipeline = LIOPipeline(config, identity_extrinsics, identity_extrinsics)
+
+    cloud1 = simple_point_cloud
+    timestamps1 = create_lidar_timestamps(len(cloud1))
+    pipeline.add_lidar(cloud1, timestamps1)
+
+    cloud2 = simple_point_cloud
+    timestamps2 = create_lidar_timestamps(len(cloud2))
+
+    pipeline.add_lidar(cloud2, timestamps2)
+
+    assert len(pipeline.lidar_buffer) == 2
+
+
+def test_add_lidar_points_with_imu(identity_extrinsics, simple_point_cloud):
+    config = LIOConfig()
+    pipeline = LIOPipeline(config, identity_extrinsics, identity_extrinsics)
+
+    cloud1 = simple_point_cloud
+    timestamps1 = create_lidar_timestamps(len(cloud1))
+    pipeline.add_lidar(cloud1, timestamps1)
+
+    # Add 10 IMU measurements with increasing timestamps > lidar end time
+    start_time = timestamps1[-1] + 0.01
+    for i in range(10):
+        t = start_time + i * 0.01
+        pipeline.add_imu(t, np.zeros(3), np.zeros(3))
+
+    assert len(pipeline.lidar_buffer) == 0  # first lidar processed for initialization
+
+    cloud2 = simple_point_cloud
+    timestamps2 = create_lidar_timestamps(len(cloud2)) + timestamps1[-1]
+    pipeline.add_lidar(cloud2, timestamps2)
+
+    # Add one imu measurement after second lidar end time just in case to trigger second register
+    pipeline.add_imu(timestamps2[-1] + 0.01, np.zeros(3), np.zeros(3))
+
+    assert len(pipeline.lidar_buffer) == 0  # second lidar processed
+
+    pose = pipeline.lio.pose()
+    assert np.allclose(pose, np.eye(4), atol=1e-6)

--- a/python/tests/test_lio_pybind.py
+++ b/python/tests/test_lio_pybind.py
@@ -1,0 +1,24 @@
+import pytest
+
+from rko_lio.lio import LIO, LIOConfig
+
+
+def test_lioconfig_creation():
+    config = LIOConfig()
+    assert config is not None
+
+
+def test_lioconfig_attributes():
+    config = LIOConfig(max_range=50.0)
+    config.voxel_size = 2.0
+    config.deskew = False
+
+    assert config.voxel_size == 2.0
+    assert config.max_range == 50.0
+    assert config.deskew is False
+
+
+def test_lio_init_with_config():
+    config = LIOConfig()
+    lio_obj = LIO(config)
+    assert lio_obj is not None

--- a/ros/package.xml
+++ b/ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?><package format="3">
   <name>rko_lio</name>
-  <version>0.0.1</version>
+  <version>0.0.2</version>
   <description>A Robust Approach for LiDAR-Inertial Odometry Without Sensor-Specific Modelling</description>
   <maintainer email="rm.meher97@gmail.com">Meher Malladi</maintainer>
   <license>MIT</license>


### PR DESCRIPTION
A bunch of changes here
- we drop named support for python 3.9. It's EoL in oct 2025 anyways, and was causing issues on the windows 2022 build.
- added rudimentary pytests that check that imports work, and even that identity scan registration works. point of the tests is more to check that the build work, rather than test coverage.
- fix helipr reader struct packing so that it is portable and compiles with msvc as well (this part is incredibly ugly, and i half understand myself the preprocessor directives i added for msvc. helipr needs to be deprecated next major release)
- a few new workflows: i have builds working on macOS-14, macOS-15, windows 2022, ubuntu 22.04, ubuntu 24.04, ubuntu 24-04-arm (which is for wheels, so should be usable on ubuntu 22 04 arm as well theoretically)
- as briefly mentioned before, we have a lot more wheels being built. arm support is theoretically possible? need to test myself on a jetson
- version bump to 0.0.2