### PR TITLE
Add a version print for the python cli, and add a workflow to ensure python and ros versions match

### DIFF
--- a/.github/workflows/ensure_versions_match.yaml
+++ b/.github/workflows/ensure_versions_match.yaml
@@ -1,0 +1,22 @@
+name: Check Python and ROS versions match
+on:
+  pull_request:
+    branches: ["master"]
+    paths:
+      - 'python/pyproject.toml'
+      - 'ros/package.xml'
+jobs:
+  check-version-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check Python and ROS version match
+        run: |
+          py_version=$(sed -n 's/^version\s*=\s*"\(.*\)"/\1/p' python/pyproject.toml | head -n 1)
+          ros_version=$(sed -n 's:.*<version>\(.*\)</version>.*:\1:p' ros/package.xml | head -n 1)
+          if [ "$py_version" != "$ros_version" ]; then
+            echo "Version mismatch! pyproject.toml=$py_version vs package.xml=$ros_version"
+            exit 1
+          else
+            echo "Versions match: $py_version"
+          fi

--- a/python/rko_lio/cli.py
+++ b/python/rko_lio/cli.py
@@ -30,6 +30,15 @@ import numpy as np
 import typer
 
 
+def version_callback(value: bool):
+    if value:
+        from importlib.metadata import version
+
+        rko_lio_version = version("rko_lio")
+        print(f"RKO_LIO Version: {rko_lio_version}")
+        raise typer.Exit(0)
+
+
 def dataloader_name_callback(value: str):
     from .dataloaders import available_dataloaders
 
@@ -132,6 +141,13 @@ def cli(
         None,
         "--lidar_frame",
         help="Extra dataloader argument: lidar frame overload (for rosbag only)",
+    ),
+    version: bool | None = typer.Option(
+        None,
+        "--version",
+        help="Show the current version of RKO_LIO",
+        callback=version_callback,
+        is_eager=True,
     ),
 ):
     """


### PR DESCRIPTION
simple `rko_lio --version`
and a ci to ensure python/pyproject.toml version and ros/package.xml match on pull requests modifying either file.