### PR TITLE
Readme simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pip install rko_lio rosbags rerun-sdk
 ```
 
 `rko_lio` is our odometry package, `rosbags` is required for using our rosbag dataloader, and `rerun-sdk` is what we use for our optional visualizer.
-After everything is installed, run
+Next, run
 
 ```bash
 rko_lio -v /path/to/rosbag_folder # <- has to be a directory! with either *.bag files or metadata.yaml from ROS2
@@ -54,9 +54,9 @@ and you should be good to go!
 <summary><b>Click here for some more details on how the above works and how to use RKO_LIO!</b></summary>
 <br />
 
-For all possible CLI flags, please check `rko_lio --help`.
-
 The `-v` flag enables visualization.
+
+You can specify a dataloader to use with `-d`, but if you don't, we try to guess the format based on the layout of the data.
 
 Our rosbag dataloader works with either ROS1 or ROS2 bags.
 Place split ROS1 bags in a single folder and pass the folder as the data path.
@@ -86,6 +86,8 @@ An example invocation would then be
 # the config should have the sensor extrinsics if the rosbag doesn't
 rko_lio -v -c config.yaml --imu imu_topic --lidar lidar_topic /path/to/rosbag_folder
 ```
+
+For all possible CLI flags, please check `rko_lio --help`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ rko_lio -v /path/to/rosbag_folder # <- has to be a directory! with either *.bag 
 and you should be good to go!
 
 <details>
-<summary><b><u>Click here for some more details on how the above works and how to use RKO_LIO!</u></b></summary>
+<summary><b>Click here for some more details on how the above works and how to use RKO_LIO!</b></summary>
 <br />
 
 For all possible CLI flags, please check `rko_lio --help`.
@@ -94,7 +94,7 @@ For more install and usage instructions of our python interface, please refer to
 The python interface to our system can be convenient to investigate recorded data offline as you don't need to setup a ROS environment first.
 
 <details>
-<summary><b><u>But please prefer the ROS version over the python version if you can!</u></b></summary>
+<summary><b>But please prefer the ROS version over the python version if you can!</b></summary>
 <br />
 
 The ROS version is the intended way to use our odometry system on a robot.
@@ -110,7 +110,7 @@ The python interface is merely meant to be a convenience.
 > We are working on getting the odometry package into the ROS index, so you can install it using system package managers instead of building from source.
 
 <details>
-<summary><b><u>Here's a ROS2 quick start!</u></b></summary>
+<summary><b>Here's a ROS2 quick start!</b></summary>
 <br />
 
 Clone the repository into your ROS workspace and then

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ rko_lio -v /path/to/rosbag_folder # <- has to be a directory! with either *.bag 
 and you should be good to go!
 
 <details>
-<summary><b>Click here for some more details on how the above works and how to use RKO_LIO!</b></summary>
+<summary><b><u>Click here for some more details on how the above works and how to use RKO_LIO!</u></b></summary>
 <br />
 
 For all possible CLI flags, please check `rko_lio --help`.
@@ -94,7 +94,8 @@ For more install and usage instructions of our python interface, please refer to
 The python interface to our system can be convenient to investigate recorded data offline as you don't need to setup a ROS environment first.
 
 <details>
-<summary><b>But please prefer the ROS version over the python version if you can!</b></summary>
+<summary><b><u>But please prefer the ROS version over the python version if you can!</u></b></summary>
+<br />
 
 The ROS version is the intended way to use our odometry system on a robot.
 The ROS version also has better performance mainly due to how we read incoming data.
@@ -109,7 +110,7 @@ The python interface is merely meant to be a convenience.
 > We are working on getting the odometry package into the ROS index, so you can install it using system package managers instead of building from source.
 
 <details>
-<summary><b>Here's a ROS2 quick start!</b></summary>
+<summary><b><u>Here's a ROS2 quick start!</u></b></summary>
 <br />
 
 Clone the repository into your ROS workspace and then

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Python Bindings:
 
 ## Quick Start
 
+### Python
+
 In case you already have a rosbag (ROS1 or ROS2) which contains a TF tree, you can inspect the results of our odometry system with the following two steps
 
 ```bash
@@ -46,29 +48,34 @@ After everything is installed, run
 rko_lio -v /path/to/rosbag_folder # <- has to be a directory! with either *.bag files or metadata.yaml from ROS2
 ```
 
-and you should be good to go! For some quick details, click below.
+and you should be good to go!
 
 <details>
-<summary>Click here for some more details on how to use RKO_LIO and how the above works!</summary>
+<summary><b>Click here for some more details on how the above works and how to use RKO_LIO!</b></summary>
+<br />
 
 For all possible CLI flags, please check `rko_lio --help`.
 
 The `-v` flag enables visualization.
 
 Our rosbag dataloader works with either ROS1 or ROS2 bags.
-Note that we don't fully support running `rko_lio` on partial or incomplete bags.
+Place split ROS1 bags in a single folder and pass the folder as the data path.
+Note that we don't support running `rko_lio` on partial or incomplete bags, though you can try (and maybe raise an issue if you think we should support this).
 ROS2 especially will need a `metadata.yaml` file.
 
 By default, we assume there is just one IMU topic and one LiDAR topic in the bag, in which case we automatically pick up the topic names and proceed further.
 If there are multiple topics per sensor, you will be prompted to select one via the `--imu` or `--lidar` flags, which you can pass to `rko_lio`.
 
-Next, we assume there is a (static) TF tree in the bag. If so, we take the frame ids from the message topics we just picked up, build a static TF tree, and then query it for the extrinsic from IMU to LiDAR.
-By default, we assume the LiDAR frame to be the base frame for odometry. If you would like to use a different frame, you can pass the frame id with `--base_frame` (note the other options available with `--help`).
+Next, we assume there is a (static) TF tree in the bag.
+If so, we take the frame ids from the message topics we just picked up, build a static TF tree, and then query it for the extrinsic from IMU to LiDAR.
+Our odometry estimates the robot pose with respect to a base frame, and by default, we assume the LiDAR frame to be the base frame.
+If you would like to use a different frame, you can pass the frame id with `--base_frame` (note the other options available with `--help`).
 The TF tree will be queried for the appropriate transformations (if they exist in the bag!).
 
-In case there is no TF tree in the bag, then you will have to manually specify the extrinsics for IMU to base and LiDAR to base, as these two are **required** parameters.
-Leave one of the extrinsics as identity if you want the other one to be the frame of estimation (you will still have to specify both parameters).
+In case there is no TF tree in the bag, then you will have to manually specify the extrinsics for IMU to base frame and LiDAR to base frame, as these two are **required** parameters.
+Set one of the extrinsics to identity if you want that one to be the base frame (you will still have to specify both parameters).
 You can specify the extrinsics via a config YAML file with the keys `extrinsic_imu2base_quat_xyzw_xyz` and `extrinsic_lidar2base_quat_xyzw_xyz`.
+
 You can dump a config with all the options set to default values by running `rko_lio --dump_config`.
 Modify as you require, and pass this file to `rko_lio` using the `-c` flag.
 Please check `python/config` in the GitHub repository for example configurations.
@@ -76,31 +83,34 @@ Please check `python/config` in the GitHub repository for example configurations
 An example invocation would then be
 
 ```bash
-# the config file has the sensor extrinsics
+# the config should have the sensor extrinsics if the rosbag doesn't
 rko_lio -v -c config.yaml --imu imu_topic --lidar lidar_topic /path/to/rosbag_folder
 ```
 
-For more install and usage instructions, please refer to the [python bindings readme](python#rko_lio---python-bindings) and also to the [configuration doc](/docs/config.md).
 </details>
 
+For more install and usage instructions of our python interface, please refer to the [python readme](python#rko_lio---python-bindings) and the [config doc](/docs/config.md).
 
-## About
+The python interface to our system can be convenient to investigate recorded data offline as you don't need to setup a ROS environment first.
 
-RKO_LIO is a LiDAR-inertial odometry system that is by design simple to deploy on different sensor configurations and robotic platforms with as minimal a change in configuration as necessary.
+<details>
+<summary><b>But please prefer the ROS version over the python version if you can!</b></summary>
 
-We have no restriction on which LiDAR you can use, and you can do so without changing any config (we've tested Velodyne, Ouster, Hesai, Livox, Robosense, Aeva sensors).
-For using an IMU, we require only the accelerometer and gyroscope readings, the bare minimum.
-You don't need to look up manufacturer spec sheets to provide noise specifications, etc.
+The ROS version is the intended way to use our odometry system on a robot.
+The ROS version also has better performance mainly due to how we read incoming data.
+Without getting into details, if you can, you should prefer using the ROS version.
+For offline use, we provide a way to directly inspect and run our odometry on recorded rosbags (see offline mode in [ROS usage](ros#usage)), which should be preferred over the python dataloader.
+The python interface is merely meant to be a convenience.
 
-All you need to provide is the extrinsic transformation between the IMU and LiDAR and you can start using our system for your LiDAR-inertial odometry needs!
-
-## Setup
+</details>
 
 ### ROS2
 
 > We are working on getting the odometry package into the ROS index, so you can install it using system package managers instead of building from source.
 
-We currently support ROS2 Humble, Jazzy and Kilted.
+<details>
+<summary><b>Here's a ROS2 quick start!</b></summary>
+<br />
 
 Clone the repository into your ROS workspace and then
 
@@ -115,64 +125,23 @@ To launch the odometry node:
 ros2 launch rko_lio odometry.launch.py # config_file:=/path/to/a/config.yaml rviz:=true
 ```
 
-Please refer to the [ROS readme](ros) for further ROS-specific details.
-
-<details>
-<summary>Build information</summary>
-
-
 Note that we have some [default build configuration options](ros/colcon.pkg) which should automatically get picked up by colcon.
 We have a few dependencies, but as long as these defaults apply, the package should build without any further consideration.
 If you encounter any issues, please check [docs/build.md](docs/build.md) for further details or open an issue afterwards.
 
 </details>
 
-## Python
+Please refer to the [ROS readme](ros) for further ROS-specific details.
 
-The python interface to our system can be convenient to investigate recorded data offline as you don't need to setup a ROS environment first.
+## About
 
-We provide wheels for Linux, macOS, and Windows.
+RKO_LIO is a LiDAR-inertial odometry system that is by design simple to deploy on different sensor configurations and robotic platforms with as minimal a change in configuration as necessary.
 
-You can install RKO_LIO by simply
+We have no restriction on which LiDAR you can use, and you can do so without changing any config (we've tested Velodyne, Ouster, Hesai, Livox, Robosense, Aeva sensors).
+For using an IMU, we require only the accelerometer and gyroscope readings, the bare minimum.
+You don't need to look up manufacturer spec sheets to provide noise specifications, etc.
 
-```bash
-pip install rko_lio
-```
-
-<details>
-<summary>Optional dependencies</summary>
-
-There's a few optional dependencies depending on what part of the interface you use.
-E.g., inspecting rosbag data will require `rosbags`, and enabling visualization will require `rerun-sdk`; you will be prompted when a dependency is missing.
-In case you don't mind pulling in a few additional dependencies and want everything available, instead run
-
-```bash
-pip install "rko_lio[all]"
-```
-
-</details>
-
-Afterwards, check
-
-```bash
-rko_lio --help
-```
-
-You'll find further usage instructions [here](python#usage).
-
-For instructions on how to build from source, please check [here](/python/README.md#build-from-source).
-
-<details>
-<summary><b>Please prefer the ROS version over the python version if you can</b></summary>
-
-The ROS version is the intended way to use our odometry system on a robot.
-The python version is slower than the ROS version, not on the odometry itself, but on how we read incoming data, i.e. dataloading.
-Without getting into details, if you can, you should prefer using the ROS version.
-We also provide a way to directly inspect and run our odometry on recorded rosbags (see offline mode in [ROS usage](ros#usage)) which has a performance benefit over the python version.
-The python interface is merely meant to be a convenience.
-
-</details>
-
+All you need to provide is the extrinsic transformation between the IMU and LiDAR and you can start using our system for your LiDAR-inertial odometry needs!
 
 ## A note on transformations
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,7 +1,6 @@
 # RKO_LIO - Python Bindings
 
 The python interface/wrapper is a convenience tool to run the odometry offline on recorded data.
-We provide PyPI wheels for Linux, macOS, and Windows.
 
 ## Setup
 
@@ -13,8 +12,17 @@ Simply
 pip install rko_lio
 ```
 
+We provide PyPI wheels for Linux, macOS, and Windows ([PyPI page](https://pypi.org/project/rko-lio)).
+
 To be able to use `rko_lio` with any of the dataloaders or to enable visualization, you'll need to install additional dependencies.
 You'll be prompted for specific packages as they become required during runtime.
+
+For example, to use our rosbag dataloader and visualize the results, you'll need
+
+```bash
+pip install rko_lio rosbags rerun-sdk
+```
+
 If you want to install everything at once, do
 
 ```bash
@@ -35,7 +43,7 @@ To have all dependencies installed, run
 pip install ".[all]"
 ```
 
-Or use the convenience recipes provided in the Makefile
+Or use the convenience recipes provided in the [Makefile](Makefile)
 
 ```bash
 make install # installs all optional deps
@@ -73,7 +81,7 @@ are **required parameters**. You can provide them (with those keys) via a config
 See the examples in the `config/` folder.
 
 You can also override any other config parameters via the config file.
-The default set is in `config/default.yaml`.
+You can dump a default config using `rko_lio --dump_config`.
 
 If you don't pass the extrinsic parameters, we try to infer them from the dataset directly, and assume the lidar frame as the base frame where applicable.
 For more details, please expand the dataset specific sections below.
@@ -107,7 +115,8 @@ Requirements:
   - Filename: must be a timestamp (ns) corresponding to the end of recording for that scan, i.e., close to time of last recorded point. This timestamp is used along with the IMU timestamp to sort both sensor data into a common index, which is then processed sequentially by the odometry system.
   - Each `.ply` must include a time field for points. Accepted field names are: `time`, `timestamp`, `timestamps`, or `t`. This time must be in seconds, representing the absolute time of point collection.
 
-PRs welcome to improve this dataloader.
+PRs are welcome to improve this dataloader.
+
 </details>
 
 ---
@@ -126,13 +135,14 @@ and the system will work. These are:
   - If multiple exist, you’ll be prompted to select one via the `--lidar` and/or `--imu` flags.
 - The bag contains a TF tree with a static transform between the lidar and imu frames.
   - Note that we support only static TFs, on either the python bindings or the ROS version. Dynamic TF handling is out of the scope of the python bindings. I haven't really had a requirement where I need to handle a dynamic TF between the IMU and LiDAR, though I did consider how to. Open an issue if you need this supported on the ROS side.
-- The frame names in the message header match the names in the TF tree. I.e., the lidar message header `frame_id` has to match a frame id in the TF tree. Similary for the imu.
-  - Yes, there are cases where the frame ids don't match. And yes, because i ran into this problem myself, i provide a way to handle the case in which they don't match. Override the frame ids with the `--lidar_frame` or `--imu_frame` flags.
+- The frame names in the message header match the names in the TF tree, i.e., the lidar message header `frame_id` has to match a frame id in the TF tree. Similary for the imu.
+  - Yes, there are cases where the frame ids don't match. And yes, because I ran into this problem myself, I provide a way to handle this case. Override the frame ids with the `--lidar_frame` or `--imu_frame` flags.
 
 If the rosbag has no TF tree:
 - First, please ask your data provider to include the TF tree.
-- You can manually specify the extrinsics via the config (see `config/leg_kilo.yaml` or `config/oxford_spires.yaml` as references).
+- You can manually specify the extrinsics via the config (see [`config/leg_kilo.yaml`](/config/leg_kilo.yaml) or [`config/oxford_spires.yaml`](/config/oxford_spires.yaml) as references).
 - Also: can dataset providers please include TF trees in bags by default? ~~makes no sense~~
+
 </details>
 
 ---
@@ -141,11 +151,12 @@ If the rosbag has no TF tree:
 <summary>HeLiPR dataloader</summary>
 
 This is deprecated and planned to be removed in a future release. I'm prioritising documentation for other parts and other tasks. If you need it, open an issue.
+
 </details>
 
 ---
 
 ### Configuration
 
-All configurable parameters are defined in `config/default.yaml`.
+All configurable parameters are defined in [`config/default.yaml`](/config/default.yaml).
 For descriptions of each parameter, see [config.md](../docs/config.md).

--- a/python/README.md
+++ b/python/README.md
@@ -140,7 +140,7 @@ and the system will work. These are:
 
 If the rosbag has no TF tree:
 - First, please ask your data provider to include the TF tree.
-- You can manually specify the extrinsics via the config (see [`config/leg_kilo.yaml`](/config/leg_kilo.yaml) or [`config/oxford_spires.yaml`](/config/oxford_spires.yaml) as references).
+- You can manually specify the extrinsics via the config (see [`config/leg_kilo.yaml`](config/leg_kilo.yaml) or [`config/oxford_spires.yaml`](config/oxford_spires.yaml) as references).
 - Also: can dataset providers please include TF trees in bags by default? ~~makes no sense~~
 
 </details>
@@ -158,5 +158,5 @@ This is deprecated and planned to be removed in a future release. I'm prioritisi
 
 ### Configuration
 
-All configurable parameters are defined in [`config/default.yaml`](/config/default.yaml).
+All configurable parameters are defined in [`config/default.yaml`](config/default.yaml).
 For descriptions of each parameter, see [config.md](../docs/config.md).


### PR DESCRIPTION
- remove redundancies from the main readme
- put a bit more stuff under expandable banners so the information is not overwhelming at first glance
- slight additions to the python readme