### PR TITLE
Remove scipy as a dependency for the python side

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "scikit_build_core.build"
 name = "rko_lio"
 version = "0.0.4"
 description = "A Robust Approach for LiDAR-Inertial Odometry Without Sensor-Specific Modelling"
-dependencies = ["numpy", "typer", "pyyaml", "scipy", "tqdm"]
 authors = [{ name = "Meher Malladi", email = "rm.meher97@gmail.com" }]
 readme = "README.md"
 requires-python = ">=3.10"
@@ -32,9 +31,7 @@ keywords = [
   "Localization",
   "SLAM",
 ]
-
-[project.urls]
-Homepage = "https://github.com/PRBonn/rko_lio"
+dependencies = ["numpy", "typer", "pyyaml", "pyquaternion", "tqdm"]
 
 [project.optional-dependencies]
 all = [
@@ -43,6 +40,9 @@ all = [
   "rosbags",
   "pytest"
 ]
+
+[project.urls]
+Homepage = "https://github.com/PRBonn/rko_lio"
 
 [project.scripts]
 rko_lio = "rko_lio.cli:app"

--- a/python/rko_lio/cli.py
+++ b/python/rko_lio/cli.py
@@ -203,7 +203,7 @@ def cli(
             import rerun as rr
 
             rr.init("rko_lio")
-            rr.spawn(memory_limit="20GB")
+            rr.spawn(memory_limit="2GB")
             rr.log_file_from_path(Path(__file__).parent / "rko_lio.rbl")
 
         except ImportError:

--- a/python/rko_lio/cli.py
+++ b/python/rko_lio/cli.py
@@ -84,9 +84,9 @@ def parse_extrinsics_from_config(config_data: dict):
 
         qx, qy, qz, qw = quat_xyzw_xyz[:4]
         xyz = quat_xyzw_xyz[4:]
-        rot = Quaternion(x=qx, y=qy, z=qz, w=qw).rotation_matrix
+
         transform = np.eye(4, dtype=np.float64)
-        transform[:3, :3] = rot.as_matrix()
+        transform[:3, :3] = Quaternion(x=qx, y=qy, z=qz, w=qw).rotation_matrix
         transform[:3, 3] = xyz
         return transform
 

--- a/python/rko_lio/cli.py
+++ b/python/rko_lio/cli.py
@@ -80,11 +80,11 @@ def dataloader_name_callback(value: str):
 
 def parse_extrinsics_from_config(config_data: dict):
     def convert_quat_xyzw_xyz_to_matrix(quat_xyzw_xyz: np.ndarray) -> np.ndarray:
-        from scipy.spatial.transform import Rotation
+        from pyquaternion import Quaternion
 
-        quat = quat_xyzw_xyz[:4]
+        qx, qy, qz, qw = quat_xyzw_xyz[:4]
         xyz = quat_xyzw_xyz[4:]
-        rot = Rotation.from_quat([quat[0], quat[1], quat[2], quat[3]])
+        rot = Quaternion(x=qx, y=qy, z=qz, w=qw).rotation_matrix
         transform = np.eye(4, dtype=np.float64)
         transform[:3, :3] = rot.as_matrix()
         transform[:3, 3] = xyz
@@ -203,7 +203,7 @@ def cli(
             import rerun as rr
 
             rr.init("rko_lio")
-            rr.spawn(memory_limit="2GB")
+            rr.spawn(memory_limit="20GB")
             rr.log_file_from_path(Path(__file__).parent / "rko_lio.rbl")
 
         except ImportError:

--- a/python/rko_lio/dataloaders/helipr.py
+++ b/python/rko_lio/dataloaders/helipr.py
@@ -63,7 +63,6 @@ class HeliprDataLoader:
 
     def _load_extrinsics(self):
         """Load IMU->base and LIDAR->base transforms for HeLiPR."""
-        from scipy.spatial.transform import Rotation as R
 
         calib_dir = self.data_path / "Calibration"
 

--- a/python/rko_lio/dataloaders/utils/static_tf_tree.py
+++ b/python/rko_lio/dataloaders/utils/static_tf_tree.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 import numpy as np
-from scipy.spatial.transform import Rotation as R
+from pyquaternion import Quaternion
 from tqdm import tqdm
 
 
@@ -53,7 +53,7 @@ def create_static_tf_tree(bag):
             t = transform_stamped.transform.translation
             q = transform_stamped.transform.rotation
             T = np.eye(4)
-            T[:3, :3] = R.from_quat([q.x, q.y, q.z, q.w]).as_matrix()
+            T[:3, :3] = Quaternion(x=q.x, y=q.y, z=q.z, w=q.w).rotation_matrix
             T[:3, 3] = [t.x, t.y, t.z]
 
             tf_tree[child] = (parent, T)


### PR DESCRIPTION
since we ever only need to go from a quaternion to a rotation matrix, using scipy for this is overkill.

switched to using pyquaternion.

this probably also means that we _might_ be able to build on windows 11 arm now, since it was scipy that was causing an issue earlier.