### PR TITLE
Better error messages and add odometry demo video to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Python Bindings:
 </p>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/PRBonn/rko_lio/refs/heads/master/docs/example_multiple_platforms.png" alt="Visualization of odometry system running on data from four different platforms in four different environments" />
+  <a href="https://www.youtube.com/watch?v=QrVHip5opIc">
+    <img src="https://raw.githubusercontent.com/PRBonn/rko_lio/refs/heads/master/docs/example_multiple_platforms.png" alt="Visualization of odometry system running on data from four different platforms in four different environments" />
+  </a>
   <br />
   <em>Four different platforms, four different environments, one odometry system</em>
 </p>
@@ -146,6 +148,10 @@ For using an IMU, we require only the accelerometer and gyroscope readings, the 
 You don't need to look up manufacturer spec sheets to provide noise specifications, etc.
 
 All you need to provide is the extrinsic transformation between the IMU and LiDAR and you can start using our system for your LiDAR-inertial odometry needs!
+
+For a brief demo showcasing the capabilities of our odometry on data from different platforms, click the video below:
+
+[![Thumbnail](https://img.youtube.com/vi/QrVHip5opIc/maxresdefault.jpg)](https://www.youtube.com/watch?v=QrVHip5opIc)
 
 ## A note on transformations
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ You don't need to look up manufacturer spec sheets to provide noise specificatio
 
 All you need to provide is the extrinsic transformation between the IMU and LiDAR and you can start using our system for your LiDAR-inertial odometry needs!
 
-For a brief demo showcasing the capabilities of our odometry on data from different platforms, click the video below:
+For a brief demo of our odometry on data from different platforms, click below for a (YouTube) video:
 
 [![Thumbnail](https://img.youtube.com/vi/QrVHip5opIc/maxresdefault.jpg)](https://www.youtube.com/watch?v=QrVHip5opIc)
 

--- a/python/rko_lio/dataloaders/utils/static_tf_tree.py
+++ b/python/rko_lio/dataloaders/utils/static_tf_tree.py
@@ -64,16 +64,18 @@ def create_static_tf_tree(bag):
 def query_static_tf(tf_tree, from_frame, to_frame):
     """
     Compute transform matrix from 'from_frame' to 'to_frame' using a static TF tree.
-
-    Raises ValueError if frames are disconnected.
     """
     available_frames = set(tf_tree.keys()) | {parent for parent, _ in tf_tree.values()}
     missing = [f for f in (from_frame, to_frame) if f not in available_frames]
     if missing:
-        raise ValueError(
-            f"Frame(s) {missing} not found in static TF tree. "
-            f"Available frames: {sorted(available_frames)}. You can specify frames with CLI options."
+        print(
+            f"[ERROR] Frame(s) {missing} not found in static TF tree. "
+            f"Available frames: {sorted(available_frames)}. You can specify frame overrides with CLI options."
         )
+        import sys
+
+        sys.exit(1)
+
     # Walk up from "from_frame" to root, collecting transforms
     from_chain = []
     cur = from_frame


### PR DESCRIPTION
- In case the frame ids need to be overridden due to a frame mismatch, print a better error message instead of raising an exception which clutters the console
- Add a demo odometry video to the readme expanding on the motivation picture