### PR TITLE
Update docs to specify more details on data format

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,19 @@ If you found this work useful, please consider citing our [paper](https://arxiv.
 }
 ```
 
+## Platforms and Sensors Tested
+
+RKO LIO has been tested on a variety of platforms with different sensor setups:
+
+- Car: Ouster OS1-128; OS2-128, Livox Avia, Aeva Aeries II (HeLiPR dataset)
+- Backpack: Hesai XT32, QT32, QT64 (DigiForests dataset); QT128
+- Forestry Harvester: Hesai XT32
+- Quadruped: Velodyne VLP-16 (Leg-KILO dataset)
+- Bicycle: Livox Avia (thanks to @rlabs-oss, [YouTube video](https://www.youtube.com/watch?v=dKDGIAu628w))
+
+If you've tested RKO LIO on any other platform or sensor configuration, I'd be glad to list it here.
+Please reach out by [email](mailto:rm.meher97@gmail.com) or open an issue!
+
 ## RA-L Submission
 
 You can check out the branch `ral_submission` for the version of the code used for submission to RA-L.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For all possible CLI flags, please check `rko_lio --help`.
 
 </details>
 
-For more install and usage instructions of our python interface, please refer to the [python readme](/python/README.md#rko_lio---python-bindings), [config](/docs/config.md), and [data](/docs/data.md).
+For more install and usage instructions of our python interface, please refer to the [python readme](/python/README.md#rko_lio---python-bindings), [config.md](/docs/config.md), and [data.md](/docs/data.md).
 
 The python interface to our system can be convenient to investigate recorded data offline as you don't need to setup a ROS environment first.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <h1>RKO_LIO - LiDAR-Inertial Odometry<br />Without Sensor-Specific Modelling</h1>
+  <h1>RKO LIO - LiDAR-Inertial Odometry<br />Without Sensor-Specific Modelling</h1>
 </div>
 
 <p align="center">
@@ -54,7 +54,7 @@ rko_lio -v /path/to/rosbag_folder # <- has to be a directory! with either *.bag 
 and you should be good to go!
 
 <details>
-<summary><b>Click here for some more details on how the above works and how to use RKO_LIO!</b></summary>
+<summary><b>Click here for some more details on how the above works and how to use RKO LIO!</b></summary>
 <br />
 
 The `-v` flag enables visualization.
@@ -63,7 +63,7 @@ You can specify a dataloader to use with `-d`, but if you don't, we try to guess
 
 Our rosbag dataloader works with either ROS1 or ROS2 bags.
 Place split ROS1 bags in a single folder and pass the folder as the data path.
-Note that we don't support running `rko_lio` on partial or incomplete bags, though you can try (and maybe raise an issue if you think we should support this).
+Note that we don't support running RKO LIO on partial or incomplete bags, though you can try (and maybe raise an issue if you think we should support this).
 ROS2 especially will need a `metadata.yaml` file.
 
 By default, we assume there is just one IMU topic and one LiDAR topic in the bag, in which case we automatically pick up the topic names and proceed further.
@@ -94,7 +94,7 @@ For all possible CLI flags, please check `rko_lio --help`.
 
 </details>
 
-For more install and usage instructions of our python interface, please refer to the [python readme](/python/README.md#rko_lio---python-bindings) and the [config doc](/docs/config.md).
+For more install and usage instructions of our python interface, please refer to the [python readme](/python/README.md#rko_lio---python-bindings), [config](/docs/config.md), and [data](/docs/data.md).
 
 The python interface to our system can be convenient to investigate recorded data offline as you don't need to setup a ROS environment first.
 
@@ -141,7 +141,7 @@ Please refer to the [ROS readme](/ros/README.md) for further ROS-specific detail
 
 ## About
 
-RKO_LIO is a LiDAR-inertial odometry system that is by design simple to deploy on different sensor configurations and robotic platforms with as minimal a change in configuration as necessary.
+RKO LIO is a LiDAR-inertial odometry system that is by design simple to deploy on different sensor configurations and robotic platforms with as minimal a change in configuration as necessary.
 
 We have no restriction on which LiDAR you can use, and you can do so without changing any config (we've tested Velodyne, Ouster, Hesai, Livox, Robosense, Aeva sensors).
 For using an IMU, we require only the accelerometer and gyroscope readings, the bare minimum.
@@ -172,6 +172,21 @@ The superscript on the vector indicates the frame in which the vector is express
 ## License
 
 This project is free software made available under the MIT license. For details, see the [LICENSE](LICENSE) file.
+
+## Citation
+
+If you found this work useful, please consider citing our [paper](https://arxiv.org/abs/2509.06593):
+
+```bib
+@article{malladi2025arxiv,
+  author      = {M.V.R. Malladi and T. Guadagnino and L. Lobefaro and C. Stachniss},
+  title       = {A Robust Approach for LiDAR-Inertial Odometry Without Sensor-Specific Modeling},
+  journal     = {arXiv preprint},
+  year        = {2025},
+  volume      = {arXiv:2509.06593},
+  url         = {https://arxiv.org/pdf/2509.06593},
+}
+```
 
 ## RA-L Submission
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,0 +1,27 @@
+# The sensor data
+
+RKO LIO is a LiDAR-inertial odometry system.
+Unsurprisingly, we need both IMU and LiDAR data.
+It is assumed that both sensors are time synchronized, i.e. the data timestamps refer to the same time clock and are consistent across both sensors.
+Some delay in the arrival of the data itself is fine.
+
+## IMU
+
+We only need the measurement time, the accelerometer reading, and the gyroscope reading (from a 6-axis IMU).
+Acceleration values should be in m/s^2.
+If your accelerometer outputs readings in g's, be sure to convert them to m/s^2 before using the odometry.
+Angular velocity values should be in rad/s; if your device uses other units, convert accordingly.
+
+## LiDAR
+
+If your platform experiences rapid or aggressive motions, I strongly recommend enabling deskewing (motion compensation) for good odometry.
+Deskewing the LiDAR scan will account for the motion of the platform during the scan acquisition time.
+This requires per-point timestamp information.
+If these are relative time measurements, we also need either the scan recording start or end time.
+Further specifics depend on the specific format of data or the dataloader, but for ROS this translates to requiring the timestamp in the message header and a time field in the point format for a PointCloud2 message.
+I attempt to automatically handle the different ways timestamps may be encoded, so most sensor drivers should work out of the box.
+Check [here](../cpp/rko_lio/core/process_timestamps.cpp) if you're curious, or if you'd like to contribute a solution for a sensor I don't handle.
+
+## Extrinsic
+
+Finally, we need the extrinsic calibration between the IMU and LiDAR. The convention for specifying extrinsics is covered [here](/README.md#a-note-on-transformations).

--- a/python/README.md
+++ b/python/README.md
@@ -1,4 +1,4 @@
-# RKO_LIO - Python Bindings
+# RKO LIO - Python Bindings
 
 The python interface/wrapper is a convenience tool to run the odometry offline on recorded data.
 
@@ -160,3 +160,4 @@ This is deprecated and planned to be removed in a future release. I'm prioritisi
 
 All configurable parameters are defined in [`config/default.yaml`](config/default.yaml).
 For descriptions of each parameter, see [config.md](../docs/config.md).
+Some further requirements on the data are given in [data.md](../docs/data.md).

--- a/python/rko_lio/dataloaders/get_dataloader.py
+++ b/python/rko_lio/dataloaders/get_dataloader.py
@@ -89,7 +89,6 @@ def guess_dataloader(
     base_frame_id: str | None = None,
     query_extrinsics: bool = True,
 ):
-    print("Guessing the dataloader...")
     # Check for rosbag files
     rosbag_exts = [".bag", ".db3", ".mcap"]
     found_rosbag_file = False
@@ -99,7 +98,7 @@ def guess_dataloader(
             found_rosbag_file = True
             break
     if found_rosbag_file:
-        print("Guessed rosbag!")
+        print("Guessed dataloader as rosbag!")
         return get_dataloader(
             "rosbag",
             data_path,
@@ -117,7 +116,7 @@ def guess_dataloader(
     txt_files = list(data_path.glob("*.txt"))
     csv_files = list(data_path.glob("*.csv"))
     if lidar_folder.is_dir() and (txt_files or csv_files):
-        print("Guessed raw!")
+        print("Guessed dataloader as raw!")
         return get_dataloader("raw", data_path, query_extrinsics=query_extrinsics)
 
     # Check for helipr data
@@ -132,12 +131,12 @@ def guess_dataloader(
         if not seq_folder.is_dir():
             raise ValueError(f"Helipr sequence folder does not exist: {seq_folder}")
 
-        print("Guessed Helipr!")
+        print("Guessed dataloader as Helipr!")
         return get_dataloader(
             "helipr", data_path, sequence=sequence, query_extrinsics=query_extrinsics
         )
 
     # No matching dataloader found
     raise ValueError(
-        f"Could not guess dataloader for path: {data_path}, please pass the loader with -d"
+        f"Could not guess dataloader for path: {data_path}, please pass the loader with --dataloader or -d"
     )

--- a/ros/README.md
+++ b/ros/README.md
@@ -1,4 +1,4 @@
-# RKO_LIO - LiDAR-Inertial Odometry
+# RKO LIO - LiDAR-Inertial Odometry
 
 Supported ROS Distros: Humble, Jazzy, Kilted and Rolling.
 
@@ -41,7 +41,8 @@ ros2 launch rko_lio odometry.launch.py -s
 ```
 
 That will also provide additional documentation about the different parameters.
-For some additional details regarding the odometry parameters, please refer to [config.md](../docs/config.md). ROS-specific parameters are covered here.
+For some additional details regarding the odometry parameters and data itself, please refer to [config.md](../docs/config.md) and [data.md](../docs/data.md).
+ROS-specific parameters are covered here.
 
 At minimum, you'll need to specify the `lidar_topic`, `imu_topic` and `base_frame` parameters.
 


### PR DESCRIPTION
Add details like we need the accelerometer measurements in m/s^2 and not g's.
This covers the case for data encountered in #23.
Also cover the timestamp requirement if deskewing is to be enabled.
This lives in a separate docs file which we link to from the normal readmes.

Add the citation for the arxiv paper in an easily copyable manner.

Add a section in the main readme where we cover all the platforms rko lio has been tested on. Also include the video by @rlabs-oss.

Minor error message improvements.

We log the extrinsics that we read from a dataloader, so that a user can potentially copy the extrinsic easily into a config file if they want to.

Refer to RKO_LIO with RKO LIO instead.