### PR TITLE
fix: ros launch - correctly overload config file params with cli params

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,9 +21,11 @@ assignees: ''
 ```yaml
 contents of your config file here
 ```
-- If you're using ROS, please include the Launch configuration that gets printed to console when you use the launch file (no need to include the launch file contents itself).
+- If you're using ROS, please include the Launch configuration that gets printed to console (between `====`) when you use the launch file (no need to include the launch file contents itself).
 ```text
-launch configuration console log here
+====
+launch configuration console log
+====
 ```
 
 **Data**

--- a/ros/config/default.yaml
+++ b/ros/config/default.yaml
@@ -1,7 +1,7 @@
 # PLEASE NOTE THIS FILE IS NOT USED AUTOMATICALLY BY THE ODOMETRY'S LAUNCH FILE
 # it's meant to just tell you what are the defaults for all the parameters
 # to use this config with the launch file, you will still have to pass it with 
-# `config_file:=<full_path_here>/default.yaml`
+# `config_file:=<full_or_relative_path_to>/default.yaml`
 # #############################################################################
 # base_frame: base
 # imu_topic: /imu

--- a/ros/config/default.yaml
+++ b/ros/config/default.yaml
@@ -1,3 +1,8 @@
+# PLEASE NOTE THIS FILE IS NOT USED AUTOMATICALLY BY THE ODOMETRY'S LAUNCH FILE
+# it's meant to just tell you what are the defaults for all the parameters
+# to use this config with the launch file, you will still have to pass it with 
+# `config_file:=<full_path_here>/default.yaml`
+# #############################################################################
 # base_frame: base
 # imu_topic: /imu
 # imu_frame: <leave empty if tf is well defined>

--- a/ros/launch/odometry.launch.py
+++ b/ros/launch/odometry.launch.py
@@ -279,9 +279,7 @@ def auto_cast_params(params, param_defs):
 def get_configured_cli_parameters(configurable_parameters, context):
     "Return only CLI parameters that were explicitly set by the user"
     explicit_params = {
-        arg.split(":=")[0]
-        for arg in getattr(context, "argv", [])
-        if ":=" in arg
+        arg.split(":=")[0] for arg in getattr(context, "argv", []) if ":=" in arg
     }
     cli_params = {}
     for param in configurable_parameters:
@@ -336,6 +334,30 @@ def merge_and_validate_parameters(
         print("[ERROR] missing required parameter(s):")
         print(", ".join(missing))
         print("Please provide them via cli (param:=value) or a config file.")
+        print("=" * 40 + "\n\n")
+        import sys
+
+        sys.exit(1)
+
+    # Check extrinsics
+    extrinsic_params = [
+        "extrinsic_lidar2base_quat_xyzw_xyz",
+        "extrinsic_imu2base_quat_xyzw_xyz",
+    ]
+    extrinsic_set = [
+        p in merged and merged[p] not in ("", None) for p in extrinsic_params
+    ]
+    if any(extrinsic_set) and not all(extrinsic_set):
+        print("\n\n" + "=" * 40)
+        print("[ERROR] extrinsic parameters incomplete:")
+        print(
+            "If one of {} is specified, both must be provided.".format(
+                ", ".join(extrinsic_params)
+            )
+        )
+        print(
+            "Please provide them via a config file. If you only need one, then explicitly set the other to identity."
+        )
         print("=" * 40 + "\n\n")
         import sys
 

--- a/ros/launch/odometry.launch.py
+++ b/ros/launch/odometry.launch.py
@@ -262,33 +262,40 @@ def auto_cast_params(params, param_defs):
     out = {}
     for p in param_defs:
         name = p["name"]
-        v = params.get(name)
-        tp = p.get("type", None)
-        if tp == "bool":
-            out[name] = str(v).lower() == "true"
-        elif tp == "int":
-            out[name] = int(v)
-        elif tp == "float":
-            out[name] = float(v)
-        else:
-            out[name] = v
+        if name in params:
+            v = params.get(name)
+            tp = p.get("type", None)
+            if tp == "bool":
+                out[name] = str(v).lower() == "true"
+            elif tp == "int":
+                out[name] = int(v)
+            elif tp == "float":
+                out[name] = float(v)
+            else:
+                out[name] = v
     return out
 
 
-def get_configurable_parameters(configurable_parameters, context):
-    return auto_cast_params(
-        dict(
-            [
-                (param["name"], LaunchConfiguration(param["name"]).perform(context))
-                for param in configurable_parameters
-            ]
-        ),
-        configurable_parameters,
-    )
+def get_configured_cli_parameters(configurable_parameters, context):
+    "Return only CLI parameters that were explicitly set by the user"
+    explicit_params = {
+        arg.split(":=")[0]
+        for arg in getattr(context, "argv", [])
+        if ":=" in arg
+    }
+    cli_params = {}
+    for param in configurable_parameters:
+        name = param["name"]
+        if name in explicit_params:
+            cli_params[name] = LaunchConfiguration(name).perform(context)
+    return auto_cast_params(cli_params, configurable_parameters)
 
 
-def yaml_to_dict(path_to_yaml):
-    with open(path_to_yaml, "r") as f:
+def get_config_file_parameters(context):
+    config_file = LaunchConfiguration("config_file").perform(context)
+    if config_file == "":
+        return {}
+    with open(config_file, "r") as f:
         return yaml.safe_load(f)
 
 
@@ -306,17 +313,17 @@ def merge_and_validate_parameters(
 
     merged.update(file_params)
 
-    # override with CLI only if non-empty
+    # override with cli only if non-empty
     for k, v in cli_params.items():
         if v not in ("", None):
             merged[k] = v
 
-    # Validating required params
+    # validating required params
     missing = []
     for param in configurable_parameters:
         name = param["name"]
 
-        # Skip offline-only params in online mode
+        # skip offline-only params in online mode
         if mode == "online" and param in offline_only_parameters:
             continue
 
@@ -326,9 +333,9 @@ def merge_and_validate_parameters(
 
     if missing:
         print("\n\n" + "=" * 40)
-        print("[ERROR] Missing required parameter(s):")
+        print("[ERROR] missing required parameter(s):")
         print(", ".join(missing))
-        print("Please provide them via CLI (param:=value) or a config file.")
+        print("Please provide them via cli (param:=value) or a config file.")
         print("=" * 40 + "\n\n")
         import sys
 
@@ -374,7 +381,7 @@ def prepare_rviz_config(rviz_config_file: Path, parameters: dict) -> Path:
     tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".rviz", delete=False)
     yaml.safe_dump(rviz_cfg, tmp)
     tmp.flush()
-    # since its the default config file, we also want to viz the deskewed scan and local map
+    # since its the default rviz config file, we also want to viz the deskewed scan and local map
     parameters["publish_deskewed_scan"] = True
     parameters["publish_local_map"] = True
 
@@ -385,9 +392,8 @@ def launch_setup(context, *args, **kwargs):
     mode = LaunchConfiguration("mode").perform(context).lower()
 
     # Prepare parameters
-    config_file = LaunchConfiguration("config_file").perform(context)
-    params_from_file = {} if config_file == "" else yaml_to_dict(config_file)
-    cli_params = get_configurable_parameters(configurable_parameters, context=context)
+    cli_params = get_configured_cli_parameters(configurable_parameters, context=context)
+    params_from_file = get_config_file_parameters(context)
     final_params = merge_and_validate_parameters(
         cli_params=cli_params,
         file_params=params_from_file,


### PR DESCRIPTION
there was a mistake earlier and we would just populate the final config with default values defined for the launch configurations, ignoring any values passed by the user. with the changes we also now dont log to console all the default values, but only those that were set by the user