### PR TITLE
Switch python dataloaders to a sequential iterator style

### DIFF
--- a/python/rko_lio/cli.py
+++ b/python/rko_lio/cli.py
@@ -292,13 +292,7 @@ def cli(
 
     from tqdm import tqdm
 
-    from .scoped_profiler import ScopedProfiler
-
-    data_count = len(dataloader)
-    for idx in tqdm(range(data_count), total=data_count, desc="Data"):
-        with ScopedProfiler("Pipeline - Data Loader") as pipeline_timer:
-            kind, data_tuple = dataloader[idx]
-
+    for kind, data_tuple in tqdm(dataloader, total=len(dataloader), desc="Data"):
         if kind == "imu":
             pipeline.add_imu(*data_tuple)
         elif kind == "lidar":

--- a/python/rko_lio/cli.py
+++ b/python/rko_lio/cli.py
@@ -61,7 +61,7 @@ def dump_config_callback(value: bool):
         typer.echo(
             "Default config dumped to config.yaml. Note that the extrinsics are left as an empty list. If you don't need them, delete the two respective keys. If you need them, you need to specify them as [qx, qy, qz, qw, x, y, z]."
         )
-        raise typer.Exit()
+        raise typer.Exit(0)
 
 
 def dataloader_name_callback(value: str):
@@ -98,17 +98,19 @@ def parse_extrinsics_from_config(config_data: dict):
 
     if imu_config_val is not None:
         if not len(imu_config_val) == 7:
-            raise ValueError(
-                f"extrinsic_imu2base_quat_xyzw_xyz cannot be of length {len(imu_config_val)} but should be 7"
+            print(
+                f"[ERROR] extrinsic_imu2base_quat_xyzw_xyz cannot be of length {len(imu_config_val)} but should be 7"
             )
+            typer.Abort()
         extrinsic_imu2base = convert_quat_xyzw_xyz_to_matrix(
             np.asarray(imu_config_val, dtype=np.float64)
         )
     if lidar_config_val is not None:
         if not len(lidar_config_val) == 7:
-            raise ValueError(
+            print(
                 f"[ERROR] extrinsic_lidar2base_quat_xyzw_xyz cannot be of length {len(imu_config_val)} but should be 7"
             )
+            typer.Abort()
         extrinsic_lidar2base = convert_quat_xyzw_xyz_to_matrix(
             np.asarray(lidar_config_val, dtype=np.float64)
         )
@@ -223,9 +225,7 @@ def cli(
             print(
                 "[ERROR] Please install rerun with `pip install rerun-sdk` to enable visualization."
             )
-            import sys
-
-            sys.exit(1)
+            typer.Abort()
 
     config_data = {}
     if config_fp:
@@ -303,8 +303,6 @@ def cli(
             pipeline.add_imu(*data_tuple)
         elif kind == "lidar":
             pipeline.add_lidar(*data_tuple)
-        else:
-            raise ValueError(f"data type {kind} is invalid from the dataloader")
 
     if log_results and results_dir:
         results_dir.mkdir(parents=True, exist_ok=True)

--- a/python/rko_lio/dataloaders/get_dataloader.py
+++ b/python/rko_lio/dataloaders/get_dataloader.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import sys
 from pathlib import Path
 
 
@@ -72,7 +73,8 @@ def get_dataloader(
         from .helipr import HeliprDataLoader
 
         if sequence is None:
-            raise ValueError("HeliprDataLoader requires --sequence parameter")
+            print("[ERROR] HeliprDataLoader requires --sequence parameter")
+            sys.exit(1)
         return HeliprDataLoader(data_path, sequence)
 
     else:
@@ -125,11 +127,13 @@ def guess_dataloader(
 
     if xsens_imu_path.is_file() and lidar_folder.is_dir():
         if sequence is None:
-            raise ValueError("HeLiPR dataLoader requires --sequence parameter")
+            print("[ERROR] HeLiPR dataLoader requires --sequence parameter")
+            sys.exit(1)
 
         seq_folder = lidar_folder / sequence
         if not seq_folder.is_dir():
-            raise ValueError(f"Helipr sequence folder does not exist: {seq_folder}")
+            print(f"[ERROR] Helipr sequence folder does not exist: {seq_folder}")
+            sys.exit(1)
 
         print("Guessed dataloader as Helipr!")
         return get_dataloader(
@@ -137,6 +141,7 @@ def guess_dataloader(
         )
 
     # No matching dataloader found
-    raise ValueError(
-        f"Could not guess dataloader for path: {data_path}, please pass the loader with --dataloader or -d"
+    print(
+        f"[ERROR] Could not guess dataloader for path: {data_path}, please pass the loader with --dataloader or -d"
     )
+    sys.exit(1)


### PR DESCRIPTION
Python
- fewer `raise Exception`s and more `print("[ERROR]"); sys.exit(1)` so that exits are more graceful if we know why they're caused.

- fix #30 by switching dataloaders to a sequential iterator style with `__iter__` and `__next__` instead of `__getitem__`. 
Occasionally the data might have lidar scans which we cannot process (usually a timestamp error in ros), and we used to fetch the next data point recursively inside `__getitem__` before. This didn't modify the iteration counter outside when using a `range(len(dataloader))` style `for` loop over the dataloader. and hence we would try to read past the end of the data at some point. Since the `__getitem__` was a disguised `__next__` anyways, I've switch all the dataloaders to just implement only the sequential iterator interface. We did not support skipping data before, we do not now.
  - rosbag dataloader modified according to this
  - raw dataloader modified according to this. Note: the changes have not been tested as I currently don't have raw data on hand. But the changes should not be the source of an issue.
  - helipr dataloader modified according to this. Plus fixed an error with parsing the sensor extrinsics for at least Aeva, Avia, Velodyne. Ouster is still be broken, but this is planned to be deprecated eventually anyways...