### PR TITLE
fix (ros): proper component registration so it shows up ros2 component types

### DIFF
--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -44,5 +44,22 @@ find_package(rclcpp_components REQUIRED)
 
 add_subdirectory(rko_lio)
 
+# ament macros cannot be in a CMake subdirectory, even the component stuff. such
+# a pain to debug
+rclcpp_components_register_node(
+  online_node_component
+  PLUGIN
+  "rko_lio::ros::OnlineNode"
+  EXECUTABLE
+  online_node)
+
+install(
+  TARGETS online_node_component offline_node
+  EXPORT rko_lioTargets
+  RUNTIME DESTINATION lib/${PROJECT_NAME})
+
 install(DIRECTORY config launch DESTINATION share/rko_lio)
+
+ament_export_targets(rko_lioTargets)
+
 ament_package()

--- a/ros/rko_lio/CMakeLists.txt
+++ b/ros/rko_lio/CMakeLists.txt
@@ -54,15 +54,3 @@ target_link_libraries(offline_node PRIVATE rko_lio::ros)
 add_library(online_node_component SHARED online_node.cpp)
 ament_target_dependencies(online_node_component PUBLIC rclcpp_components)
 target_link_libraries(online_node_component PRIVATE rko_lio::ros)
-# the following registers the component and then creates an executable
-# "online_node", by default using a single threaded executor. install should be
-# handled by the macro
-rclcpp_components_register_node(
-  online_node_component
-  PLUGIN
-  "rko_lio::ros::OnlineNode"
-  EXECUTABLE
-  online_node)
-
-install(TARGETS online_node_component offline_node
-        RUNTIME DESTINATION lib/${PROJECT_NAME})


### PR DESCRIPTION
Fix the `online_node_component` to actually be a loadable plugin. While I earlier thought I was doing the setup for that properly, I was wrong. This just never popped up because I always use the `online_node` executable instead of the component.

ament macros won't work inside CMake subdirectories, this is mentioned in the ament ros docs. And i dont know if its documented somewhere, but apparently also `rclcpp_component_register_node` and the `...nodes` version as well won't work inside a subdirectory. suffice to say, i'll be putting all ros macros without exception alongside the `ament_package` call now. sheesh.

Second, i was not exporting the target set with the component. Well even if i did, the above problem would have meant it'd not work.

Either way, now if one does `ros2 component types`, the component will show up
```
root@6b9b9db7a6dd:~/ros2_ws# ros2 component types
rko_lio
  rko_lio::ros::OnlineNode
```
and will be loadable with a `component_container`.

This may or may not have been the issue with #33. But that remains to be seen (see the issue for more).