### PR TITLE
Drop irregular lidar frames

### DIFF
--- a/cpp/rko_lio/core/lio.cpp
+++ b/cpp/rko_lio/core/lio.cpp
@@ -416,9 +416,10 @@ Vector3dVector LIO::register_scan(const Vector3dVector& scan, const TimestampVec
   }
 
   if (std::chrono::abs(current_lidar_time - lidar_state.time).count() > 1.0) {
-    double diff_seconds = (current_lidar_time - lidar_state.time).count();
-    throw std::runtime_error("Received LiDAR scan with " + std::to_string(diff_seconds) +
-                             " seconds delta to previous scan.");
+    const double diff_seconds = (current_lidar_time - lidar_state.time).count();
+    // std::expected would be better, but thats c++23. unless we add another dep...
+    throw std::invalid_argument("Received LiDAR scan with " + std::to_string(diff_seconds) +
+                                " seconds delta to previous scan.");
   }
 
   const auto& [avg_body_accel, avg_ang_vel] = std::invoke([&]() -> std::pair<Eigen::Vector3d, Eigen::Vector3d> {

--- a/cpp/rko_lio/core/lio.cpp
+++ b/cpp/rko_lio/core/lio.cpp
@@ -415,6 +415,12 @@ Vector3dVector LIO::register_scan(const Vector3dVector& scan, const TimestampVec
     return {};
   }
 
+  if (std::chrono::abs(current_lidar_time - lidar_state.time).count() > 1.0) {
+    double diff_seconds = (current_lidar_time - lidar_state.time).count();
+    throw std::runtime_error("Received LiDAR scan with " + std::to_string(diff_seconds) +
+                             " seconds delta to previous scan.");
+  }
+
   const auto& [avg_body_accel, avg_ang_vel] = std::invoke([&]() -> std::pair<Eigen::Vector3d, Eigen::Vector3d> {
     if (config.initialization_phase && !_initialized) {
       // assume static and

--- a/python/rko_lio/lio_pipeline.py
+++ b/python/rko_lio/lio_pipeline.py
@@ -171,18 +171,25 @@ class LIOPipeline:
                     imu for imu in self.imu_buffer if imu["time"] >= frame["end_time"]
                 ]
                 # Register the lidar scan
-                if self.extrinsic_lidar2base is not None:
-                    # TODO: rerun the deskewed scan as well, but there is some flickering in the viz for some reason
-                    self.lio.register_scan_with_extrinsic(
-                        self.extrinsic_lidar2base,
-                        frame["scan"],
-                        frame["timestamps"],
+                try:
+                    if self.extrinsic_lidar2base is not None:
+                        # TODO: rerun the deskewed scan as well, but there is some flickering in the viz for some reason
+                        self.lio.register_scan_with_extrinsic(
+                            self.extrinsic_lidar2base,
+                            frame["scan"],
+                            frame["timestamps"],
+                        )
+                    else:
+                        self.lio.register_scan(
+                            frame["scan"],
+                            frame["timestamps"],
+                        )
+                except ValueError as e:
+                    print(
+                        "ERROR: Dropping LiDAR frame as there was an error. Odometry might suffer. Error:",
+                        e,
                     )
-                else:
-                    self.lio.register_scan(
-                        frame["scan"],
-                        frame["timestamps"],
-                    )
+                    continue
 
             if self.viz:
                 with ScopedProfiler("Pipeline - Visualization") as viz_timer:

--- a/ros/rko_lio/ros_utils/point_cloud_read.cpp
+++ b/ros/rko_lio/ros_utils/point_cloud_read.cpp
@@ -68,7 +68,7 @@ point_cloud2_to_eigen_with_timestamps(const PointCloud2::ConstSharedPtr& msg) {
         }
       }
     }
-    throw std::logic_error("Point cloud needs timestamps for deskewing");
+    throw std::invalid_argument("Point cloud needs timestamps for deskewing");
   });
 
   // templated lambda (auto) ftw


### PR DESCRIPTION
Specifically, handling the case when the lidar stamp is more than a second (positive or negative) in delta to the previous scan. We don't handle the situation when data arrives out of order, so drop those frames instead as it could be a one-off.

Core:
- throw an invalid argument exception, which might not be the best intuitively, but its the best alternative to writing custom exceptions. I'll take that for now.
- std expected return with a custom error type would probably be much cleaner in intent and code. but thats c++23 which ubuntu 22's default gcc 11 wont support. so can't use that, unless i throw in another dep like https://github.com/TartanLlama/expected. For now the use case is too limited for an entire new dep.

Python:
- try except on register_scan. tested on some data where i did indeed have this problem,

ROS:
- Try catch on invalid argument (also switch out an earlier case of logic error to invalid argument)

