### PR TITLE
python: prettier logs using rich

### DIFF
--- a/python/rko_lio/dataloaders/get_dataloader.py
+++ b/python/rko_lio/dataloaders/get_dataloader.py
@@ -70,10 +70,11 @@ def get_dataloader(
         return RawDataLoader(data_path)
 
     elif name == "helipr":
+        from ..util import error
         from .helipr import HeliprDataLoader
 
         if sequence is None:
-            print("[ERROR] HeliprDataLoader requires --sequence parameter")
+            error("HeliprDataLoader requires --sequence parameter")
             sys.exit(1)
         return HeliprDataLoader(data_path, sequence)
 
@@ -91,6 +92,8 @@ def guess_dataloader(
     base_frame_id: str | None = None,
     query_extrinsics: bool = True,
 ):
+    from ..util import error, info
+
     # Check for rosbag files
     rosbag_exts = [".bag", ".db3", ".mcap"]
     found_rosbag_file = False
@@ -100,7 +103,7 @@ def guess_dataloader(
             found_rosbag_file = True
             break
     if found_rosbag_file:
-        print("Guessed dataloader as rosbag!")
+        info("Guessed dataloader as rosbag!")
         return get_dataloader(
             "rosbag",
             data_path,
@@ -118,7 +121,7 @@ def guess_dataloader(
     txt_files = list(data_path.glob("*.txt"))
     csv_files = list(data_path.glob("*.csv"))
     if lidar_folder.is_dir() and (txt_files or csv_files):
-        print("Guessed dataloader as raw!")
+        info("Guessed dataloader as raw!")
         return get_dataloader("raw", data_path, query_extrinsics=query_extrinsics)
 
     # Check for helipr data
@@ -127,21 +130,21 @@ def guess_dataloader(
 
     if xsens_imu_path.is_file() and lidar_folder.is_dir():
         if sequence is None:
-            print("[ERROR] HeLiPR dataLoader requires --sequence parameter")
+            error("HeLiPR dataLoader requires --sequence parameter")
             sys.exit(1)
 
         seq_folder = lidar_folder / sequence
         if not seq_folder.is_dir():
-            print(f"[ERROR] Helipr sequence folder does not exist: {seq_folder}")
+            error(f"Helipr sequence folder does not exist: {seq_folder}")
             sys.exit(1)
 
-        print("Guessed dataloader as Helipr!")
+        info("Guessed dataloader as Helipr!")
         return get_dataloader(
             "helipr", data_path, sequence=sequence, query_extrinsics=query_extrinsics
         )
 
     # No matching dataloader found
-    print(
-        f"[ERROR] Could not guess dataloader for path: {data_path}, please pass the loader with --dataloader or -d"
+    error(
+        f"Could not guess dataloader for path: {data_path}, please pass the loader with --dataloader or -d"
     )
     sys.exit(1)

--- a/python/rko_lio/dataloaders/rosbag.py
+++ b/python/rko_lio/dataloaders/rosbag.py
@@ -35,6 +35,7 @@ except ModuleNotFoundError:
 
 from .. import rko_lio_pybind
 from ..scoped_profiler import ScopedProfiler
+from ..util import error, warning
 from .utils.ros_read_point_cloud import read_point_cloud as ros_read_point_cloud
 from .utils.static_tf_tree import create_static_tf_tree, query_static_tf
 
@@ -95,8 +96,8 @@ class RosbagDataLoader:
             print("Building TF tree.")
             static_tf_tree = create_static_tf_tree(self.bag)
             if not static_tf_tree:
-                print(
-                    "[ERROR] The rosbag doesn't contain a static tf tree, cannot query it for extrinsics. Please specify the extrinsics manually in a config. You can use 'rko_lio --dump_config' to dump a default config."
+                error(
+                    "The rosbag doesn't contain a static tf tree, cannot query it for extrinsics. Please specify the extrinsics manually in a config. You can use 'rko_lio --dump_config' to dump a default config."
                 )
                 sys.exit(1)
 
@@ -182,10 +183,8 @@ class RosbagDataLoader:
             raw_timestamps = np.ones(points.shape[0]) * header_stamp_sec
             if not hasattr(self, "_printed_timestamp_warning"):
                 self._printed_timestamp_warning = True
-                RED_TEXT_ON_WHITE_BG = "\033[1;31;47m"
-                RESET = "\033[0m"
-                print(
-                    f"\n\n{RED_TEXT_ON_WHITE_BG}[WARNING] Could not detect timestamps in the point cloud. Odometry performance will suffer. Also please disable deskewing (enabled by default) otherwise the odometry may not work properly.{RESET}\n\n"
+                warning(
+                    "Could not detect timestamps in the point cloud. Odometry performance will suffer. Also please disable deskewing (enabled by default) otherwise the odometry may not work properly."
                 )
             return points, raw_timestamps
 
@@ -206,18 +205,22 @@ class RosbagDataLoader:
         if topic and topic in topics_of_type:
             return topic
         if topic and topic not in topics_of_type:
-            print(
-                f'[ERROR] Rosbag does not contain any msg with the topic name "{topic}". '
-                f"Please select one of these for {expected_msgtype}:"
+            error(
+                "Rosbag does not contain any msg with the topic name",
+                topic,
+                ". Please select one of these for",
+                expected_msgtype,
             )
             print_available_topics_and_exit()
         if len(topics_of_type) > 1:
-            print(
-                f"Multiple {expected_msgtype} topics available. Please select one with the appropriate flag."
+            error(
+                "Multiple",
+                expected_msgtype,
+                "topics available. Please select one with the appropriate flag.",
             )
             print_available_topics_and_exit()
         if len(topics_of_type) == 0:
-            print(f"[ERROR] Your rosbag does not contain any {expected_msgtype} topic")
+            error("Your rosbag does not contain any", expected_msgtype, "topic.")
             sys.exit(1)
         return topics_of_type[0]
 

--- a/python/rko_lio/util.py
+++ b/python/rko_lio/util.py
@@ -1,0 +1,31 @@
+from rich.console import Console
+from rich.panel import Panel
+
+console = Console()
+
+
+def error(*args):
+    msg = " ".join(str(a) for a in args)
+    console.print(
+        Panel(msg, title="Error", border_style="red", expand=False, title_align="left")
+    )
+
+
+def warning(*args):
+    msg = " ".join(str(a) for a in args)
+    console.print(
+        Panel(
+            msg,
+            title="Warning",
+            border_style="yellow",
+            expand=False,
+            title_align="left",
+        )
+    )
+
+
+def info(*args):
+    msg = " ".join(str(a) for a in args)
+    console.print(
+        Panel(msg, title="Info", border_style="cyan", expand=False, title_align="left")
+    )


### PR DESCRIPTION
since we have rich available with typer already, use rich to prettify console logs, like how typer does. 

there's still a few remaining vanilla logs, which I won't touch. The rich-ified logs are stuff that should be highlighted to the user as they're more important. changing everything over to this would probably be overkill.

the other stuff we should move to `logging` later anyways.