### PR TITLE
fix (core): in case map is empty, correct lidar frame timestamping

### DIFF
--- a/python/rko_lio/cli.py
+++ b/python/rko_lio/cli.py
@@ -152,7 +152,7 @@ def cli(
         None,
         "--dataloader",
         "-d",
-        help="Specify a dataloader: [rosbag, raw, helipr]. Leave empty to guess one.",
+        help="Specify a dataloader: [rosbag, raw, helipr]. Leave empty to guess one",
         show_choices=True,
         callback=dataloader_name_callback,
         case_sensitive=False,
@@ -167,11 +167,11 @@ def cli(
     results_dir: Path | None = typer.Option(
         "results", "--results_dir", "-r", help="Where to dump LIO results if logging"
     ),
-    run_name: str = typer.Option(
-        "rko_lio_experiment",
+    run_name: str | None = typer.Option(
+        None,
         "--run_name",
         "-n",
-        help="Name prefix for output files if logging",
+        help="Name prefix for output files if logging. Default takes the name from the data_path argument",
     ),
     sequence: str | None = typer.Option(
         None,
@@ -202,7 +202,7 @@ def cli(
     version: bool | None = typer.Option(
         None,
         "--version",
-        help="Show the current version of RKO_LIO and exit",
+        help="Print the current version of RKO_LIO and exit",
         callback=version_callback,
         is_eager=True,
         rich_help_panel="Auxilary commands",
@@ -307,7 +307,7 @@ def cli(
 
     if log_results and results_dir:
         results_dir.mkdir(parents=True, exist_ok=True)
-        pipeline.dump_results_to_disk(results_dir, run_name)
+        pipeline.dump_results_to_disk(results_dir, run_name or data_path.name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In case the map is empty, which is being checked on the second frame and initialization (which implicitly also updated lidar time) was off, the lidar state time was not being updated.

since initialization is off by default, timestamping in this case is fixed now. 

there is one further fix, questionable if i can call it that, that can be done. In case the map is empty, the pose is not updated and the incoming frame is added to the map with an identity pose. We do have the initial guess from the IMU which could be used instead. but for now, not adding it in. at best, this leads to an error initially, but things should still settle after a few frames. better yet, (please) just start the system from rest and enable initialization.

the first frame which is used as global frame is also now logged in the trajectory dump as identity. this is the real "start" of the trajectory now.

minor python change: cli parameter `run_name` has a better default value by taking the name from `data_path` itself.