### PR TITLE
Add self qualifer to __iter__ function

### DIFF
--- a/python/rko_lio/dataloaders/raw.py
+++ b/python/rko_lio/dataloaders/raw.py
@@ -130,7 +130,7 @@ class RawDataLoader:
         return self.T_imu_to_base, self.T_lidar_to_base
 
     def __iter__(self):
-        self._iter = iter(entries)
+        self._iter = iter(self.entries)
         return self
 
     def __next__(self):


### PR DESCRIPTION
This fixes the raw dataloader functionality in the master branch, as discussed in #38 