### PR TITLE
Drop ros cmake min version to 3.26.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.26.5)
 project(rko_lio LANGUAGES CXX)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies.cmake)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -20,11 +20,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-
 include(FetchContent)
 
 option(RKO_LIO_FETCH_CONTENT_DEPS
        "Fetch dependencies via FetchContent instead of using find_package" OFF)
+
+set(RKO_LIO_FETCHCONTENT_COMMON_FLAGS SYSTEM OVERRIDE_FIND_PACKAGE)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.28")
+  list(APPEND RKO_LIO_FETCHCONTENT_COMMON_FLAGS EXCLUDE_FROM_ALL)
+endif()
 
 # Bonxai (always fetched, as upstream releases no system version)
 include(${CMAKE_CURRENT_LIST_DIR}/dependencies/bonxai/bonxai.cmake)

--- a/cmake/dependencies/bonxai/bonxai.cmake
+++ b/cmake/dependencies/bonxai/bonxai.cmake
@@ -2,11 +2,7 @@ FetchContent_Declare(
   Bonxai
   GIT_REPOSITORY https://github.com/facontidavide/Bonxai.git
   GIT_TAG 02d401b1ce38bce870c6704bcd4e35a56a641411 # sep 14 2025 master
-  SOURCE_SUBDIR
-  bonxai_core
-  SYSTEM
-  EXCLUDE_FROM_ALL
-  OVERRIDE_FIND_PACKAGE)
+  SOURCE_SUBDIR bonxai_core ${RKO_LIO_FETCHCONTENT_COMMON_FLAGS})
 FetchContent_MakeAvailable(Bonxai)
 
 if(FETCHCONTENT_FULLY_DISCONNECTED)

--- a/cmake/dependencies/eigen/eigen.cmake
+++ b/cmake/dependencies/eigen/eigen.cmake
@@ -20,5 +20,5 @@ set(EIGEN_BUILD_LAPACK
 FetchContent_Declare(
   Eigen3
   URL https://gitlab.com/libeigen/eigen/-/archive/5.0.0/eigen-5.0.0.tar.gz
-      SYSTEM EXCLUDE_FROM_ALL OVERRIDE_FIND_PACKAGE)
+      ${RKO_LIO_FETCHCONTENT_COMMON_FLAGS})
 FetchContent_MakeAvailable(Eigen3)

--- a/cmake/dependencies/json/nlohmann_json.cmake
+++ b/cmake/dependencies/json/nlohmann_json.cmake
@@ -1,5 +1,5 @@
 FetchContent_Declare(
   nlohmann_json
-  URL https://github.com/nlohmann/json/archive/refs/tags/v3.12.0.tar.gz SYSTEM
-      EXCLUDE_FROM_ALL OVERRIDE_FIND_PACKAGE)
+  URL https://github.com/nlohmann/json/archive/refs/tags/v3.12.0.tar.gz
+      ${RKO_LIO_FETCHCONTENT_COMMON_FLAGS})
 FetchContent_MakeAvailable(nlohmann_json)

--- a/cmake/dependencies/sophus/sophus.cmake
+++ b/cmake/dependencies/sophus/sophus.cmake
@@ -13,5 +13,5 @@ set(BUILD_PYTHON_BINDINGS
 
 FetchContent_Declare(
   Sophus URL https://github.com/strasdat/Sophus/archive/refs/tags/1.24.6.tar.gz
-             SYSTEM EXCLUDE_FROM_ALL OVERRIDE_FIND_PACKAGE)
+             ${RKO_LIO_FETCHCONTENT_COMMON_FLAGS})
 FetchContent_MakeAvailable(Sophus)

--- a/cmake/dependencies/tbb/tbb.cmake
+++ b/cmake/dependencies/tbb/tbb.cmake
@@ -7,5 +7,5 @@ option(TBB_TEST OFF)
 FetchContent_Declare(
   TBB
   URL https://github.com/uxlfoundation/oneTBB/archive/refs/tags/v2022.2.0.tar.gz
-      SYSTEM EXCLUDE_FROM_ALL OVERRIDE_FIND_PACKAGE)
+      ${RKO_LIO_FETCHCONTENT_COMMON_FLAGS})
 FetchContent_MakeAvailable(TBB)


### PR DESCRIPTION
Since rhel 9 builds are failing on the ros build farm. 

and figuring out how to patch the release repository is too much of a pain in the **** as documentation is sparse.

To keep behavior the same on our target platforms, EXCLUDE_FROM_ALL is still added, only if version > 3.28. As far as i can tell from cmake changelogs, this is the only relevant (to me) thing that is different between the two versions.