### PR TITLE
Drop cmake min version to 3.22.1 to support ros humble builds with default toolchains 

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -30,3 +30,19 @@ with section("format"):
     # If a cmdline positional group consumes more than this many lines without
     # nesting, then invalidate the layout (and nest)
     max_rows_cmdline = 2
+
+with section("parse"):
+    additional_commands = {
+        "compat_target_sources": {
+            "pargs": 1,
+            "flags": [],
+            "kwargs": {
+                "PRIVATE": "*",
+                "PUBLIC": "*",
+                "FILE_SET": "*",
+                "HEADERS": "*",
+                "FILES": "*",
+                "BASE_DIRS": 1,
+            },
+        }
+    }

--- a/.github/workflows/ros_build_humble.yaml
+++ b/.github/workflows/ros_build_humble.yaml
@@ -9,4 +9,4 @@ jobs:
     uses: ./.github/workflows/ros_build_reusable.yaml
     with:
       ros_distro: humble
-      container_image: alexsilener/ros_humble_desktop_cmake_328_ninja
+      container_image: osrf/ros:humble-desktop

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,8 @@
 cmake_minimum_required(VERSION 3.22.1)
 project(rko_lio LANGUAGES CXX)
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies.cmake)
+include(cmake/dependencies.cmake)
+include(cmake/compat_target_sources.cmake)
 
 find_package(Eigen3 3.4 REQUIRED CONFIG)
 find_package(Sophus REQUIRED CONFIG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@
 cmake_minimum_required(VERSION 3.22.1)
 project(rko_lio LANGUAGES CXX)
 
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 include(cmake/dependencies.cmake)
 include(cmake/compat_target_sources.cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22.1)
 project(rko_lio LANGUAGES CXX)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies.cmake)

--- a/cmake/compat_target_sources.cmake
+++ b/cmake/compat_target_sources.cmake
@@ -24,8 +24,13 @@
 # for CMake < 3.23. Adds private sources normally, adds include directories
 # fallback using BASE_DIRS
 macro(compat_target_sources target)
-  list(REMOVE_AT ARGV 0)
-  set(args ${ARGV})
+  if(NOT ARGC GREATER 0)
+    message(FATAL_ERROR "compat_target_sources requires at least 1 argument")
+  endif()
+  set(all_args ${ARGV})
+  list(REMOVE_AT all_args 0)
+  set(target ${ARGV0})
+  set(args ${all_args})
 
   if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.23")
     target_sources(${target} ${args})

--- a/cmake/compat_target_sources.cmake
+++ b/cmake/compat_target_sources.cmake
@@ -24,47 +24,26 @@
 # for CMake < 3.23. Adds private sources normally, adds include directories
 # fallback using BASE_DIRS
 macro(compat_target_sources target)
-  if(NOT ARGC GREATER 0)
-    message(FATAL_ERROR "compat_target_sources requires at least 1 argument")
-  endif()
-  set(all_args ${ARGV})
-  list(REMOVE_AT all_args 0)
-  set(target ${ARGV0})
-  set(args ${all_args})
+  set(options)
+  set(oneValueArgs BASE_DIRS)
+  set(multiValueArgs
+      PRIVATE
+      PUBLIC
+      FILE_SET
+      HEADERS
+      FILES)
+
+  cmake_parse_arguments(
+    CTS
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN})
 
   if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.23")
-    target_sources(${target} ${args})
+    target_sources(${target} ${ARGN})
   else()
-    set(private_sources)
-    set(base_dir "")
-    set(in_private OFF)
-    set(in_public OFF)
-    foreach(arg IN LISTS args)
-      if(arg STREQUAL "PRIVATE")
-        set(in_private ON)
-        set(in_public OFF)
-        continue()
-      elseif(arg STREQUAL "PUBLIC")
-        set(in_private OFF)
-        set(in_public ON)
-        continue()
-      elseif(arg STREQUAL "BASE_DIRS")
-        set(in_private OFF)
-        set(in_public OFF)
-        continue()
-      endif()
-
-      if(in_private)
-        list(APPEND private_sources ${arg})
-      elseif(
-        NOT in_private
-        AND NOT in_public
-        AND NOT base_dir)
-        set(base_dir ${arg})
-      endif()
-    endforeach()
-
-    target_sources(${target} PRIVATE ${private_sources})
-    target_include_directories(${target} PUBLIC "${base_dir}")
+    target_sources(${target} PRIVATE ${CTS_PRIVATE})
+    target_include_directories(${target} PUBLIC "${CTS_BASE_DIRS}")
   endif()
 endmacro()

--- a/cmake/compat_target_sources.cmake
+++ b/cmake/compat_target_sources.cmake
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2025 Meher V.R. Malladi.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 # compat_target_sources macro: backward-compatible target_sources with FILE_SET
 # for CMake < 3.23. Adds private sources normally, adds include directories
 # fallback using BASE_DIRS

--- a/cmake/compat_target_sources.cmake
+++ b/cmake/compat_target_sources.cmake
@@ -1,0 +1,43 @@
+# compat_target_sources macro: backward-compatible target_sources with FILE_SET
+# for CMake < 3.23. Adds private sources normally, adds include directories
+# fallback using BASE_DIRS
+macro(compat_target_sources target)
+  list(REMOVE_AT ARGV 0)
+  set(args ${ARGV})
+
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.23")
+    target_sources(${target} ${args})
+  else()
+    set(private_sources)
+    set(base_dir "")
+    set(in_private OFF)
+    set(in_public OFF)
+    foreach(arg IN LISTS args)
+      if(arg STREQUAL "PRIVATE")
+        set(in_private ON)
+        set(in_public OFF)
+        continue()
+      elseif(arg STREQUAL "PUBLIC")
+        set(in_private OFF)
+        set(in_public ON)
+        continue()
+      elseif(arg STREQUAL "BASE_DIRS")
+        set(in_private OFF)
+        set(in_public OFF)
+        continue()
+      endif()
+
+      if(in_private)
+        list(APPEND private_sources ${arg})
+      elseif(
+        NOT in_private
+        AND NOT in_public
+        AND NOT base_dir)
+        set(base_dir ${arg})
+      endif()
+    endforeach()
+
+    target_sources(${target} PRIVATE ${private_sources})
+    target_include_directories(${target} PUBLIC "${base_dir}")
+  endif()
+endmacro()

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -36,7 +36,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.28")
   list(APPEND RKO_LIO_FETCHCONTENT_COMMON_FLAGS EXCLUDE_FROM_ALL)
 endif()
 
-include("${CMAKE_CURRENT_LIST_DIR}/mock_find_package.cmake")
+include(${CMAKE_CURRENT_LIST_DIR}/mock_find_package.cmake)
 
 # Bonxai (always fetched, as upstream releases no system version)
 include(${CMAKE_CURRENT_LIST_DIR}/dependencies/bonxai/bonxai.cmake)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -25,10 +25,18 @@ include(FetchContent)
 option(RKO_LIO_FETCH_CONTENT_DEPS
        "Fetch dependencies via FetchContent instead of using find_package" OFF)
 
-set(RKO_LIO_FETCHCONTENT_COMMON_FLAGS SYSTEM OVERRIDE_FIND_PACKAGE)
+set(RKO_LIO_FETCHCONTENT_COMMON_FLAGS)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
+  list(APPEND RKO_LIO_FETCHCONTENT_COMMON_FLAGS OVERRIDE_FIND_PACKAGE)
+endif()
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.25")
+  list(APPEND RKO_LIO_FETCHCONTENT_COMMON_FLAGS SYSTEM)
+endif()
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.28")
   list(APPEND RKO_LIO_FETCHCONTENT_COMMON_FLAGS EXCLUDE_FROM_ALL)
 endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/mock_find_package.cmake")
 
 # Bonxai (always fetched, as upstream releases no system version)
 include(${CMAKE_CURRENT_LIST_DIR}/dependencies/bonxai/bonxai.cmake)

--- a/cmake/dependencies/bonxai/README.md
+++ b/cmake/dependencies/bonxai/README.md
@@ -1,12 +1,11 @@
-The code here is covered by Bonxai's [LICENSE](../LICENSE) file.
-Please note that this is essentially a hack to fix a very specific case encountered in the ROS build farm.
-I'm repeating the comment i have from [bonxai.cmake](bonxai.cmake) here.
+The code here is covered by Bonxai's [LICENSE](LICENSE) file.
+Please note that this is essentially a hack to fix a very specific case encountered in the ROS build farms.
 
-The ros build farm uses `FETCHCONTENT_FULLY_DISCONNECTED` to perform an isolated build.
-But as per the author of FetchContent himself, this is an abuse of the flag.
+The ros build farm uses `FETCHCONTENT_FULLY_DISCONNECTED` (and other flags) to perform an isolated build.
+As a side note, as per the author of FetchContent himself, this is an abuse of the flag.
 See https://github.com/Homebrew/brew/pull/17075 and https://gitlab.kitware.com/cmake/cmake/-/issues/25946.
-Nevertheless this is a problem for us since Bonxai is not part of rosdistro (or any upstream system package repo) yet.
+Nevertheless, this is a problem for us since Bonxai is not part of rosdistro (or any upstream system package repo) yet.
 See here for possible progress: https://github.com/facontidavide/Bonxai/issues/55.
 
-Since a user can use this flag as valid behavior, my best attempt at fixing this issue for the build farm is to vendor Bonxai code right here.
+I've made my best attempt at fixing this problem for isolated builds in `bonxai.cmake`. If a user runs afoul of it in an actual use case, then please raise an issue.
 Hopefully soon enough, one way or another, I can remove this hack and stop vendoring bonxai code in my own repository.

--- a/cmake/dependencies/bonxai/bonxai.cmake
+++ b/cmake/dependencies/bonxai/bonxai.cmake
@@ -1,3 +1,23 @@
+# Copyright (c) 2025 Meher V.R. Malladi.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 FetchContent_Declare(
   Bonxai
   GIT_REPOSITORY https://github.com/facontidavide/Bonxai.git

--- a/cmake/dependencies/bonxai/bonxai.cmake
+++ b/cmake/dependencies/bonxai/bonxai.cmake
@@ -18,12 +18,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-if(CMAKE_EXPORT_NO_PACKAGE_REGISTRY STREQUAL "ON"
-   AND CMAKE_FIND_USE_PACKAGE_REGISTRY STREQUAL "OFF"
-   AND CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY STREQUAL "ON")
-  # looks like the humble isolated build won't be using
-  # FETCHCONTENT_FULLY_DISCONNECTED and I can think of no other way to detect
-  # this case, except match all the other variables they set
+FetchContent_Declare(
+  Bonxai
+  GIT_REPOSITORY https://github.com/facontidavide/Bonxai.git
+  GIT_TAG 02d401b1ce38bce870c6704bcd4e35a56a641411 # sep 14 2025 master
+  SOURCE_SUBDIR bonxai_core ${RKO_LIO_FETCHCONTENT_COMMON_FLAGS})
+
+if(NOT
+   (CMAKE_EXPORT_NO_PACKAGE_REGISTRY STREQUAL "ON"
+    AND CMAKE_FIND_USE_PACKAGE_REGISTRY STREQUAL "OFF"
+    AND CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY STREQUAL "ON"))
+  # This branch is usual behaviour. The else branch is relevant for network
+  # isolated builds
+  FetchContent_MakeAvailable(Bonxai)
+else()
   message(
     WARNING
       "You're probably doing a network-isolated build. But Bonxai is a required dependency which should be fetched. It's being manually vendored in the repo for now for this purpose."
@@ -44,13 +52,6 @@ if(CMAKE_EXPORT_NO_PACKAGE_REGISTRY STREQUAL "ON"
     )
   endif()
   add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/bonxai_core)
-else()
-  FetchContent_Declare(
-    Bonxai
-    GIT_REPOSITORY https://github.com/facontidavide/Bonxai.git
-    GIT_TAG 02d401b1ce38bce870c6704bcd4e35a56a641411 # sep 14 2025 master
-    SOURCE_SUBDIR bonxai_core ${RKO_LIO_FETCHCONTENT_COMMON_FLAGS})
-  FetchContent_MakeAvailable(Bonxai)
 endif()
 
 mock_find_package_for_older_cmake(Bonxai)

--- a/cmake/dependencies/bonxai/bonxai.cmake
+++ b/cmake/dependencies/bonxai/bonxai.cmake
@@ -18,39 +18,39 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FetchContent_Declare(
-  Bonxai
-  GIT_REPOSITORY https://github.com/facontidavide/Bonxai.git
-  GIT_TAG 02d401b1ce38bce870c6704bcd4e35a56a641411 # sep 14 2025 master
-  SOURCE_SUBDIR bonxai_core ${RKO_LIO_FETCHCONTENT_COMMON_FLAGS})
-FetchContent_MakeAvailable(Bonxai)
-
-if(FETCHCONTENT_FULLY_DISCONNECTED)
-  # the ros build farm uses this option to perform an isolated build. but as per
-  # the author of FetchContent himself, this is an abuse of the flag. See
-  # https://github.com/Homebrew/brew/pull/17075 and
-  # https://gitlab.kitware.com/cmake/cmake/-/issues/25946. Nevertheless this is
-  # a problem for us since Bonxai is not part of rosdistro yet. See here for
-  # progress: https://github.com/facontidavide/Bonxai/issues/55. Since a user
-  # can use this flag as valid behavior, the following is my best attempt at
-  # catching the specific situation in the build farm. Hopefully soon enough, i
-  # can remove this hack and stop vendoring bonxai code in my own repository.
-
-  file(
-    GLOB_RECURSE bonxai_source_files
-    LIST_DIRECTORIES false
-    "${bonxai_SOURCE_DIR}/*")
-
-  list(LENGTH bonxai_source_files bonxai_source_count)
-
-  if(bonxai_source_count EQUAL 0)
+if(CMAKE_EXPORT_NO_PACKAGE_REGISTRY STREQUAL "ON"
+   AND CMAKE_FIND_USE_PACKAGE_REGISTRY STREQUAL "OFF"
+   AND CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY STREQUAL "ON")
+  # looks like the humble isolated build won't be using
+  # FETCHCONTENT_FULLY_DISCONNECTED and I can think of no other way to detect
+  # this case, except match all the other variables they set
+  message(
+    WARNING
+      "You're probably doing a network-isolated build. But Bonxai is a required dependency which should be fetched. It's being manually vendored in the repo for now for this purpose."
+  )
+  if(NOT FETCHCONTENT_FULLY_DISCONNECTED)
+    # noble isolated builds have this as ON. the purpose of this if is to just
+    # emit a warning in case a user unintentionally ends up in this branch. as
+    # per the author of FetchContent himself, the build farm use is an abuse of
+    # the flag. See https://github.com/Homebrew/brew/pull/17075 and
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/25946. Nevertheless this
+    # is a problem for us since Bonxai is not part of rosdistro yet. See here
+    # for progress: https://github.com/facontidavide/Bonxai/issues/55. Hopefully
+    # soon enough, i can remove this hack and stop vendoring bonxai code in my
+    # own repository.
     message(
       WARNING
-        "Bonxai source directory (${bonxai_SOURCE_DIR}) is empty and FETCHCONTENT_FULLY_DISCONNECTED is ON. This is likely unintended. Bonxai will be manually included for now as it is a required dependency."
+        "It looks like an isolated build is happening, but FETCHCONTENT_FULLY_DISCONNECTED is not ON."
     )
-    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/bonxai_core)
   endif()
-
+  add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/bonxai_core)
+else()
+  FetchContent_Declare(
+    Bonxai
+    GIT_REPOSITORY https://github.com/facontidavide/Bonxai.git
+    GIT_TAG 02d401b1ce38bce870c6704bcd4e35a56a641411 # sep 14 2025 master
+    SOURCE_SUBDIR bonxai_core ${RKO_LIO_FETCHCONTENT_COMMON_FLAGS})
+  FetchContent_MakeAvailable(Bonxai)
 endif()
 
 mock_find_package_for_older_cmake(Bonxai)

--- a/cmake/dependencies/bonxai/bonxai.cmake
+++ b/cmake/dependencies/bonxai/bonxai.cmake
@@ -32,3 +32,5 @@ if(FETCHCONTENT_FULLY_DISCONNECTED)
   endif()
 
 endif()
+
+mock_find_package_for_older_cmake(Bonxai)

--- a/cmake/dependencies/eigen/eigen.cmake
+++ b/cmake/dependencies/eigen/eigen.cmake
@@ -22,3 +22,5 @@ FetchContent_Declare(
   URL https://gitlab.com/libeigen/eigen/-/archive/5.0.0/eigen-5.0.0.tar.gz
       ${RKO_LIO_FETCHCONTENT_COMMON_FLAGS})
 FetchContent_MakeAvailable(Eigen3)
+
+mock_find_package_for_older_cmake(Eigen3)

--- a/cmake/dependencies/json/nlohmann_json.cmake
+++ b/cmake/dependencies/json/nlohmann_json.cmake
@@ -3,3 +3,5 @@ FetchContent_Declare(
   URL https://github.com/nlohmann/json/archive/refs/tags/v3.12.0.tar.gz
       ${RKO_LIO_FETCHCONTENT_COMMON_FLAGS})
 FetchContent_MakeAvailable(nlohmann_json)
+
+mock_find_package_for_older_cmake(nlohmann_json)

--- a/cmake/dependencies/sophus/sophus.cmake
+++ b/cmake/dependencies/sophus/sophus.cmake
@@ -11,9 +11,16 @@ set(BUILD_PYTHON_BINDINGS
     OFF
     CACHE BOOL "Don't build Sophus Python Bindings")
 
+if(CMAKE_VERSION VERSION_LESS "3.24")
+  set(SOPHUS_VERSION "1.22.10")
+else()
+  set(SOPHUS_VERSION "1.24.6")
+endif()
+
 FetchContent_Declare(
-  Sophus URL https://github.com/strasdat/Sophus/archive/refs/tags/1.24.6.tar.gz
-             ${RKO_LIO_FETCHCONTENT_COMMON_FLAGS})
+  Sophus
+  URL https://github.com/strasdat/Sophus/archive/refs/tags/${SOPHUS_VERSION}.tar.gz
+      ${RKO_LIO_FETCHCONTENT_COMMON_FLAGS})
 FetchContent_MakeAvailable(Sophus)
 
 mock_find_package_for_older_cmake(Sophus)

--- a/cmake/dependencies/sophus/sophus.cmake
+++ b/cmake/dependencies/sophus/sophus.cmake
@@ -15,3 +15,5 @@ FetchContent_Declare(
   Sophus URL https://github.com/strasdat/Sophus/archive/refs/tags/1.24.6.tar.gz
              ${RKO_LIO_FETCHCONTENT_COMMON_FLAGS})
 FetchContent_MakeAvailable(Sophus)
+
+mock_find_package_for_older_cmake(Sophus)

--- a/cmake/dependencies/tbb/tbb.cmake
+++ b/cmake/dependencies/tbb/tbb.cmake
@@ -9,3 +9,5 @@ FetchContent_Declare(
   URL https://github.com/uxlfoundation/oneTBB/archive/refs/tags/v2022.2.0.tar.gz
       ${RKO_LIO_FETCHCONTENT_COMMON_FLAGS})
 FetchContent_MakeAvailable(TBB)
+
+mock_find_package_for_older_cmake(TBB)

--- a/cmake/mock_find_package.cmake
+++ b/cmake/mock_find_package.cmake
@@ -1,0 +1,21 @@
+macro(mock_find_package_for_older_cmake PACKAGE_NAME)
+  # Only if CMake < 3.24 (no OVERRIDE_FIND_PACKAGE)
+  if(NOT CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
+    set(MOCK_CONFIG_DIR "${CMAKE_BINARY_DIR}/cmake-mock-configs")
+    if(NOT EXISTS "${MOCK_CONFIG_DIR}")
+      file(MAKE_DIRECTORY "${MOCK_CONFIG_DIR}")
+    endif()
+
+    list(APPEND CMAKE_PREFIX_PATH "${MOCK_CONFIG_DIR}")
+    list(REMOVE_DUPLICATES CMAKE_PREFIX_PATH)
+    set(CMAKE_PREFIX_PATH
+        "${CMAKE_PREFIX_PATH}"
+        CACHE STRING "Mock config path" FORCE)
+
+    set(MOCK_CONFIG_FILE "${MOCK_CONFIG_DIR}/${PACKAGE_NAME}Config.cmake")
+
+    if(NOT EXISTS "${MOCK_CONFIG_FILE}")
+      file(WRITE "${MOCK_CONFIG_FILE}" "set(${PACKAGE_NAME}_FOUND TRUE)\n")
+    endif()
+  endif()
+endmacro()

--- a/cmake/mock_find_package.cmake
+++ b/cmake/mock_find_package.cmake
@@ -1,3 +1,23 @@
+# Copyright (c) 2025 Meher V.R. Malladi.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 macro(mock_find_package_for_older_cmake PACKAGE_NAME)
   # Only if CMake < 3.24 (no OVERRIDE_FIND_PACKAGE)
   if(NOT CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")

--- a/cmake/mock_find_package.cmake
+++ b/cmake/mock_find_package.cmake
@@ -21,6 +21,7 @@
 macro(mock_find_package_for_older_cmake PACKAGE_NAME)
   # Only if CMake < 3.24 (no OVERRIDE_FIND_PACKAGE)
   if(NOT CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
+    message(STATUS "Mocking find_package for ${PACKAGE_NAME}")
     set(MOCK_CONFIG_DIR "${CMAKE_BINARY_DIR}/cmake-mock-configs")
     if(NOT EXISTS "${MOCK_CONFIG_DIR}")
       file(MAKE_DIRECTORY "${MOCK_CONFIG_DIR}")

--- a/cpp/rko_lio/core/CMakeLists.txt
+++ b/cpp/rko_lio/core/CMakeLists.txt
@@ -22,21 +22,25 @@
 
 add_library(rko_lio.core STATIC)
 add_library(rko_lio::core ALIAS rko_lio.core)
-target_sources(
+compat_target_sources(
   rko_lio.core
-  PRIVATE lio.cpp sparse_voxel_grid.cpp voxel_down_sample.cpp
-          process_timestamps.cpp
-  PUBLIC FILE_SET
-         HEADERS
-         FILES
-         ../../rko_lio/core/lio.hpp
-         ../../rko_lio/core/process_timestamps.hpp
-         ../../rko_lio/core/profiler.hpp
-         ../../rko_lio/core/sparse_voxel_grid.hpp
-         ../../rko_lio/core/util.hpp
-         ../../rko_lio/core/voxel_down_sample.hpp
-         BASE_DIRS
-         ../..)
+  PRIVATE
+  lio.cpp
+  sparse_voxel_grid.cpp
+  voxel_down_sample.cpp
+  process_timestamps.cpp
+  PUBLIC
+  FILE_SET
+  HEADERS
+  FILES
+  ../../rko_lio/core/lio.hpp
+  ../../rko_lio/core/process_timestamps.hpp
+  ../../rko_lio/core/profiler.hpp
+  ../../rko_lio/core/sparse_voxel_grid.hpp
+  ../../rko_lio/core/util.hpp
+  ../../rko_lio/core/voxel_down_sample.hpp
+  BASE_DIRS
+  ../..)
 target_link_libraries(
   rko_lio.core
   PRIVATE nlohmann_json::nlohmann_json TBB::tbb

--- a/cpp/rko_lio/core/CMakeLists.txt
+++ b/cpp/rko_lio/core/CMakeLists.txt
@@ -24,23 +24,18 @@ add_library(rko_lio.core STATIC)
 add_library(rko_lio::core ALIAS rko_lio.core)
 compat_target_sources(
   rko_lio.core
-  PRIVATE
-  lio.cpp
-  sparse_voxel_grid.cpp
-  voxel_down_sample.cpp
-  process_timestamps.cpp
+  PRIVATE lio.cpp sparse_voxel_grid.cpp voxel_down_sample.cpp
+          process_timestamps.cpp
   PUBLIC
   FILE_SET
   HEADERS
-  FILES
-  ../../rko_lio/core/lio.hpp
-  ../../rko_lio/core/process_timestamps.hpp
-  ../../rko_lio/core/profiler.hpp
-  ../../rko_lio/core/sparse_voxel_grid.hpp
-  ../../rko_lio/core/util.hpp
-  ../../rko_lio/core/voxel_down_sample.hpp
-  BASE_DIRS
-  ../..)
+  FILES ../../rko_lio/core/lio.hpp
+        ../../rko_lio/core/process_timestamps.hpp
+        ../../rko_lio/core/profiler.hpp
+        ../../rko_lio/core/sparse_voxel_grid.hpp
+        ../../rko_lio/core/util.hpp
+        ../../rko_lio/core/voxel_down_sample.hpp
+  BASE_DIRS ../..)
 target_link_libraries(
   rko_lio.core
   PRIVATE nlohmann_json::nlohmann_json TBB::tbb

--- a/cpp/rko_lio/core/lio.hpp
+++ b/cpp/rko_lio/core/lio.hpp
@@ -26,6 +26,7 @@
 #include "sparse_voxel_grid.hpp"
 #include "util.hpp"
 #include <filesystem>
+#include <optional>
 
 namespace rko_lio::core {
 // return type struct in place of a tuple

--- a/docs/build.md
+++ b/docs/build.md
@@ -2,21 +2,19 @@
 
 The package is split into three parts, a core C++ library in `cpp`, which implements all the LiDAR-inertial odometry logic, and the python bindings in `python` and the ROS interface in `ros`, which essentially handle reading data.
 
-The main build requirement probably is `CMake>=3.28`, due to how we handle core library dependencies.
+I highly recommend you use `cmake>=3.28`, due to how I handle core library dependencies.
 This is the default CMake version on Ubuntu 24.04 (also the ROS Jazzy/Kilted target Ubuntu platform).
-If you are on older systems, your options to satisfy the version are either `pip install cmake` or to build CMake from source (see [this section](#upgrading-cmake-to-version-328)).
+We still support building with `3.22`, which is the default version on Ubuntu 22.04 (if you're using humble), but this is less tested.
+In case you encounter some build problems, please report it, and I'll look into it.
 
-Additionally, in the different build options we provide ([cpp](Makefile#L7), [python](python/pyproject.toml#L50), [ros](ros/colcon.pkg#L2)), we default to using `ninja` as a generator.
+I also recommend using `ninja` as a generator.
 On ubuntu, you can install it with
 
 ```bash
 sudo apt install ninja-build
 ```
 
-You can switch this out if required.
-
-In summary, `CMake>=3.28` and `ninja` (optional) are the two build requirements.
-The python build additionally handles the CMake and ninja requirements as well.
+The python build will automatically use both `cmake>=3.28` and `ninja`.
 
 ## The core library
 

--- a/ros/rko_lio/CMakeLists.txt
+++ b/ros/rko_lio/CMakeLists.txt
@@ -24,15 +24,17 @@ add_subdirectory(ros_utils)
 
 add_library(rko_lio.ros STATIC)
 add_library(rko_lio::ros ALIAS rko_lio.ros)
-target_sources(
+compat_target_sources(
   rko_lio.ros
-  PRIVATE node.cpp
-  PUBLIC FILE_SET
-         HEADERS
-         FILES
-         ../rko_lio/node.hpp
-         BASE_DIRS
-         ..)
+  PRIVATE
+  node.cpp
+  PUBLIC
+  FILE_SET
+  HEADERS
+  FILES
+  ../rko_lio/node.hpp
+  BASE_DIRS
+  ..)
 target_link_libraries(
   rko_lio.ros
   PUBLIC rko_lio::ros_utils

--- a/ros/rko_lio/CMakeLists.txt
+++ b/ros/rko_lio/CMakeLists.txt
@@ -26,15 +26,12 @@ add_library(rko_lio.ros STATIC)
 add_library(rko_lio::ros ALIAS rko_lio.ros)
 compat_target_sources(
   rko_lio.ros
-  PRIVATE
-  node.cpp
+  PRIVATE node.cpp
   PUBLIC
   FILE_SET
   HEADERS
-  FILES
-  ../rko_lio/node.hpp
-  BASE_DIRS
-  ..)
+  FILES ../rko_lio/node.hpp
+  BASE_DIRS ..)
 target_link_libraries(
   rko_lio.ros
   PUBLIC rko_lio::ros_utils

--- a/ros/rko_lio/ros_utils/CMakeLists.txt
+++ b/ros/rko_lio/ros_utils/CMakeLists.txt
@@ -24,23 +24,18 @@ add_library(rko_lio.ros_utils STATIC)
 add_library(rko_lio::ros_utils ALIAS rko_lio.ros_utils)
 compat_target_sources(
   rko_lio.ros_utils
-  PRIVATE
-  point_cloud_read.cpp
-  point_cloud_write.cpp
-  rosbag_utils.cpp
+  PRIVATE point_cloud_read.cpp point_cloud_write.cpp rosbag_utils.cpp
   PUBLIC
   FILE_SET
   HEADERS
-  FILES
-  ../../rko_lio/ros_utils/point_cloud_read.hpp
-  ../../rko_lio/ros_utils/point_cloud_write.hpp
-  ../../rko_lio/ros_utils/ros_utils.hpp
-  ../../rko_lio/ros_utils/ros_vectors.hpp
-  ../../rko_lio/ros_utils/rosbag_utils.hpp
-  ../../rko_lio/ros_utils/time.hpp
-  ../../rko_lio/ros_utils/transforms.hpp
-  BASE_DIRS
-  ../..)
+  FILES ../../rko_lio/ros_utils/point_cloud_read.hpp
+        ../../rko_lio/ros_utils/point_cloud_write.hpp
+        ../../rko_lio/ros_utils/ros_utils.hpp
+        ../../rko_lio/ros_utils/ros_vectors.hpp
+        ../../rko_lio/ros_utils/rosbag_utils.hpp
+        ../../rko_lio/ros_utils/time.hpp
+        ../../rko_lio/ros_utils/transforms.hpp
+  BASE_DIRS ../..)
 target_link_libraries(
   rko_lio.ros_utils
   PUBLIC # ros deps

--- a/ros/rko_lio/ros_utils/CMakeLists.txt
+++ b/ros/rko_lio/ros_utils/CMakeLists.txt
@@ -22,21 +22,25 @@
 
 add_library(rko_lio.ros_utils STATIC)
 add_library(rko_lio::ros_utils ALIAS rko_lio.ros_utils)
-target_sources(
+compat_target_sources(
   rko_lio.ros_utils
-  PRIVATE point_cloud_read.cpp point_cloud_write.cpp rosbag_utils.cpp
-  PUBLIC FILE_SET
-         HEADERS
-         FILES
-         ../../rko_lio/ros_utils/point_cloud_read.hpp
-         ../../rko_lio/ros_utils/point_cloud_write.hpp
-         ../../rko_lio/ros_utils/ros_utils.hpp
-         ../../rko_lio/ros_utils/ros_vectors.hpp
-         ../../rko_lio/ros_utils/rosbag_utils.hpp
-         ../../rko_lio/ros_utils/time.hpp
-         ../../rko_lio/ros_utils/transforms.hpp
-         BASE_DIRS
-         ../..)
+  PRIVATE
+  point_cloud_read.cpp
+  point_cloud_write.cpp
+  rosbag_utils.cpp
+  PUBLIC
+  FILE_SET
+  HEADERS
+  FILES
+  ../../rko_lio/ros_utils/point_cloud_read.hpp
+  ../../rko_lio/ros_utils/point_cloud_write.hpp
+  ../../rko_lio/ros_utils/ros_utils.hpp
+  ../../rko_lio/ros_utils/ros_vectors.hpp
+  ../../rko_lio/ros_utils/rosbag_utils.hpp
+  ../../rko_lio/ros_utils/time.hpp
+  ../../rko_lio/ros_utils/transforms.hpp
+  BASE_DIRS
+  ../..)
 target_link_libraries(
   rko_lio.ros_utils
   PUBLIC # ros deps


### PR DESCRIPTION
Finally, I've done the one thing I didn't want to do: complicate the build system.

We now should be able to build on ros humble ubuntu 22.04 with the default toolchain. This meant the following changes to the build system
- Backwards compatible FetchContent_Declare args: we add additional flags in as they become available with newer versions
- Backwards compatible OVERRIDE_FIND_PACKAGE behaviour. I've tried to keep it clean by using a macro and having one additional line in each dependency file.
- Backwards compatible target_sources(FILE_SET HEADERS) behaviour. This was the most painful one. FILE_SET was introduced with cmake 3.23, just one minor version above. And I really like how clean FILE_SET is. The solution is another macro `compat_target_sources` that is a drop-in replacement for `target_sources`. On the older cmake it'll do the old style `target_include_directories` using the BASE_DIRS spec. It's not exactly very robust as i tried to keep it tailored to the minimum i needed to handle.
- main cmake has a policy specified to suppress the warning that shows up on newer cmake versions.

The ros humble workflow has been updated to not use our custom image, but rather an osrf one.
The build doc has been updated to state cmake 3.28 as a suggestion rather than a requirement.