### PR TITLE
python: remove unintentional additional scan viz

### DIFF
--- a/rko_lio/python/rko_lio/lio_pipeline.py
+++ b/rko_lio/python/rko_lio/lio_pipeline.py
@@ -269,8 +269,6 @@ class LIOPipeline:
                     )
                     self.last_xyz = pose[:3, 3].copy()
 
-                    self.rerun.log("world/lidar/raw_scan", self.rerun.Points3D(frame["scan"]))
-                    self.rerun.log("world/lidar/deskewed_scan", self.rerun.Points3D(deskewed_scan))
                     self.viz_counter += 1
                     if self.viz_counter % self.config.viz_every_n_frames != 0:
                         # logging the point clouds is more expensive


### PR DESCRIPTION
This somehow slipped through in #77 
While it might be nice to have this, rerun viz has some problem when i publish scans at the same time i emit the transformations as well. Usually it requires a little bit of delay in playback. Either case, I haven't put the time in to investigate that problem well, and my solution (from the start) was to just visualize the local map as thats stable.

I usually add these two lines in when debugging, and looks like I forgot to remove them. would be nice to have this in release, but the jerkiness needs to be fixed