### PR TITLE
Bump FetchContent Eigen version

### DIFF
--- a/cmake/dependencies/eigen/eigen.cmake
+++ b/cmake/dependencies/eigen/eigen.cmake
@@ -19,7 +19,7 @@ set(EIGEN_BUILD_LAPACK
 
 FetchContent_Declare(
   Eigen3
-  URL https://gitlab.com/libeigen/eigen/-/archive/5.0.0/eigen-5.0.0.tar.gz
+  URL https://gitlab.com/libeigen/eigen/-/archive/5.0.1/eigen-5.0.1.tar.gz
       ${RKO_LIO_FETCHCONTENT_COMMON_FLAGS})
 FetchContent_MakeAvailable(Eigen3)
 


### PR DESCRIPTION
Automated bump of FetchContent dependencies by bump_fetchcontent GitHub Action.

### Dependencies bumped:
- **Eigen3**: `5.0.0` → `5.0.1` (in `cmake/dependencies/eigen/eigen.cmake`)