### PR TITLE
ros: offline node exits once lidar buffer has been emptied

### DIFF
--- a/rko_lio/ros/offline_node.cpp
+++ b/rko_lio/ros/offline_node.cpp
@@ -114,7 +114,7 @@ public:
       {
         // wait for the registration buffer to drain - leftover IMU after the last lidar scan is harmless
         std::lock_guard<std::mutex> lock(buffer_mutex);
-        if (lidar_buffer.empty()) {
+        if (lidar_buffer.empty() && !registration_busy.load()) {
           break;
         }
       }

--- a/rko_lio/ros/offline_node.cpp
+++ b/rko_lio/ros/offline_node.cpp
@@ -112,9 +112,9 @@ public:
     }
     while (rclcpp::ok()) {
       {
-        // even if the bag finishes, we need to wait on the registration buffers to empty
+        // wait for the registration buffer to drain - leftover IMU after the last lidar scan is harmless
         std::lock_guard<std::mutex> lock(buffer_mutex);
-        if (imu_buffer.empty() && lidar_buffer.empty()) {
+        if (lidar_buffer.empty()) {
           break;
         }
       }

--- a/rko_lio/ros/threaded_node.cpp
+++ b/rko_lio/ros/threaded_node.cpp
@@ -111,6 +111,7 @@ void ThreadedNode::registration_loop() {
     }
     LidarFrame frame = std::move(lidar_buffer.front());
     lidar_buffer.pop();
+    registration_busy = true;
     const auto& [timestamps, scan] = frame;
     const auto& [start_stamp, end_stamp, time_vector] = timestamps;
     for (; !imu_buffer.empty() && imu_buffer.front().time < end_stamp; imu_buffer.pop()) {
@@ -132,6 +133,7 @@ void ThreadedNode::registration_loop() {
     } catch (const std::invalid_argument& ex) {
       RCLCPP_ERROR_STREAM(node->get_logger(), "Encountered error, dropping frame. Error: " << ex.what());
     }
+    registration_busy = false;
   }
   atomic_node_running = false;
 }

--- a/rko_lio/ros/threaded_node.hpp
+++ b/rko_lio/ros/threaded_node.hpp
@@ -47,6 +47,7 @@ public:
   std::mutex buffer_mutex;
   std::condition_variable sync_condition_variable;
   std::atomic<bool> atomic_can_process = false;
+  std::atomic<bool> registration_busy{false};
   std::queue<core::ImuControl> imu_buffer;
   std::queue<LidarFrame> lidar_buffer;
   size_t max_lidar_buffer_size = 50;


### PR DESCRIPTION
the offline node in the ros wrapper was earlier waiting on both lidar and imu buffers to empty before exiting. if there are lefover imu messages after the last lidar, this meant a hang. now we check on just that the lidar buffer is empty and the reg thread is not processing a lidar (i.e. we can quit).