### PR TITLE
core: time in nanoseconds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 compile_commands.json
 docker_zsh_history.txt
 **/__cmake_systeminformation/
+logs/

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Why `pip install` those three packages?
 - `rosbags` -> required for the rosbag dataloader. Both ros1 and ros2 bags are supported!
 - `rerun-sdk` -> required for the optional visualizer (`-v` flag)
 
-`pip install "rko_lio[all]` fetches the other optional dependencies as well.
+`pip install "rko_lio[all]"` fetches the other optional dependencies as well.
 
 Check further options for the CLI through `rko_lio --help`.
 

--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -69,7 +69,7 @@ struct AccelFilterStep {
 AccelFilterStep step_body_accel_filter(const BodyAccelKF& prev,
                                        const IntervalStats& stats,
                                        const Sophus::SO3d& rotation_estimate,
-                                       const Secondsd& dt,
+                                       const Nsec dt,
                                        const double max_expected_jerk) {
   if (stats.imu_count <= 1) {
     std::cerr << "[WARNING] " << stats.imu_count
@@ -83,7 +83,7 @@ AccelFilterStep step_body_accel_filter(const BodyAccelKF& prev,
   const double accel_mag_variance = stats.welford_sum_of_squares / (stats.imu_count - 1);
   const Eigen::Vector3d body_accel_measurement = avg_imu_accel + rotation_estimate.inverse() * gravity();
 
-  const double max_acceleration_change = max_expected_jerk * dt.count();
+  const double max_acceleration_change = max_expected_jerk * to_seconds(dt);
   // assume [j, -j] range for uniform dist. on jerk. variance is (2j)^2 / 12 = j^2/3. multiply by dt^2 for accel
   const Eigen::Matrix3d process_noise = square(max_acceleration_change) / 3 * Eigen::Matrix3d::Identity();
   const Eigen::Matrix3d cov_pred = prev.covariance + process_noise;
@@ -102,17 +102,17 @@ AccelFilterStep step_body_accel_filter(const BodyAccelKF& prev,
 }
 
 template <typename Functor>
-  requires requires(Functor f, Secondsd stamp) {
+  requires requires(Functor f, Nsec stamp) {
     { f(stamp) } -> std::same_as<Sophus::SE3d>;
   }
 Vector3dVector deskew_scan(const Vector3dVector& frame,
                            const TimestampVector& timestamps,
-                           const Secondsd& end_time,
+                           const Nsec end_time,
                            const Functor& relative_pose_at_time) {
   const Sophus::SE3d scan_to_scan_motion_inverse = relative_pose_at_time(end_time).inverse();
   Vector3dVector deskewed(frame.size());
   std::transform(frame.cbegin(), frame.cend(), timestamps.cbegin(), deskewed.begin(),
-                 [&](const Eigen::Vector3d& point, const Secondsd& timestamp) {
+                 [&](const Eigen::Vector3d& point, const Nsec timestamp) {
                    return (scan_to_scan_motion_inverse * relative_pose_at_time(timestamp)) * point;
                  });
   return deskewed;
@@ -242,7 +242,7 @@ namespace rko_lio::core {
 //          private
 // ==========================
 
-void LIO::initialize(const Secondsd lidar_time) {
+void LIO::initialize(const Nsec lidar_time) {
   if (interval_stats.imu_count == 0) {
     std::cerr << "[WARNING] Cannot initialize. No imu measurements received.\n";
     // lidar_state.time has the time from the previous lidar, which we didn't log if init_phase was on
@@ -277,7 +277,7 @@ void LIO::initialize(const Secondsd lidar_time) {
             << ", gyro bias: " << imu_bias.gyroscope.transpose() << "\n";
 }
 
-Vector3dVector LIO::bootstrap_first_scan(const Vector3dVector& scan, const Secondsd& current_lidar_time) {
+Vector3dVector LIO::bootstrap_first_scan(const Vector3dVector& scan, const Nsec current_lidar_time) {
   lidar_state.time = current_lidar_time;
   imu_state = lidar_state;
   auto preproc = preprocess_scan(scan, config);
@@ -289,7 +289,7 @@ Vector3dVector LIO::bootstrap_first_scan(const Vector3dVector& scan, const Secon
   return std::move(preproc.filtered_frame);
 }
 
-std::pair<Eigen::Vector3d, Eigen::Vector3d> LIO::motion_priors_from_imu(const Secondsd& current_lidar_time) {
+std::pair<Eigen::Vector3d, Eigen::Vector3d> LIO::motion_priors_from_imu(const Nsec current_lidar_time) {
   if (config.initialization_phase && !_initialized) {
     // assume static and
     initialize(current_lidar_time);
@@ -330,7 +330,7 @@ void LIO::add_imu_measurement(const ImuControl& base_imu) {
     imu_state = lidar_state;
   }
 
-  const double dt = (base_imu.time - imu_state.time).count();
+  const double dt = to_seconds(base_imu.time - imu_state.time);
 
   if (dt < 0.0) {
     // messages are out of sync. thats a problem, since we integrate gyro from last lidar time onwards
@@ -377,10 +377,10 @@ void LIO::add_imu_measurement(const Sophus::SE3d& extrinsic_imu2base, const ImuC
   base_imu.angular_velocity = extrinsic_rotation * raw_imu.angular_velocity;
 
   const Eigen::Vector3d& lever_arm = -1 * extrinsic_imu2base.translation();
-  const Secondsd dt = raw_imu.time - _last_real_imu_time;
+  const Nsec dt = raw_imu.time - _last_real_imu_time;
 
   const Eigen::Vector3d angular_acceleration = std::invoke([&]() -> Eigen::Vector3d {
-    if (std::chrono::abs(dt) < Secondsd(1.0 / 5000.0)) {
+    if (std::chrono::abs(dt) < std::chrono::microseconds(200)) {
       // if dt is less than the equivalent of a 5000 Hz imu, assuming zero ang accel,
       // causes numerical issues otherwise
       static bool warning_imu_too_close = false;
@@ -392,7 +392,7 @@ void LIO::add_imu_measurement(const Sophus::SE3d& extrinsic_imu2base, const ImuC
       return Eigen::Vector3d::Zero();
     } else {
       const Eigen::Vector3d angular_acceleration =
-          (base_imu.angular_velocity - _last_real_base_imu_ang_vel) / dt.count();
+          (base_imu.angular_velocity - _last_real_base_imu_ang_vel) / to_seconds(dt);
       return angular_acceleration;
     }
   });
@@ -407,14 +407,14 @@ void LIO::add_imu_measurement(const Sophus::SE3d& extrinsic_imu2base, const ImuC
 
 Vector3dVector LIO::register_scan(const Vector3dVector& scan, const TimestampVector& timestamps) {
   // TODO: redundant max compute as its available after process_timestamps
-  const Secondsd current_lidar_time = *std::max_element(timestamps.cbegin(), timestamps.cend());
+  const Nsec current_lidar_time = *std::max_element(timestamps.cbegin(), timestamps.cend());
 
   if (lidar_state.time < EPSILON_TIME) {
     return bootstrap_first_scan(scan, current_lidar_time);
   }
 
-  if (std::chrono::abs(current_lidar_time - lidar_state.time).count() > 1.0) {
-    const double diff_seconds = (current_lidar_time - lidar_state.time).count();
+  if (std::chrono::abs(current_lidar_time - lidar_state.time) > std::chrono::seconds(1)) {
+    const double diff_seconds = to_seconds(current_lidar_time - lidar_state.time);
     // TODO: std::expected with tl::expected (because ros humble)
     throw std::invalid_argument("Received LiDAR scan with " + std::to_string(diff_seconds) +
                                 " seconds delta to previous scan.");
@@ -423,8 +423,8 @@ Vector3dVector LIO::register_scan(const Vector3dVector& scan, const TimestampVec
   const auto [avg_body_accel, avg_ang_vel] = motion_priors_from_imu(current_lidar_time);
 
   // compute relative motion using controls
-  auto relative_pose_at_time = [&](const Secondsd& time) -> Sophus::SE3d {
-    const double dt = (time - lidar_state.time).count();
+  auto relative_pose_at_time = [&](const Nsec time) -> Sophus::SE3d {
+    const double dt = to_seconds(time - lidar_state.time);
     Eigen::Vector6d tau;
     tau.head<3>() = lidar_state.velocity * dt + (avg_body_accel * square(dt) / 2);
     tau.tail<3>() = avg_ang_vel * dt;
@@ -458,7 +458,7 @@ Vector3dVector LIO::register_scan(const Vector3dVector& scan, const TimestampVec
     const Sophus::SE3d optimized_pose = icp(preproc_result.keypoints, map, initial_guess, config, kf_step.info);
 
     // estimate velocities and accelerations from the new pose
-    const double dt = (current_lidar_time - lidar_state.time).count();
+    const double dt = to_seconds(current_lidar_time - lidar_state.time);
     const Sophus::SE3d motion = lidar_state.pose.inverse() * optimized_pose;
     const Eigen::Vector6d local_velocity = motion.log() / dt;
     const Eigen::Vector3d local_linear_acceleration =

--- a/rko_lio/core/lio.hpp
+++ b/rko_lio/core/lio.hpp
@@ -135,7 +135,7 @@ public:
                                const TimestampVector& timestamps);
 
   /** Sequence of registered scan poses with corresponding timestamps. */
-  std::vector<std::pair<Secondsd, Sophus::SE3d>> poses_with_timestamps;
+  std::vector<std::pair<Nsec, Sophus::SE3d>> poses_with_timestamps;
 
   /** Base-frame state propagated from IMU measurements. Runs ahead of `lidar_state` between scans; reset to the
    *  optimized lidar pose after each successful registration. Used for gravity compensation and for publishing
@@ -148,19 +148,19 @@ private:
    * Initialize internal odometry state using the given lidar timestamp.
    * @param lidar_time Current lidar timestamp.
    */
-  void initialize(const Secondsd lidar_time);
+  void initialize(const Nsec lidar_time);
 
   /** First-scan path: stamps state, optionally seeds the map, logs the pose. */
-  Vector3dVector bootstrap_first_scan(const Vector3dVector& scan, const Secondsd& current_lidar_time);
+  Vector3dVector bootstrap_first_scan(const Vector3dVector& scan, const Nsec current_lidar_time);
 
   /** Average body acceleration and angular velocity over the IMU interval, with init-phase and no-IMU fallbacks. */
-  std::pair<Eigen::Vector3d, Eigen::Vector3d> motion_priors_from_imu(const Secondsd& current_lidar_time);
+  std::pair<Eigen::Vector3d, Eigen::Vector3d> motion_priors_from_imu(const Nsec current_lidar_time);
 
   /** True if odometry initialization has been completed. */
   bool _initialized = false;
 
   /** Timestamp of the most recent real IMU measurement. */
-  Secondsd _last_real_imu_time = Secondsd{0.0};
+  Nsec _last_real_imu_time{0};
 
   /** Angular velocity of last true IMU measurement expressed in base frame. */
   Eigen::Vector3d _last_real_base_imu_ang_vel = Eigen::Vector3d::Zero();

--- a/rko_lio/core/process_timestamps.cpp
+++ b/rko_lio/core/process_timestamps.cpp
@@ -25,46 +25,59 @@
 #include "process_timestamps.hpp"
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <functional>
 #include <iomanip>
 #include <iostream>
 #include <stdexcept>
 
 namespace {
-using rko_lio::core::Secondsd;
+using rko_lio::core::Nsec;
 using rko_lio::core::TimestampProcessingConfig;
 using rko_lio::core::Timestamps;
 using rko_lio::core::TimestampVector;
 using namespace std::chrono_literals;
 
+inline Nsec raw_to_ns(const double ts, const double multiplier_to_ns, const bool source_is_ns) {
+  if (source_is_ns) {
+    return Nsec(static_cast<int64_t>(ts));
+  }
+  return Nsec(static_cast<int64_t>(std::llround(ts * multiplier_to_ns)));
+}
+
 // The timestamps are either in seconds or in nanoseconds, otherwise the user needs to specify the multiplier
-Timestamps timestamps_in_sec_from_raw(const std::vector<double>& raw_timestamps, const double multiplier_to_seconds) {
+Timestamps timestamps_from_raw(const std::vector<double>& raw_timestamps, const double multiplier_to_seconds) {
   const auto& [min_it, max_it] = std::minmax_element(raw_timestamps.begin(), raw_timestamps.end());
   const double min_stamp = *min_it;
   const double max_stamp = *max_it;
-  double timestamp_multiplier = multiplier_to_seconds;
 
-  if (timestamp_multiplier < 1e-12) {
+  bool source_is_ns = false;
+  double multiplier_to_ns = 0.0;
+  if (multiplier_to_seconds < 1e-12) {
     const double scan_duration = std::abs(max_stamp - min_stamp);
-    const bool is_nanoseconds = (scan_duration > 100.0);
     // 100 seconds is far more than the duration of any normal scan
-    timestamp_multiplier = is_nanoseconds ? 1e-9 : 1.0;
+    source_is_ns = (scan_duration > 100.0);
+    multiplier_to_ns = source_is_ns ? 1.0 : 1e9;
+  } else {
+    multiplier_to_ns = multiplier_to_seconds * 1e9;
   }
 
-  TimestampVector times_in_seconds(raw_timestamps.size());
-  std::transform(raw_timestamps.cbegin(), raw_timestamps.cend(), times_in_seconds.begin(),
-                 [timestamp_multiplier](const double ts) { return Secondsd(ts * timestamp_multiplier); });
-  return {.min = Secondsd(min_stamp * timestamp_multiplier),
-          .max = Secondsd(max_stamp * timestamp_multiplier),
-          .times = times_in_seconds};
+  TimestampVector times_ns(raw_timestamps.size());
+  std::transform(raw_timestamps.cbegin(), raw_timestamps.cend(), times_ns.begin(),
+                 [multiplier_to_ns, source_is_ns](const double ts) {
+                   return raw_to_ns(ts, multiplier_to_ns, source_is_ns);
+                 });
+  return {.min = raw_to_ns(min_stamp, multiplier_to_ns, source_is_ns),
+          .max = raw_to_ns(max_stamp, multiplier_to_ns, source_is_ns),
+          .times = times_ns};
 }
 } // namespace
 
 namespace rko_lio::core {
 Timestamps process_timestamps(const std::vector<double>& raw_timestamps,
-                              const Secondsd& header_stamp,
+                              const Nsec header_stamp,
                               const TimestampProcessingConfig& config) {
-  Timestamps timestamps = timestamps_in_sec_from_raw(raw_timestamps, config.multiplier_to_seconds);
+  Timestamps timestamps = timestamps_from_raw(raw_timestamps, config.multiplier_to_seconds);
 
   const bool absolute_stamps = config.force_absolute || (std::chrono::abs(header_stamp - timestamps.min) < 1ms) ||
                                (std::chrono::abs(header_stamp - timestamps.max) < 10ms);
@@ -78,7 +91,7 @@ Timestamps process_timestamps(const std::vector<double>& raw_timestamps,
 
   if (relative_stamps) {
     std::transform(timestamps.times.cbegin(), timestamps.times.cend(), timestamps.times.begin(),
-                   [&header_stamp](const Secondsd& ts) { return ts + header_stamp; });
+                   [header_stamp](const Nsec ts) { return ts + header_stamp; });
     timestamps.min += header_stamp;
     timestamps.max += header_stamp;
     return timestamps;
@@ -86,11 +99,11 @@ Timestamps process_timestamps(const std::vector<double>& raw_timestamps,
 
   // Error-out for unique/unsupported cases
   std::cout << std::setprecision(18);
-  std::cout << "is_absolute: " << relative_stamps << "\n";
+  std::cout << "is_absolute: " << absolute_stamps << "\n";
   std::cout << "is_relative: " << relative_stamps << "\n";
-  std::cout << "point times min: " << timestamps.min.count() << "\n";
-  std::cout << "point times max: " << timestamps.max.count() << "\n";
-  std::cout << "header_sec: " << header_stamp.count() << "\n";
+  std::cout << "point times min (ns): " << timestamps.min.count() << "\n";
+  std::cout << "point times max (ns): " << timestamps.max.count() << "\n";
+  std::cout << "header_stamp (ns): " << header_stamp.count() << "\n";
   std::cout << "TimestampProcessingConfig:\n"
             << "  multiplier_to_seconds: " << config.multiplier_to_seconds << "\n"
             << "  force_absolute: " << std::boolalpha << config.force_absolute << "\n"

--- a/rko_lio/core/process_timestamps.hpp
+++ b/rko_lio/core/process_timestamps.hpp
@@ -35,8 +35,8 @@
 namespace rko_lio::core {
 
 struct Timestamps {
-  Secondsd min;
-  Secondsd max;
+  Nsec min;
+  Nsec max;
   TimestampVector times;
 };
 
@@ -53,11 +53,11 @@ struct TimestampProcessingConfig {
 };
 
 /**
- * Process raw timestamps and calculates absolute timestamps in seconds.
+ * Process raw timestamps and calculates absolute timestamps in nanoseconds.
  *
  * The input timestamps can be either absolute or relative and may be in seconds or nanoseconds.
  * The function automatically detects whether the timestamps are in nanoseconds by checking the
- * duration spread and converts them to seconds accordingly.
+ * duration spread and converts them to nanoseconds accordingly.
  * Then the case of absolute or relative time is disambiguated based on how close (or away) the min or max times are to
  * the header time.
  *
@@ -68,13 +68,13 @@ struct TimestampProcessingConfig {
  * @param header_stamp Reference absolute timestamp corresponding to the scan's header time.
  * @param config timestamp specific config to use in processing.
  * @return A struct containing:
- *   - The computed scan start time (absolute, Secondsd),
- *   - The computed scan end time (absolute, Secondsd),
- *   - A vector of all processed point timestamps converted to absolute seconds (TimestampVector).
+ *   - The computed scan start time (absolute, Nsec),
+ *   - The computed scan end time (absolute, Nsec),
+ *   - A vector of all processed point timestamps converted to absolute nanoseconds (TimestampVector).
  * @throws std::runtime_error If the timestamp format or values are unrecognized or unsupported.
  */
 Timestamps process_timestamps(const std::vector<double>& raw_timestamps,
-                              const Secondsd& header_stamp,
+                              const Nsec header_stamp,
                               const TimestampProcessingConfig& config);
 
 } // namespace rko_lio::core

--- a/rko_lio/core/util.hpp
+++ b/rko_lio/core/util.hpp
@@ -36,17 +36,19 @@ using Matrix6d = Matrix<double, 6, 6>;
 namespace rko_lio::core {
 // aliases
 using Vector3dVector = std::vector<Eigen::Vector3d>;
-using Secondsd = std::chrono::duration<double>;
-using TimestampVector = std::vector<Secondsd>;
+using Nsec = std::chrono::nanoseconds;
+using TimestampVector = std::vector<Nsec>;
 
 // constants and util funcs
 constexpr double square(double x) { return x * x; }
 constexpr double GRAVITY_MAG = 9.8107;
 inline Eigen::Vector3d gravity() { return {0, 0, -GRAVITY_MAG}; }
 
+inline double to_seconds(const Nsec d) { return std::chrono::duration<double>(d).count(); }
+
 // data structs
 struct State {
-  Secondsd time{0};
+  Nsec time{0};
   Sophus::SE3d pose;
   Eigen::Vector3d velocity = Eigen::Vector3d::Zero();
   Eigen::Vector3d angular_velocity = Eigen::Vector3d::Zero();
@@ -59,7 +61,7 @@ struct ImuBias {
 };
 
 struct ImuControl {
-  Secondsd time{0};
+  Nsec time{0};
   Eigen::Vector3d acceleration = Eigen::Vector3d::Zero();
   Eigen::Vector3d angular_velocity = Eigen::Vector3d::Zero();
 };

--- a/rko_lio/python/pybind/rko_lio_pybind.cpp
+++ b/rko_lio/python/pybind/rko_lio_pybind.cpp
@@ -26,6 +26,7 @@
 #include "rko_lio/core/process_timestamps.hpp"
 #include "stl_vector_eigen.hpp"
 #include <cmath>
+#include <cstdint>
 #include <pybind11/eigen.h>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
@@ -38,11 +39,13 @@ using namespace rko_lio::core;
 
 PYBIND11_MAKE_OPAQUE(std::vector<Eigen::Vector3d>);
 PYBIND11_MAKE_OPAQUE(std::vector<double>);
+PYBIND11_MAKE_OPAQUE(std::vector<int64_t>);
 
 PYBIND11_MODULE(rko_lio_pybind, m) {
   auto vector3dvector = pybind_eigen_vector_of_vector<Eigen::Vector3d>(
       m, "_Vector3dVector", "std::vector<Eigen::Vector3d>", py::py_array_to_vectors_double<Eigen::Vector3d>);
   py::bind_vector<std::vector<double>>(m, "_VectorDouble");
+  py::bind_vector<std::vector<int64_t>>(m, "_VectorInt64");
 
   // for introspecting IMU data
   py::class_<IntervalStats>(m, "_IntervalStats")
@@ -74,9 +77,9 @@ PYBIND11_MODULE(rko_lio_pybind, m) {
       .def(py::init<const LIO::Config&>(), "config"_a)
       .def(
           "add_imu_measurement",
-          [](LIO& self, const Eigen::Vector3d& accel, const Eigen::Vector3d& gyro, const double time) {
+          [](LIO& self, const Eigen::Vector3d& accel, const Eigen::Vector3d& gyro, const int64_t time_ns) {
             self.add_imu_measurement(ImuControl{
-                .time = Secondsd(time),
+                .time = Nsec(time_ns),
                 .acceleration = accel,
                 .angular_velocity = gyro,
             });
@@ -85,9 +88,9 @@ PYBIND11_MODULE(rko_lio_pybind, m) {
       .def(
           "add_imu_measurement",
           [](LIO& self, const Eigen::Matrix4d& extrinsic_imu2base, const Eigen::Vector3d& accel,
-             const Eigen::Vector3d& gyro, const double time) {
+             const Eigen::Vector3d& gyro, const int64_t time_ns) {
             self.add_imu_measurement(Sophus::SE3d(extrinsic_imu2base), ImuControl{
-                                                                           .time = Secondsd(time),
+                                                                           .time = Nsec(time_ns),
                                                                            .acceleration = accel,
                                                                            .angular_velocity = gyro,
                                                                        });
@@ -95,21 +98,21 @@ PYBIND11_MODULE(rko_lio_pybind, m) {
           "extrinsic_imu2base"_a, "acceleration"_a, "angular_velocity"_a, "time"_a)
       .def(
           "register_scan",
-          [](LIO& self, const std::vector<Eigen::Vector3d>& scan, const std::vector<double>& timestamps) {
-            std::vector<Secondsd> tsd(timestamps.size());
-            std::transform(timestamps.cbegin(), timestamps.cend(), tsd.begin(),
-                           [](const double t) { return Secondsd(t); });
-            return self.register_scan(scan, tsd);
+          [](LIO& self, const std::vector<Eigen::Vector3d>& scan, const std::vector<int64_t>& timestamps_ns) {
+            TimestampVector timestamps(timestamps_ns.size());
+            std::transform(timestamps_ns.cbegin(), timestamps_ns.cend(), timestamps.begin(),
+                           [](const int64_t t) { return Nsec(t); });
+            return self.register_scan(scan, timestamps);
           },
           "scan"_a, "timestamps"_a)
       .def(
           "register_scan",
           [](LIO& self, const Eigen::Matrix4d& extrinsic_lidar2base, const std::vector<Eigen::Vector3d>& scan,
-             const std::vector<double>& timestamps) {
-            std::vector<Secondsd> tsd(timestamps.size());
-            std::transform(timestamps.cbegin(), timestamps.cend(), tsd.begin(),
-                           [](const double t) { return Secondsd(t); });
-            return self.register_scan(Sophus::SE3d(extrinsic_lidar2base), scan, tsd);
+             const std::vector<int64_t>& timestamps_ns) {
+            TimestampVector timestamps(timestamps_ns.size());
+            std::transform(timestamps_ns.cbegin(), timestamps_ns.cend(), timestamps.begin(),
+                           [](const int64_t t) { return Nsec(t); });
+            return self.register_scan(Sophus::SE3d(extrinsic_lidar2base), scan, timestamps);
           },
           "extrinsic_lidar2base"_a, "scan"_a, "timestamps"_a)
       .def("map_point_cloud", [](LIO& self) { return self.map.pointcloud(); })
@@ -120,13 +123,13 @@ PYBIND11_MODULE(rko_lio_pybind, m) {
       .def("poses_with_timestamps",
            [](LIO& self) {
              const size_t n = self.poses_with_timestamps.size();
-             std::vector<double> times(n);
+             std::vector<int64_t> times_ns(n);
              pybind11::array_t<double> poses({n, static_cast<size_t>(7)});
              // https://pybind11.readthedocs.io/en/stable/advanced/pycpp/numpy.html#direct-access
              auto pose_buf = poses.mutable_unchecked<2>();
              for (size_t i = 0; i < n; ++i) {
                const auto& [time, pose] = self.poses_with_timestamps[i];
-               times[i] = time.count();
+               times_ns[i] = time.count();
                const Eigen::Vector3d& trans = pose.translation();
                const Eigen::Quaterniond& q = pose.unit_quaternion();
                pose_buf(i, 0) = trans.x();
@@ -137,7 +140,7 @@ PYBIND11_MODULE(rko_lio_pybind, m) {
                pose_buf(i, 5) = q.z();
                pose_buf(i, 6) = q.w();
              }
-             return pybind11::make_tuple(times, poses);
+             return pybind11::make_tuple(times_ns, poses);
            })
       .def_readonly("interval_stats", &LIO::interval_stats);
 
@@ -150,11 +153,11 @@ PYBIND11_MODULE(rko_lio_pybind, m) {
 
   m.def(
       "_process_timestamps",
-      [](const std::vector<double>& raw_ts, const double header_stamp, const TPConfig& config) {
-        const auto& [begin, end, abs_ts] = process_timestamps(raw_ts, Secondsd(header_stamp), config);
-        std::vector<double> abs_ts_double(abs_ts.size());
-        std::transform(abs_ts.cbegin(), abs_ts.cend(), abs_ts_double.begin(), [&](const auto& t) { return t.count(); });
-        return std::make_tuple(begin.count(), end.count(), std::move(abs_ts_double));
+      [](const std::vector<double>& raw_ts, const int64_t header_stamp_ns, const TPConfig& config) {
+        const auto& [begin, end, abs_ts] = process_timestamps(raw_ts, Nsec(header_stamp_ns), config);
+        std::vector<int64_t> abs_ts_ns(abs_ts.size());
+        std::transform(abs_ts.cbegin(), abs_ts.cend(), abs_ts_ns.begin(), [](const Nsec t) { return t.count(); });
+        return std::make_tuple(begin.count(), end.count(), std::move(abs_ts_ns));
       },
       "raw_timestamps"_a, "header_stamp"_a, "config"_a);
 }

--- a/rko_lio/python/rko_lio/config.py
+++ b/rko_lio/python/rko_lio/config.py
@@ -53,7 +53,7 @@ Description of parameters
 - ``multiplier_to_seconds``:
 
     Factor applied to raw timestamp values to convert them to seconds.
-    Secondsd and nanoseconds are detected automatically when this is 0.0 (default).
+    Seconds and nanoseconds are detected automatically when this is 0.0 (default).
     Specify this for any other case.
     For example, if timestamps are in microseconds, use ``1e-6``.
 

--- a/rko_lio/python/rko_lio/dataloaders/helipr.py
+++ b/rko_lio/python/rko_lio/dataloaders/helipr.py
@@ -158,13 +158,13 @@ class HeliprDataLoader:
                 return (
                     "imu",
                     {
-                        "time": data["timestamp"] / 1e9,
+                        "time": int(data["timestamp"]),
                         "acceleration": data["accel"],
                         "angular_velocity": data["gyro"],
                     },
                 )
             elif kind == "lidar":
-                header_stamp_sec = data["timestamp"] / 1e9
+                header_stamp_ns = int(data["timestamp"])
 
                 try:
                     points, raw_timestamps = read_lidar_bin(
@@ -176,18 +176,18 @@ class HeliprDataLoader:
                     continue
 
                 points_arr = np.asarray(points).reshape(-1, 3)
-                start, end, abs_timestamps = rko_lio_pybind._process_timestamps(
+                start_ns, end_ns, abs_timestamps_ns = rko_lio_pybind._process_timestamps(
                     rko_lio_pybind._VectorDouble(np.asarray(raw_timestamps)),
-                    header_stamp_sec,
+                    header_stamp_ns,
                     self.timestamp_config.to_pybind(),
                 )
                 return (
                     "lidar",
                     {
-                        "start_time": start,
-                        "end_time": end,
+                        "start_time": start_ns,
+                        "end_time": end_ns,
                         "scan": points_arr,
-                        "timestamps": np.asarray(abs_timestamps),
+                        "timestamps": np.asarray(abs_timestamps_ns, dtype=np.int64),
                     },
                 )
 

--- a/rko_lio/python/rko_lio/dataloaders/raw.py
+++ b/rko_lio/python/rko_lio/dataloaders/raw.py
@@ -306,7 +306,7 @@ class RawDataLoader:
 
             if kind == "imu":
                 return "imu", {
-                    "time": data["timestamp"] / 1e9,
+                    "time": int(data["timestamp"]),
                     "acceleration": data["accel"],
                     "angular_velocity": data["gyro"],
                 }
@@ -315,7 +315,7 @@ class RawDataLoader:
                 # Find a field for per-point timestamp
                 for attr_name in self.possible_timestamp_attribute_names:
                     if attr_name in ply.point:
-                        timestamps = ply.point[attr_name].numpy().flatten()
+                        timestamps_sec = ply.point[attr_name].numpy().flatten()
                         # TODO: use pybind.process_timestamps to handle non seconds cases
                         break
                 else:
@@ -324,11 +324,12 @@ class RawDataLoader:
                         f"No per-point timestamp attribute found in {data['filename']}. Please check the attributes."
                     )
                 points = ply.point["positions"].numpy()
+                timestamps_ns = np.round(np.asarray(timestamps_sec, dtype=np.float64) * 1e9).astype(np.int64)
                 return "lidar", {
-                    "start_time": np.min(timestamps),
-                    "end_time": np.max(timestamps),
+                    "start_time": int(timestamps_ns.min()),
+                    "end_time": int(timestamps_ns.max()),
                     "scan": points,
-                    "timestamps": timestamps,
+                    "timestamps": timestamps_ns,
                 }
 
     def __repr__(self):

--- a/rko_lio/python/rko_lio/dataloaders/rosbag.py
+++ b/rko_lio/python/rko_lio/dataloaders/rosbag.py
@@ -191,7 +191,7 @@ class RosbagDataLoader:
 
     def read_imu(self, data):
         header_stamp = data.header.stamp
-        timestamp = header_stamp.sec + (header_stamp.nanosec / 1e9)
+        timestamp_ns = int(header_stamp.sec) * 1_000_000_000 + int(header_stamp.nanosec)
         gyro = [
             data.angular_velocity.x,
             data.angular_velocity.y,
@@ -202,36 +202,36 @@ class RosbagDataLoader:
             data.linear_acceleration.y,
             data.linear_acceleration.z,
         ]
-        return {"time": timestamp, "acceleration": accel, "angular_velocity": gyro}
+        return {"time": timestamp_ns, "acceleration": accel, "angular_velocity": gyro}
 
     def read_point_cloud(self, data):
         header_stamp = data.header.stamp
-        header_stamp_sec = header_stamp.sec + (header_stamp.nanosec / 1e9)
+        header_stamp_ns = int(header_stamp.sec) * 1_000_000_000 + int(header_stamp.nanosec)
         points, mock_timestamps = ros_read_point_cloud(data)
         if mock_timestamps is not None and mock_timestamps.size > 0:
-            start, end, abs_timestamps = rko_lio_pybind._process_timestamps(
+            start_ns, end_ns, abs_timestamps_ns = rko_lio_pybind._process_timestamps(
                 rko_lio_pybind._VectorDouble(mock_timestamps),
-                header_stamp_sec,
+                header_stamp_ns,
                 self.timestamp_config.to_pybind(),
             )
             return {
-                "start_time": start,
-                "end_time": end,
+                "start_time": start_ns,
+                "end_time": end_ns,
                 "scan": points,
-                "timestamps": np.asarray(abs_timestamps),
+                "timestamps": np.asarray(abs_timestamps_ns, dtype=np.int64),
             }
         else:
-            mock_timestamps = np.ones(points.shape[0]) * header_stamp_sec
+            timestamps = np.full(points.shape[0], header_stamp_ns, dtype=np.int64)
             if not hasattr(self, "_printed_timestamp_warning"):
                 self._printed_timestamp_warning = True
                 warning(
                     "Could not detect timestamps in the point cloud. Odometry performance will suffer. Also please disable deskewing (enabled by default) otherwise the odometry may not work properly."
                 )
             return {
-                "start_time": header_stamp_sec,
-                "end_time": header_stamp_sec,
+                "start_time": header_stamp_ns,
+                "end_time": header_stamp_ns,
                 "scan": points,
-                "timestamps": mock_timestamps,
+                "timestamps": timestamps,
             }
 
     def check_topic(self, topic: str | None, expected_msgtype: str) -> str:

--- a/rko_lio/python/rko_lio/lio.py
+++ b/rko_lio/python/rko_lio/lio.py
@@ -31,7 +31,7 @@ from .rko_lio_pybind import (
     _LIO,
     _IntervalStats,
     _Vector3dVector,
-    _VectorDouble,
+    _VectorInt64,
 )
 
 
@@ -123,7 +123,7 @@ class LIO:
         self,
         acceleration: np.ndarray,
         angular_velocity: np.ndarray,
-        time: float,
+        time: int,
     ):
         acc = np.asarray(acceleration, dtype=np.float64)
         gyro = np.asarray(angular_velocity, dtype=np.float64)
@@ -131,14 +131,14 @@ class LIO:
             raise ValueError(f"acceleration: expected shape (3,), got {acc.shape}")
         if gyro.shape != (3,):
             raise ValueError(f"angular_velocity: expected shape (3,), got {gyro.shape}")
-        self._impl.add_imu_measurement(acc, gyro, float(time))
+        self._impl.add_imu_measurement(acc, gyro, int(time))
 
     def add_imu_measurement_with_extrinsic(
         self,
         extrinsic_imu2base: np.ndarray,
         acceleration: np.ndarray,
         angular_velocity: np.ndarray,
-        time: float,
+        time: int,
     ):
         extr = np.asarray(extrinsic_imu2base, dtype=np.float64)
         acc = np.asarray(acceleration, dtype=np.float64)
@@ -151,11 +151,11 @@ class LIO:
             raise ValueError(f"acceleration: expected shape (3,), got {acc.shape}")
         if gyro.shape != (3,):
             raise ValueError(f"angular_velocity: expected shape (3,), got {gyro.shape}")
-        self._impl.add_imu_measurement(extr, acc, gyro, float(time))
+        self._impl.add_imu_measurement(extr, acc, gyro, int(time))
 
     def register_scan(self, scan: np.ndarray, timestamps: np.ndarray):
         scan_arr = np.asarray(scan, dtype=np.float64)
-        times_arr = np.asarray(timestamps, dtype=np.float64)
+        times_arr = np.ascontiguousarray(np.asarray(timestamps), dtype=np.int64)
         if scan_arr.ndim != 2 or scan_arr.shape[1] != 3:
             raise ValueError(f"scan: expected (N,3), got {scan_arr.shape}")
         if times_arr.shape != (scan_arr.shape[0],):
@@ -163,7 +163,7 @@ class LIO:
                 f"timestamps: expected ({scan_arr.shape[0]},), got {times_arr.shape}"
             )
         scan_vec = _Vector3dVector(scan_arr)
-        time_vec = _VectorDouble(times_arr)
+        time_vec = _VectorInt64(times_arr)
         ret_scan = self._impl.register_scan(scan_vec, time_vec)
         return np.asarray(ret_scan)
 
@@ -172,7 +172,7 @@ class LIO:
     ):
         extr = np.asarray(extrinsic_lidar2base, dtype=np.float64)
         scan_arr = np.asarray(scan, dtype=np.float64)
-        times_arr = np.asarray(timestamps, dtype=np.float64)
+        times_arr = np.ascontiguousarray(np.asarray(timestamps), dtype=np.int64)
         if extr.shape != (4, 4):
             raise ValueError(
                 f"extrinsic_lidar2base: expected shape (4,4), got {extr.shape}"
@@ -184,7 +184,7 @@ class LIO:
                 f"timestamps: expected ({scan_arr.shape[0]},), got {times_arr.shape}"
             )
         scan_vec = _Vector3dVector(scan_arr)
-        time_vec = _VectorDouble(times_arr)
+        time_vec = _VectorInt64(times_arr)
         ret_scan = self._impl.register_scan(extr, scan_vec, time_vec)
         return np.asarray(ret_scan)
 

--- a/rko_lio/python/rko_lio/lio_pipeline.py
+++ b/rko_lio/python/rko_lio/lio_pipeline.py
@@ -100,7 +100,7 @@ class LIOPipeline:
 
     def add_imu(
         self,
-        time: float,
+        time: int,
         acceleration: np.ndarray,
         angular_velocity: np.ndarray,
     ):
@@ -109,8 +109,8 @@ class LIOPipeline:
 
         Parameters
         ----------
-        time : float
-            Measurement timestamp in seconds.
+        time : int
+            Measurement timestamp in nanoseconds (absolute, since the unix epoch).
         acceleration : array of float, shape (3,)
             Acceleration vector in m/s^2.
         angular_velocity : array of float, shape (3,)
@@ -129,34 +129,34 @@ class LIOPipeline:
             )
 
         if self.config.viz:
-            self.rerun.set_time("data_time", timestamp=time)
+            self.rerun.set_time("data_time", timestamp=time * 1e-9)
             log_vector(self.rerun, "imu/acceleration", acceleration)
             log_vector(self.rerun, "imu/angular_velocity", angular_velocity)
 
     @profile_func("Pipeline - Register Scan")
     def register_scan(
         self,
-        start_time: float,
-        end_time: float,
+        start_time: int,
+        end_time: int,
         scan: np.ndarray,
         timestamps: np.ndarray,
     ):
         """
         Register a lidar scan.
-        Timestamps are assumed to be absolute seconds.
+        Timestamps are assumed to be absolute nanoseconds.
         It is assumed there is sufficient IMU data added to the pipeline before triggering the registration (use the Sequencer).
 
 
         Parameters
         ----------
-        start_time: float
-            Absolute time of the scan recording start
-        end_time: float
-            Absolute time of the scan recording end
+        start_time: int
+            Absolute time of the scan recording start, in nanoseconds.
+        end_time: int
+            Absolute time of the scan recording end, in nanoseconds.
         scan : array of float, shape (N,3)
             Point cloud.
-        timestamps : array of float, shape (N,)
-            Absolute timestamps (seconds) for each point.
+        timestamps : array of int64, shape (N,)
+            Absolute per-point timestamps in nanoseconds.
 
         Returns
         -------
@@ -165,7 +165,7 @@ class LIOPipeline:
         """
         if self.config.viz:
             # needs to be logged before the pybinded register function is called
-            self.rerun.set_time("data_time", timestamp=end_time)
+            self.rerun.set_time("data_time", timestamp=end_time * 1e-9)
             stats = self.lio.interval_stats()
             self.rerun.log("imu/imu_count", self.rerun.Scalars(float(stats.imu_count)))
             log_vector(self.rerun, "imu/avg_acceleration", stats.avg_imu_accel())
@@ -205,8 +205,8 @@ class LIOPipeline:
         return deskewed_scan
 
     @profile_func("Pipeline - Visualization")
-    def _visualize_frame(self, end_time: float):
-        self.rerun.set_time("data_time", timestamp=end_time)
+    def _visualize_frame(self, end_time: int):
+        self.rerun.set_time("data_time", timestamp=end_time * 1e-9)
         pose = self.lio.pose()
         self.rerun.log(
             "world/lidar",
@@ -253,11 +253,12 @@ class LIOPipeline:
         - Configuration as YAML file.
         """
         traj_file = self.output_dir / f"{self.output_dir.name}_tum.txt"
-        timestamps, poses = self.lio.poses_with_timestamps()
+        timestamps_ns, poses = self.lio.poses_with_timestamps()
         with traj_file.open("w") as f:
-            for t, p in zip(timestamps, poses):
+            for t_ns, p in zip(timestamps_ns, poses):
                 # p: x,y,z,qx,qy,qz,qw
-                line = f"{t:.6f} {p[0]:.6f} {p[1]:.6f} {p[2]:.6f} {p[3]:.6f} {p[4]:.6f} {p[5]:.6f} {p[6]:.6f}\n"
+                t_s = t_ns * 1e-9
+                line = f"{t_s:.6f} {p[0]:.6f} {p[1]:.6f} {p[2]:.6f} {p[3]:.6f} {p[4]:.6f} {p[5]:.6f} {p[6]:.6f}\n"
                 f.write(line)
         info(f"Poses written to {traj_file.resolve()}")
 

--- a/rko_lio/python/rko_lio/util.py
+++ b/rko_lio/python/rko_lio/util.py
@@ -114,12 +114,12 @@ def quat_xyzw_xyz_to_transform(quat_xyzw_xyz: np.ndarray | list | None) -> np.nd
 
 def save_scan_as_ply(
     scan: np.ndarray,
-    end_time_seconds: float,
+    end_time_ns: int,
     output_dir: Path,
 ):
     """
     dumps the scan as PLY.
-    The filename is <nanoseconds_as_int>.ply based on end_time_seconds.
+    The filename is <nanoseconds_as_int>.ply.
     """
     if scan is None or len(scan) == 0:
         return
@@ -131,7 +131,7 @@ def save_scan_as_ply(
         )
 
     output_dir.mkdir(exist_ok=True, parents=True)
-    fname = output_dir / f"{int(end_time_seconds * 1e9)}.ply"
+    fname = output_dir / f"{int(end_time_ns)}.ply"
 
     pc = open3d.geometry.PointCloud()
     pc.points = open3d.utility.Vector3dVector(scan)

--- a/rko_lio/ros/base_node.cpp
+++ b/rko_lio/ros/base_node.cpp
@@ -57,7 +57,7 @@ namespace rko_lio::ros {
 
 core::ImuControl imu_msg_to_imu_data(const sensor_msgs::msg::Imu& imu_msg) {
   core::ImuControl imu_data;
-  imu_data.time = utils::ros_time_to_seconds(imu_msg.header.stamp);
+  imu_data.time = utils::ros_time_to_nanoseconds(imu_msg.header.stamp);
   imu_data.angular_velocity = utils::ros_xyz_to_eigen_vector3d(imu_msg.angular_velocity);
   imu_data.acceleration = utils::ros_xyz_to_eigen_vector3d(imu_msg.linear_acceleration);
   return imu_data;
@@ -98,7 +98,10 @@ BaseNode::BaseNode(const std::string& node_name, const rclcpp::NodeOptions& opti
   publish_local_map = node->declare_parameter<bool>("publish_local_map", publish_local_map);
   if (publish_local_map) {
     map_topic = node->declare_parameter<std::string>("map_topic", map_topic);
-    publish_map_after = core::Secondsd(node->declare_parameter<double>("publish_map_after", publish_map_after.count()));
+    const double publish_map_after_seconds =
+        node->declare_parameter<double>("publish_map_after", core::to_seconds(publish_map_after));
+    publish_map_after = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::duration<double>(publish_map_after_seconds));
     map_publisher = node->create_publisher<sensor_msgs::msg::PointCloud2>(map_topic, publisher_qos);
     map_publish_thead = std::jthread([this]() { publish_map_loop(); });
   }
@@ -213,7 +216,7 @@ bool BaseNode::check_and_set_extrinsics() {
 
 std::tuple<core::Timestamps, core::Vector3dVector>
 BaseNode::process_lidar_msg(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& lidar_msg) const {
-  const core::Secondsd& header_stamp = utils::ros_time_to_seconds(lidar_msg->header.stamp);
+  const core::Nsec header_stamp = utils::ros_time_to_nanoseconds(lidar_msg->header.stamp);
   if (lio->config.deskew) {
     const auto& [scan, raw_timestamps] = utils::point_cloud2_to_eigen_with_timestamps(lidar_msg);
     const core::Timestamps& timestamps = core::process_timestamps(raw_timestamps, header_stamp, timestamp_proc_config);
@@ -233,11 +236,11 @@ core::Vector3dVector BaseNode::register_scan_locked(const core::Vector3dVector& 
   return lio->register_scan(extrinsic_lidar2base, scan, time_vector);
 }
 
-void BaseNode::publish_lidar_outputs(const core::Vector3dVector& deskewed_frame, const core::Secondsd& stamp) const {
+void BaseNode::publish_lidar_outputs(const core::Vector3dVector& deskewed_frame, const core::Nsec stamp) const {
   if (publish_deskewed_scan) {
     std_msgs::msg::Header header;
     header.frame_id = lidar_frame;
-    header.stamp = rclcpp::Time(std::chrono::duration_cast<std::chrono::nanoseconds>(stamp).count());
+    header.stamp = rclcpp::Time(stamp.count());
     frame_publisher->publish(utils::eigen_to_point_cloud2(deskewed_frame, header));
   }
   publish_odometry(lio->lidar_state, stamp);
@@ -246,9 +249,9 @@ void BaseNode::publish_lidar_outputs(const core::Vector3dVector& deskewed_frame,
   }
 }
 
-void BaseNode::publish_odometry(const core::State& state, const core::Secondsd& stamp) const {
+void BaseNode::publish_odometry(const core::State& state, const core::Nsec stamp) const {
   nav_msgs::msg::Odometry odom_msg;
-  odom_msg.header.stamp = rclcpp::Time(std::chrono::duration_cast<std::chrono::nanoseconds>(stamp).count());
+  odom_msg.header.stamp = rclcpp::Time(stamp.count());
   odom_msg.header.frame_id = odom_frame;
   odom_msg.child_frame_id = base_frame;
   odom_msg.pose.pose = utils::sophus_to_pose(state.pose);
@@ -257,9 +260,9 @@ void BaseNode::publish_odometry(const core::State& state, const core::Secondsd& 
   odom_publisher->publish(odom_msg);
 }
 
-void BaseNode::publish_tf(const Sophus::SE3d& pose, const core::Secondsd& stamp) const {
+void BaseNode::publish_tf(const Sophus::SE3d& pose, const core::Nsec stamp) const {
   geometry_msgs::msg::TransformStamped transform_msg;
-  transform_msg.header.stamp = rclcpp::Time(std::chrono::duration_cast<std::chrono::nanoseconds>(stamp).count());
+  transform_msg.header.stamp = rclcpp::Time(stamp.count());
   if (invert_odom_tf) {
     transform_msg.header.frame_id = base_frame;
     transform_msg.child_frame_id = odom_frame;
@@ -272,9 +275,9 @@ void BaseNode::publish_tf(const Sophus::SE3d& pose, const core::Secondsd& stamp)
   tf_broadcaster->sendTransform(transform_msg);
 }
 
-void BaseNode::publish_lidar_accel(const Eigen::Vector3d& acceleration, const core::Secondsd& stamp) const {
+void BaseNode::publish_lidar_accel(const Eigen::Vector3d& acceleration, const core::Nsec stamp) const {
   auto accel_msg = geometry_msgs::msg::AccelStamped();
-  accel_msg.header.stamp = rclcpp::Time(std::chrono::duration_cast<std::chrono::nanoseconds>(stamp).count());
+  accel_msg.header.stamp = rclcpp::Time(stamp.count());
   accel_msg.header.frame_id = base_frame;
   utils::eigen_vector3d_to_ros_xyz(acceleration, accel_msg.accel.linear);
   lidar_accel_publisher->publish(accel_msg);
@@ -315,7 +318,7 @@ void BaseNode::dump_results_to_disk(const std::filesystem::path& results_dir, co
       for (const auto& [timestamp, pose] : lio->poses_with_timestamps) {
         const Eigen::Vector3d& translation = pose.translation();
         const Eigen::Quaterniond& quaternion = pose.so3().unit_quaternion();
-        file << std::fixed << std::setprecision(6) << timestamp.count() << " " << translation.x() << " "
+        file << std::fixed << std::setprecision(6) << core::to_seconds(timestamp) << " " << translation.x() << " "
              << translation.y() << " " << translation.z() << " " << quaternion.x() << " " << quaternion.y() << " "
              << quaternion.z() << " " << quaternion.w() << "\n";
       }

--- a/rko_lio/ros/base_node.cpp
+++ b/rko_lio/ros/base_node.cpp
@@ -57,7 +57,7 @@ namespace rko_lio::ros {
 
 core::ImuControl imu_msg_to_imu_data(const sensor_msgs::msg::Imu& imu_msg) {
   core::ImuControl imu_data;
-  imu_data.time = utils::ros_time_to_nanoseconds(imu_msg.header.stamp);
+  imu_data.time = utils::to_ns(imu_msg.header.stamp);
   imu_data.angular_velocity = utils::ros_xyz_to_eigen_vector3d(imu_msg.angular_velocity);
   imu_data.acceleration = utils::ros_xyz_to_eigen_vector3d(imu_msg.linear_acceleration);
   return imu_data;
@@ -216,7 +216,7 @@ bool BaseNode::check_and_set_extrinsics() {
 
 std::tuple<core::Timestamps, core::Vector3dVector>
 BaseNode::process_lidar_msg(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& lidar_msg) const {
-  const core::Nsec header_stamp = utils::ros_time_to_nanoseconds(lidar_msg->header.stamp);
+  const core::Nsec header_stamp = utils::to_ns(lidar_msg->header.stamp);
   if (lio->config.deskew) {
     const auto& [scan, raw_timestamps] = utils::point_cloud2_to_eigen_with_timestamps(lidar_msg);
     const core::Timestamps& timestamps = core::process_timestamps(raw_timestamps, header_stamp, timestamp_proc_config);
@@ -240,7 +240,7 @@ void BaseNode::publish_lidar_outputs(const core::Vector3dVector& deskewed_frame,
   if (publish_deskewed_scan) {
     std_msgs::msg::Header header;
     header.frame_id = lidar_frame;
-    header.stamp = rclcpp::Time(stamp.count());
+    header.stamp = utils::to_ros_time(stamp);
     frame_publisher->publish(utils::eigen_to_point_cloud2(deskewed_frame, header));
   }
   publish_odometry(lio->lidar_state, stamp);
@@ -251,7 +251,7 @@ void BaseNode::publish_lidar_outputs(const core::Vector3dVector& deskewed_frame,
 
 void BaseNode::publish_odometry(const core::State& state, const core::Nsec stamp) const {
   nav_msgs::msg::Odometry odom_msg;
-  odom_msg.header.stamp = rclcpp::Time(stamp.count());
+  odom_msg.header.stamp = utils::to_ros_time(stamp);
   odom_msg.header.frame_id = odom_frame;
   odom_msg.child_frame_id = base_frame;
   odom_msg.pose.pose = utils::sophus_to_pose(state.pose);
@@ -262,7 +262,7 @@ void BaseNode::publish_odometry(const core::State& state, const core::Nsec stamp
 
 void BaseNode::publish_tf(const Sophus::SE3d& pose, const core::Nsec stamp) const {
   geometry_msgs::msg::TransformStamped transform_msg;
-  transform_msg.header.stamp = rclcpp::Time(stamp.count());
+  transform_msg.header.stamp = utils::to_ros_time(stamp);
   if (invert_odom_tf) {
     transform_msg.header.frame_id = base_frame;
     transform_msg.child_frame_id = odom_frame;
@@ -277,7 +277,7 @@ void BaseNode::publish_tf(const Sophus::SE3d& pose, const core::Nsec stamp) cons
 
 void BaseNode::publish_lidar_accel(const Eigen::Vector3d& acceleration, const core::Nsec stamp) const {
   auto accel_msg = geometry_msgs::msg::AccelStamped();
-  accel_msg.header.stamp = rclcpp::Time(stamp.count());
+  accel_msg.header.stamp = utils::to_ros_time(stamp);
   accel_msg.header.frame_id = base_frame;
   utils::eigen_vector3d_to_ros_xyz(acceleration, accel_msg.accel.linear);
   lidar_accel_publisher->publish(accel_msg);

--- a/rko_lio/ros/base_node.hpp
+++ b/rko_lio/ros/base_node.hpp
@@ -89,7 +89,7 @@ public:
 
   // map publish thread
   std::jthread map_publish_thead;
-  core::Secondsd publish_map_after = std::chrono::seconds(1);
+  core::Nsec publish_map_after = std::chrono::seconds(1);
   std::mutex local_map_mutex;
 
   // shutdown flag
@@ -106,11 +106,11 @@ public:
 
   core::Vector3dVector register_scan_locked(const core::Vector3dVector& scan, const core::TimestampVector& time_vector);
 
-  void publish_lidar_outputs(const core::Vector3dVector& deskewed_frame, const core::Secondsd& stamp) const;
+  void publish_lidar_outputs(const core::Vector3dVector& deskewed_frame, const core::Nsec stamp) const;
 
-  void publish_odometry(const core::State& state, const core::Secondsd& stamp) const;
-  void publish_tf(const Sophus::SE3d& pose, const core::Secondsd& stamp) const;
-  void publish_lidar_accel(const Eigen::Vector3d& acceleration, const core::Secondsd& stamp) const;
+  void publish_odometry(const core::State& state, const core::Nsec stamp) const;
+  void publish_tf(const Sophus::SE3d& pose, const core::Nsec stamp) const;
+  void publish_lidar_accel(const Eigen::Vector3d& acceleration, const core::Nsec stamp) const;
   void publish_map_loop();
   void dump_results_to_disk(const std::filesystem::path& results_dir, const std::string& run_name) const;
 

--- a/rko_lio/ros/online_imu_rate_node.cpp
+++ b/rko_lio/ros/online_imu_rate_node.cpp
@@ -139,7 +139,7 @@ public:
 
   void publish_imu_rate_odometry(const core::State& state) const {
     nav_msgs::msg::Odometry msg;
-    msg.header.stamp = rclcpp::Time(state.time.count());
+    msg.header.stamp = utils::to_ros_time(state.time);
     msg.header.frame_id = odom_frame;
     msg.child_frame_id = base_frame;
     msg.pose.pose = utils::sophus_to_pose(state.pose);

--- a/rko_lio/ros/online_imu_rate_node.cpp
+++ b/rko_lio/ros/online_imu_rate_node.cpp
@@ -98,7 +98,7 @@ public:
     const core::ImuControl imu_data = imu_msg_to_imu_data(*imu_msg);
     lio->add_imu_measurement(extrinsic_imu2base, imu_data);
 
-    if (!(lio->imu_state.time > core::Secondsd{0})) {
+    if (!(lio->imu_state.time > core::Nsec{0})) {
       // Skip publishing before the first successful registration: until then,
       // imu_state has not been seeded from a real lidar pose. add_imu_measurement
       // leaves imu_state.time at zero in that pre-init phase.
@@ -139,7 +139,7 @@ public:
 
   void publish_imu_rate_odometry(const core::State& state) const {
     nav_msgs::msg::Odometry msg;
-    msg.header.stamp = rclcpp::Time(std::chrono::duration_cast<std::chrono::nanoseconds>(state.time).count());
+    msg.header.stamp = rclcpp::Time(state.time.count());
     msg.header.frame_id = odom_frame;
     msg.child_frame_id = base_frame;
     msg.pose.pose = utils::sophus_to_pose(state.pose);

--- a/rko_lio/ros/utils/time.hpp
+++ b/rko_lio/ros/utils/time.hpp
@@ -28,7 +28,15 @@
 #include <rclcpp/time.hpp>
 
 namespace rko_lio::ros::utils {
-inline std::chrono::nanoseconds ros_time_to_nanoseconds(const builtin_interfaces::msg::Time& stamp) {
+inline std::chrono::nanoseconds to_ns(const builtin_interfaces::msg::Time& stamp) {
   return std::chrono::nanoseconds(rclcpp::Time(stamp).nanoseconds());
+}
+
+inline std::chrono::nanoseconds to_ns(const rclcpp::Time& time) {
+  return std::chrono::nanoseconds(time.nanoseconds());
+}
+
+inline builtin_interfaces::msg::Time to_ros_time(std::chrono::nanoseconds time) {
+  return rclcpp::Time(time.count());
 }
 } // namespace rko_lio::ros::utils

--- a/rko_lio/ros/utils/time.hpp
+++ b/rko_lio/ros/utils/time.hpp
@@ -24,10 +24,11 @@
 
 #pragma once
 #include <builtin_interfaces/msg/time.hpp>
+#include <chrono>
 #include <rclcpp/time.hpp>
 
 namespace rko_lio::ros::utils {
-inline std::chrono::duration<double> ros_time_to_seconds(const builtin_interfaces::msg::Time& stamp) {
-  return std::chrono::duration<double>(rclcpp::Time(stamp).nanoseconds() * 1e-9);
+inline std::chrono::nanoseconds ros_time_to_nanoseconds(const builtin_interfaces::msg::Time& stamp) {
+  return std::chrono::nanoseconds(rclcpp::Time(stamp).nanoseconds());
 }
 } // namespace rko_lio::ros::utils

--- a/rko_lio/ros/utils/transforms.hpp
+++ b/rko_lio/ros/utils/transforms.hpp
@@ -78,29 +78,29 @@ std::optional<Sophus::SE3<Scalar>>
 get_transform(const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
               const std::string& from_frame,
               const std::string& to_frame,
-              const std::chrono::duration<double>& time,
-              const std::chrono::duration<double>& timeout = std::chrono::duration<double>(0)) {
+              const std::chrono::nanoseconds time,
+              const std::chrono::nanoseconds timeout = std::chrono::nanoseconds(0)) {
   geometry_msgs::msg::TransformStamped from_to_transform;
+  const tf2::TimePoint tf_time{time};
+  const tf2::Duration tf_timeout{timeout};
   try {
     tf_buffer->_validateFrameId("from_frame", from_frame);
     tf_buffer->_validateFrameId("to frame", to_frame);
     std::unique_ptr<std::string> error_str = std::make_unique<std::string>();
-    if (!tf_buffer->canTransform(to_frame, from_frame, tf2::TimePoint(std::chrono::duration_cast<tf2::IDuration>(time)),
-                                 std::chrono::duration_cast<tf2::Duration>(timeout), error_str.get())) {
+    if (!tf_buffer->canTransform(to_frame, from_frame, tf_time, tf_timeout, error_str.get())) {
       RCLCPP_WARN_STREAM(rclcpp::get_logger("transform lookup"),
-                         "Cannot transfrom from: " << from_frame << " -> to: " << to_frame
-                                                   << " at time: " << time.count() << " because of: " << *error_str);
+                         "Cannot transform from: " << from_frame << " -> to: " << to_frame
+                                                   << " at time: " << time.count() << "ns because of: " << *error_str);
       return std::nullopt;
     }
-    from_to_transform = tf_buffer->lookupTransform(to_frame, from_frame,
-                                                   tf2::TimePoint(std::chrono::duration_cast<tf2::Duration>(time)));
+    from_to_transform = tf_buffer->lookupTransform(to_frame, from_frame, tf_time);
     return transform_to_sophus<Scalar>(from_to_transform);
   } catch (const tf2::InvalidArgumentException& e) {
     RCLCPP_WARN_STREAM(rclcpp::get_logger("transform lookup"),
                        "TF lookup error (InvalidArgumentException): " << e.what());
     RCLCPP_WARN_STREAM(rclcpp::get_logger("transform lookup"),
                        "Arguments are, to_frame: " << to_frame << ", from_frame: " << from_frame
-                                                   << ", time: " << time.count());
+                                                   << ", time(ns): " << time.count());
   } catch (const tf2::LookupException& e) {
     RCLCPP_WARN_STREAM(rclcpp::get_logger("transform lookup"), "TF lookup error (LookupException): " << e.what());
   } catch (const tf2::TransformException& ex) {

--- a/rko_lio/ros/utils/transforms.hpp
+++ b/rko_lio/ros/utils/transforms.hpp
@@ -36,13 +36,14 @@
 #include <tf2_ros/buffer.h>
 
 namespace rko_lio::ros::utils {
-inline geometry_msgs::msg::Pose sophus_to_pose(const Sophus::SE3d& T) {
+template <typename Scalar = double>
+inline geometry_msgs::msg::Pose sophus_to_pose(const Sophus::SE3<Scalar>& T) {
   geometry_msgs::msg::Pose t;
   t.position.x = T.translation().x();
   t.position.y = T.translation().y();
   t.position.z = T.translation().z();
 
-  Eigen::Quaterniond q(T.so3().unit_quaternion());
+  Eigen::Quaternion<Scalar> q(T.so3().unit_quaternion());
   t.orientation.x = q.x();
   t.orientation.y = q.y();
   t.orientation.z = q.z();
@@ -51,13 +52,14 @@ inline geometry_msgs::msg::Pose sophus_to_pose(const Sophus::SE3d& T) {
   return t;
 }
 
-inline geometry_msgs::msg::Transform sophus_to_transform(const Sophus::SE3d& T) {
+template <typename Scalar = double>
+inline geometry_msgs::msg::Transform sophus_to_transform(const Sophus::SE3<Scalar>& T) {
   geometry_msgs::msg::Transform t;
   t.translation.x = T.translation().x();
   t.translation.y = T.translation().y();
   t.translation.z = T.translation().z();
 
-  Eigen::Quaterniond q(T.so3().unit_quaternion());
+  Eigen::Quaternion<Scalar> q(T.so3().unit_quaternion());
   t.rotation.x = q.x();
   t.rotation.y = q.y();
   t.rotation.z = q.z();

--- a/tests/core/test_imu_integration.cpp
+++ b/tests/core/test_imu_integration.cpp
@@ -26,12 +26,15 @@
 #include "synthetic_clouds.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <cmath>
+#include <cstdint>
 
 using rko_lio::core::GRAVITY_MAG;
 using rko_lio::core::ImuControl;
 using rko_lio::core::LIO;
-using rko_lio::core::Secondsd;
+using rko_lio::core::Nsec;
 using rko_lio::core::TimestampVector;
+using rko_lio::core::to_seconds;
 using rko_lio::core::Vector3dVector;
 using rko_lio::tests::approx_equal;
 using rko_lio::tests::make_hollow_cube;
@@ -47,13 +50,15 @@ LIO::Config default_config() {
   cfg.double_downsample = true;
   return cfg;
 }
+
+inline Nsec ns_from_seconds(double s) { return Nsec(static_cast<int64_t>(std::llround(s * 1e9))); }
 } // namespace
 
 TEST_CASE("IMU before first LiDAR is silently dropped", "[imu_integration]") {
   LIO lio(default_config());
   for (int i = 0; i < 5; ++i) {
     ImuControl m;
-    m.time = Secondsd{0.01 * (i + 1)};
+    m.time = ns_from_seconds(0.01 * (i + 1));
     m.acceleration = {0.0, 0.0, GRAVITY_MAG};
     m.angular_velocity = Eigen::Vector3d::Zero();
     lio.add_imu_measurement(m);
@@ -64,12 +69,12 @@ TEST_CASE("IMU before first LiDAR is silently dropped", "[imu_integration]") {
 TEST_CASE("Static IMU at rest: gravity is compensated", "[imu_integration]") {
   LIO lio(default_config());
   // Bootstrap as if a first lidar scan had been registered.
-  lio.lidar_state.time = Secondsd{1.0};
+  lio.lidar_state.time = ns_from_seconds(1.0);
 
   constexpr int N = 50;
   for (int i = 0; i < N; ++i) {
     ImuControl m;
-    m.time = Secondsd{1.0 + 0.01 * (i + 1)};
+    m.time = ns_from_seconds(1.0 + 0.01 * (i + 1));
     m.acceleration = {0.0, 0.0, GRAVITY_MAG};
     m.angular_velocity = Eigen::Vector3d::Zero();
     lio.add_imu_measurement(m);
@@ -82,7 +87,7 @@ TEST_CASE("Static IMU at rest: gravity is compensated", "[imu_integration]") {
 
 TEST_CASE("Pure rotation: gyro integration matches exp(omega*T)", "[imu_integration]") {
   LIO lio(default_config());
-  lio.lidar_state.time = Secondsd{1.0};
+  lio.lidar_state.time = ns_from_seconds(1.0);
 
   const Eigen::Vector3d omega(0.0, 0.0, 0.5);
   constexpr int N = 100;
@@ -91,7 +96,7 @@ TEST_CASE("Pure rotation: gyro integration matches exp(omega*T)", "[imu_integrat
 
   for (int i = 0; i < N; ++i) {
     ImuControl m;
-    m.time = Secondsd{1.0 + dt * (i + 1)};
+    m.time = ns_from_seconds(1.0 + dt * (i + 1));
     m.angular_velocity = omega;
     m.acceleration = Eigen::Vector3d::Zero();
     lio.add_imu_measurement(m);
@@ -99,19 +104,19 @@ TEST_CASE("Pure rotation: gyro integration matches exp(omega*T)", "[imu_integrat
 
   const Sophus::SO3d expected = Sophus::SO3d::exp(omega * T);
   REQUIRE(approx_equal(lio.imu_state.pose.so3(), expected, 1e-9));
-  REQUIRE_THAT(lio.imu_state.time.count(), WithinAbs(1.0 + T, 1e-12));
+  REQUIRE_THAT(to_seconds(lio.imu_state.time), WithinAbs(1.0 + T, 1e-12));
 }
 
 TEST_CASE("Gyro bias is subtracted before integration", "[imu_integration]") {
   LIO lio(default_config());
-  lio.lidar_state.time = Secondsd{1.0};
+  lio.lidar_state.time = ns_from_seconds(1.0);
   lio.imu_bias.gyroscope = {0.1, -0.2, 0.05};
 
   const Eigen::Vector3d measured(0.5, 0.3, 0.1);
   constexpr int N = 50;
   for (int i = 0; i < N; ++i) {
     ImuControl m;
-    m.time = Secondsd{1.0 + 0.01 * (i + 1)};
+    m.time = ns_from_seconds(1.0 + 0.01 * (i + 1));
     m.angular_velocity = measured;
     m.acceleration = Eigen::Vector3d::Zero();
     lio.add_imu_measurement(m);
@@ -124,7 +129,7 @@ TEST_CASE("Gyro bias is subtracted before integration", "[imu_integration]") {
 
 TEST_CASE("Extrinsic overload: identity extrinsic delegates to base-frame", "[imu_integration]") {
   LIO lio(default_config());
-  lio.lidar_state.time = Secondsd{1.0};
+  lio.lidar_state.time = ns_from_seconds(1.0);
 
   const Sophus::SE3d identity_extrinsic;
   const Eigen::Vector3d omega(0.1, 0.2, 0.3);
@@ -132,7 +137,7 @@ TEST_CASE("Extrinsic overload: identity extrinsic delegates to base-frame", "[im
   constexpr int N = 10;
   for (int i = 0; i < N; ++i) {
     ImuControl m;
-    m.time = Secondsd{1.0 + 0.01 * (i + 1)};
+    m.time = ns_from_seconds(1.0 + 0.01 * (i + 1));
     m.angular_velocity = omega;
     m.acceleration = {0.0, 0.0, GRAVITY_MAG};
     lio.add_imu_measurement(identity_extrinsic, m);
@@ -147,7 +152,7 @@ TEST_CASE("Extrinsic overload: identity extrinsic delegates to base-frame", "[im
 
 TEST_CASE("Extrinsic overload: pure-rotation extrinsic transforms omega", "[imu_integration]") {
   LIO lio(default_config());
-  lio.lidar_state.time = Secondsd{1.0};
+  lio.lidar_state.time = ns_from_seconds(1.0);
 
   const Sophus::SO3d R = Sophus::SO3d::rotX(M_PI / 2.0);
   const Sophus::SE3d extrinsic_imu2base(R, Eigen::Vector3d::Zero());
@@ -159,7 +164,7 @@ TEST_CASE("Extrinsic overload: pure-rotation extrinsic transforms omega", "[imu_
   constexpr int N = 20;
   for (int i = 0; i < N + 1; ++i) {
     ImuControl m;
-    m.time = Secondsd{1.0 + 0.01 * (i + 1)};
+    m.time = ns_from_seconds(1.0 + 0.01 * (i + 1));
     m.angular_velocity = omega_imu;
     m.acceleration = Eigen::Vector3d::Zero();
     lio.add_imu_measurement(extrinsic_imu2base, m);
@@ -176,12 +181,12 @@ TEST_CASE("Static IMU at rest: imu_state translation stays zero", "[imu_integrat
   LIO lio(default_config());
   // Bootstrap as if a first lidar scan had been registered. The first add_imu_measurement
   // hits the lazy-init branch and anchors imu_state.pose = identity, velocity = 0.
-  lio.lidar_state.time = Secondsd{1.0};
+  lio.lidar_state.time = ns_from_seconds(1.0);
 
   constexpr int N = 50;
   for (int i = 0; i < N; ++i) {
     ImuControl m;
-    m.time = Secondsd{1.0 + 0.01 * (i + 1)};
+    m.time = ns_from_seconds(1.0 + 0.01 * (i + 1));
     m.acceleration = {0.0, 0.0, GRAVITY_MAG};
     m.angular_velocity = Eigen::Vector3d::Zero();
     lio.add_imu_measurement(m);
@@ -195,7 +200,7 @@ TEST_CASE("Static IMU at rest: imu_state translation stays zero", "[imu_integrat
 TEST_CASE("Constant body acceleration: position grows as 0.5 * a * t^2", "[imu_integration]") {
   LIO lio(default_config());
   // Bootstrap as if a first lidar scan had been registered with identity pose.
-  lio.lidar_state.time = Secondsd{1.0};
+  lio.lidar_state.time = ns_from_seconds(1.0);
 
   constexpr double a_x = 0.5; // m/s^2 in body x
   constexpr int N = 100;
@@ -204,7 +209,7 @@ TEST_CASE("Constant body acceleration: position grows as 0.5 * a * t^2", "[imu_i
 
   for (int i = 0; i < N; ++i) {
     ImuControl m;
-    m.time = Secondsd{1.0 + dt * (i + 1)};
+    m.time = ns_from_seconds(1.0 + dt * (i + 1));
     // Raw IMU acceleration: body accel + gravity (so compensated_accel comes out (a_x, 0, 0)).
     m.acceleration = {a_x, 0.0, GRAVITY_MAG};
     m.angular_velocity = Eigen::Vector3d::Zero();
@@ -243,7 +248,7 @@ TEST_CASE("register_scan resets imu_state to optimized pose", "[imu_integration]
     const double frac = cloud.size() == 1
                             ? 0.0
                             : static_cast<double>(i) / static_cast<double>(cloud.size() - 1);
-    ts1.emplace_back(Secondsd{FIRST_SCAN_END * frac});
+    ts1.emplace_back(ns_from_seconds(FIRST_SCAN_END * frac));
   }
   lio.register_scan(cloud, ts1);
 
@@ -253,19 +258,19 @@ TEST_CASE("register_scan resets imu_state to optimized pose", "[imu_integration]
   for (int i = 0; i < N; ++i) {
     ImuControl m;
     const double frac = static_cast<double>(i) / static_cast<double>(N - 1);
-    m.time = Secondsd{FIRST_SCAN_END + 0.05 + (DT - 0.1) * frac};
+    m.time = ns_from_seconds(FIRST_SCAN_END + 0.05 + (DT - 0.1) * frac);
     m.acceleration = {0.0, 0.0, GRAVITY_MAG};
     m.angular_velocity = Eigen::Vector3d::Zero();
     lio.add_imu_measurement(m);
   }
 
   // Single-instant timestamps for the second scan -> deskewing is identity.
-  const TimestampVector ts2(cloud.size(), Secondsd{SECOND_SCAN_END});
+  const TimestampVector ts2(cloud.size(), ns_from_seconds(SECOND_SCAN_END));
   lio.register_scan(cloud, ts2);
 
   REQUIRE(lio.poses_with_timestamps.size() == 2);
   REQUIRE(approx_equal(lio.imu_state.pose, lio.lidar_state.pose, 1e-12));
-  REQUIRE_THAT(lio.imu_state.time.count(), WithinAbs(lio.lidar_state.time.count(), 1e-12));
+  REQUIRE_THAT(to_seconds(lio.imu_state.time), WithinAbs(to_seconds(lio.lidar_state.time), 1e-12));
   REQUIRE(approx_equal(lio.imu_state.velocity, lio.lidar_state.velocity, 1e-12));
   REQUIRE(approx_equal(lio.imu_state.angular_velocity, lio.lidar_state.angular_velocity, 1e-12));
   REQUIRE(approx_equal(lio.imu_state.linear_acceleration, lio.lidar_state.linear_acceleration, 1e-12));

--- a/tests/core/test_process_timestamps.cpp
+++ b/tests/core/test_process_timestamps.cpp
@@ -23,10 +23,14 @@
 #include "rko_lio/core/process_timestamps.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
 #include <stdexcept>
 
+using rko_lio::core::Nsec;
 using rko_lio::core::process_timestamps;
-using rko_lio::core::Secondsd;
+using rko_lio::core::to_seconds;
 using rko_lio::core::TimestampProcessingConfig;
 using Catch::Matchers::WithinAbs;
 
@@ -43,60 +47,62 @@ std::vector<double> linspace(double start, double end, size_t n) {
   }
   return out;
 }
+
+inline Nsec ns_from_seconds(double s) { return Nsec(static_cast<int64_t>(std::llround(s * 1e9))); }
 } // namespace
 
 TEST_CASE("process_timestamps: absolute seconds, header ~= min -> unchanged", "[process_timestamps]") {
   const auto raw = linspace(1234.0, 1234.1, 100);
-  const Secondsd header{1234.0};
+  const Nsec header = ns_from_seconds(1234.0);
   const auto result = process_timestamps(raw, header, {});
 
-  REQUIRE_THAT(result.min.count(), WithinAbs(1234.0, 1e-9));
-  REQUIRE_THAT(result.max.count(), WithinAbs(1234.1, 1e-9));
+  REQUIRE_THAT(to_seconds(result.min), WithinAbs(1234.0, 1e-9));
+  REQUIRE_THAT(to_seconds(result.max), WithinAbs(1234.1, 1e-9));
   REQUIRE(result.times.size() == raw.size());
-  REQUIRE_THAT(result.times.front().count(), WithinAbs(1234.0, 1e-9));
-  REQUIRE_THAT(result.times.back().count(), WithinAbs(1234.1, 1e-9));
+  REQUIRE_THAT(to_seconds(result.times.front()), WithinAbs(1234.0, 1e-9));
+  REQUIRE_THAT(to_seconds(result.times.back()), WithinAbs(1234.1, 1e-9));
 }
 
 TEST_CASE("process_timestamps: relative seconds, min ~= 0 -> header offset added", "[process_timestamps]") {
   const auto raw = linspace(0.0, 0.1, 100);
-  const Secondsd header{1234.5};
+  const Nsec header = ns_from_seconds(1234.5);
   const auto result = process_timestamps(raw, header, {});
 
-  REQUIRE_THAT(result.min.count(), WithinAbs(1234.5, 1e-9));
-  REQUIRE_THAT(result.max.count(), WithinAbs(1234.6, 1e-9));
-  REQUIRE_THAT(result.times.front().count(), WithinAbs(1234.5, 1e-9));
-  REQUIRE_THAT(result.times.back().count(), WithinAbs(1234.6, 1e-9));
+  REQUIRE_THAT(to_seconds(result.min), WithinAbs(1234.5, 1e-9));
+  REQUIRE_THAT(to_seconds(result.max), WithinAbs(1234.6, 1e-9));
+  REQUIRE_THAT(to_seconds(result.times.front()), WithinAbs(1234.5, 1e-9));
+  REQUIRE_THAT(to_seconds(result.times.back()), WithinAbs(1234.6, 1e-9));
 }
 
-TEST_CASE("process_timestamps: absolute nanoseconds -> heuristic infers 1e-9", "[process_timestamps]") {
+TEST_CASE("process_timestamps: absolute nanoseconds -> heuristic infers ns source", "[process_timestamps]") {
   // Duration in ns is 1e8 > 100, which trips the nanosecond heuristic.
   const auto raw = linspace(1234.0e9, 1234.1e9, 100);
-  const Secondsd header{1234.0};
+  const Nsec header = ns_from_seconds(1234.0);
   const auto result = process_timestamps(raw, header, {});
 
-  REQUIRE_THAT(result.min.count(), WithinAbs(1234.0, 1e-3));
-  REQUIRE_THAT(result.max.count(), WithinAbs(1234.1, 1e-3));
+  REQUIRE_THAT(to_seconds(result.min), WithinAbs(1234.0, 1e-3));
+  REQUIRE_THAT(to_seconds(result.max), WithinAbs(1234.1, 1e-3));
 }
 
 TEST_CASE("process_timestamps: relative nanoseconds", "[process_timestamps]") {
   const auto raw = linspace(0.0, 1.0e8, 100);
-  const Secondsd header{1234.5};
+  const Nsec header = ns_from_seconds(1234.5);
   const auto result = process_timestamps(raw, header, {});
 
-  REQUIRE_THAT(result.min.count(), WithinAbs(1234.5, 1e-3));
-  REQUIRE_THAT(result.max.count(), WithinAbs(1234.6, 1e-3));
+  REQUIRE_THAT(to_seconds(result.min), WithinAbs(1234.5, 1e-3));
+  REQUIRE_THAT(to_seconds(result.max), WithinAbs(1234.6, 1e-3));
 }
 
 TEST_CASE("process_timestamps: force_absolute overrides heuristic", "[process_timestamps]") {
   // Stamps look relative (min ~= 0); force_absolute keeps them as-is.
   const auto raw = linspace(0.0, 0.1, 100);
-  const Secondsd header{1234.5};
+  const Nsec header = ns_from_seconds(1234.5);
   TimestampProcessingConfig cfg;
   cfg.force_absolute = true;
   const auto result = process_timestamps(raw, header, cfg);
 
-  REQUIRE_THAT(result.min.count(), WithinAbs(0.0, 1e-9));
-  REQUIRE_THAT(result.max.count(), WithinAbs(0.1, 1e-9));
+  REQUIRE_THAT(to_seconds(result.min), WithinAbs(0.0, 1e-9));
+  REQUIRE_THAT(to_seconds(result.max), WithinAbs(0.1, 1e-9));
 }
 
 TEST_CASE("process_timestamps: force_relative overrides heuristic", "[process_timestamps]") {
@@ -104,26 +110,26 @@ TEST_CASE("process_timestamps: force_relative overrides heuristic", "[process_ti
   TimestampProcessingConfig cfg;
   cfg.force_relative = true;
   const auto raw = linspace(50.0, 50.1, 100);
-  const Secondsd header{1000.0};
+  const Nsec header = ns_from_seconds(1000.0);
   const auto result = process_timestamps(raw, header, cfg);
 
-  REQUIRE_THAT(result.min.count(), WithinAbs(1050.0, 1e-9));
-  REQUIRE_THAT(result.max.count(), WithinAbs(1050.1, 1e-9));
+  REQUIRE_THAT(to_seconds(result.min), WithinAbs(1050.0, 1e-9));
+  REQUIRE_THAT(to_seconds(result.max), WithinAbs(1050.1, 1e-9));
 }
 
 TEST_CASE("process_timestamps: custom multiplier_to_seconds is honored", "[process_timestamps]") {
   const auto raw = linspace(0.0, 1.0e5, 100);
-  const Secondsd header{1234.5};
+  const Nsec header = ns_from_seconds(1234.5);
   TimestampProcessingConfig cfg;
   cfg.multiplier_to_seconds = 1e-6;
   const auto result = process_timestamps(raw, header, cfg);
 
-  REQUIRE_THAT(result.min.count(), WithinAbs(1234.5, 1e-3));
-  REQUIRE_THAT(result.max.count(), WithinAbs(1234.6, 1e-3));
+  REQUIRE_THAT(to_seconds(result.min), WithinAbs(1234.5, 1e-3));
+  REQUIRE_THAT(to_seconds(result.max), WithinAbs(1234.6, 1e-3));
 }
 
 TEST_CASE("process_timestamps: ambiguous case throws", "[process_timestamps]") {
   const auto raw = linspace(50.0, 50.1, 100);
-  const Secondsd header{1000.0};
+  const Nsec header = ns_from_seconds(1000.0);
   REQUIRE_THROWS_AS(process_timestamps(raw, header, {}), std::runtime_error);
 }

--- a/tests/core/test_register_scan.cpp
+++ b/tests/core/test_register_scan.cpp
@@ -25,17 +25,24 @@
 #include "synthetic_clouds.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <cmath>
+#include <cstdint>
 #include <random>
 
 using rko_lio::core::GRAVITY_MAG;
 using rko_lio::core::ImuControl;
 using rko_lio::core::LIO;
-using rko_lio::core::Secondsd;
+using rko_lio::core::Nsec;
 using rko_lio::core::TimestampVector;
+using rko_lio::core::to_seconds;
 using rko_lio::core::Vector3dVector;
 using rko_lio::tests::approx_equal;
 using rko_lio::tests::make_hollow_cube;
 using Catch::Matchers::WithinAbs;
+
+namespace {
+inline Nsec ns_from_seconds(double s) { return Nsec(static_cast<int64_t>(std::llround(s * 1e9))); }
+}
 
 namespace {
 // dt between consecutive scans, used to derive the IMU values that produce a
@@ -50,7 +57,7 @@ TimestampVector linspace_timestamps(size_t n, double t_start, double t_end) {
   ts.reserve(n);
   for (size_t i = 0; i < n; ++i) {
     const double frac = n == 1 ? 0.0 : static_cast<double>(i) / static_cast<double>(n - 1);
-    ts.emplace_back(Secondsd{t_start + (t_end - t_start) * frac});
+    ts.emplace_back(ns_from_seconds(t_start + (t_end - t_start) * frac));
   }
   return ts;
 }
@@ -58,7 +65,7 @@ TimestampVector linspace_timestamps(size_t n, double t_start, double t_end) {
 // Single-instant timestamps for the second scan: deskewing reduces to identity
 // when every point shares end_time.
 TimestampVector instant_timestamps(size_t n, double t) {
-  return TimestampVector(n, Secondsd{t});
+  return TimestampVector(n, ns_from_seconds(t));
 }
 
 void feed_imu(LIO& lio, double t_start, double t_end, int n,
@@ -66,7 +73,7 @@ void feed_imu(LIO& lio, double t_start, double t_end, int n,
   for (int i = 0; i < n; ++i) {
     ImuControl m;
     const double frac = n == 1 ? 0.0 : static_cast<double>(i) / static_cast<double>(n - 1);
-    m.time = Secondsd{t_start + (t_end - t_start) * frac};
+    m.time = ns_from_seconds(t_start + (t_end - t_start) * frac);
     m.acceleration = acceleration;
     m.angular_velocity = angular_velocity;
     lio.add_imu_measurement(m);
@@ -88,7 +95,7 @@ void feed_imu_noisy(LIO& lio, double t_start, double t_end, int n,
   for (int i = 0; i < n; ++i) {
     ImuControl m;
     const double frac = n == 1 ? 0.0 : static_cast<double>(i) / static_cast<double>(n - 1);
-    m.time = Secondsd{t_start + (t_end - t_start) * frac};
+    m.time = ns_from_seconds(t_start + (t_end - t_start) * frac);
     m.acceleration = acceleration + Eigen::Vector3d{a_noise(rng), a_noise(rng), a_noise(rng)};
     m.angular_velocity = angular_velocity + Eigen::Vector3d{g_noise(rng), g_noise(rng), g_noise(rng)};
     lio.add_imu_measurement(m);
@@ -114,9 +121,9 @@ TEST_CASE("First scan: empty map -> populated, single pose at lidar_state.time",
 
   REQUIRE_FALSE(lio.map.empty());
   REQUIRE(lio.poses_with_timestamps.size() == 1);
-  REQUIRE_THAT(lio.lidar_state.time.count(), WithinAbs(FIRST_SCAN_END, 1e-9));
+  REQUIRE_THAT(to_seconds(lio.lidar_state.time), WithinAbs(FIRST_SCAN_END, 1e-9));
   REQUIRE(approx_equal(lio.lidar_state.pose, Sophus::SE3d{}, 1e-12));
-  REQUIRE_THAT(lio.poses_with_timestamps[0].first.count(), WithinAbs(FIRST_SCAN_END, 1e-9));
+  REQUIRE_THAT(to_seconds(lio.poses_with_timestamps[0].first), WithinAbs(FIRST_SCAN_END, 1e-9));
 }
 
 TEST_CASE("Identity registration: same cloud twice -> pose ~= identity", "[register_scan]") {

--- a/tests/python/test_lio_pipeline.py
+++ b/tests/python/test_lio_pipeline.py
@@ -37,7 +37,7 @@ def pipeline(identity_extrinsics):
 
 
 def create_lidar_timestamps(n):
-    return np.linspace(0, 0.1, n).astype(np.float32)
+    return np.linspace(0, 100_000_000, n).astype(np.int64)
 
 
 def test_pipeline_creation(pipeline):
@@ -46,19 +46,19 @@ def test_pipeline_creation(pipeline):
 
 def test_add_imu(pipeline, static_imu_measurement):
     accel, gyro = static_imu_measurement
-    pipeline.add_imu(0.0, accel, gyro)
+    pipeline.add_imu(0, accel, gyro)
 
 
 def test_register_scan(pipeline, simple_point_cloud):
     cloud1 = simple_point_cloud
     timestamps1 = create_lidar_timestamps(len(cloud1))
-    min_t, max_t = np.min(timestamps1), np.max(timestamps1)
+    min_t, max_t = int(timestamps1.min()), int(timestamps1.max())
     pipeline.register_scan(min_t, max_t, cloud1, timestamps1)
 
     cloud2 = simple_point_cloud
     timestamps2 = create_lidar_timestamps(len(cloud2))
 
-    min_t, max_t = np.min(timestamps2), np.max(timestamps2)
+    min_t, max_t = int(timestamps2.min()), int(timestamps2.max())
     pipeline.register_scan(min_t, max_t, cloud2, timestamps2)
 
 
@@ -80,17 +80,17 @@ def test_identity_registration(
     accel, gyro = static_imu_measurement
     cloud = simple_point_cloud
 
-    def add_scan_with_imu(base_time):
-        timestamps = create_lidar_timestamps(len(cloud)) + base_time
-        min_t, max_t = np.min(timestamps), np.max(timestamps)
+    def add_scan_with_imu(base_time_ns):
+        timestamps = create_lidar_timestamps(len(cloud)) + int(base_time_ns)
+        min_t, max_t = int(timestamps.min()), int(timestamps.max())
         pipeline.register_scan(min_t, max_t, cloud, timestamps)
 
         # Add 10 IMU measurements after the lidar scan end time
-        start_time = timestamps[-1] + 0.01
+        start_time = int(timestamps[-1]) + 10_000_000
         for i in range(10):
-            t = start_time + i * 0.01
+            t = start_time + i * 10_000_000
             pipeline.add_imu(t, accel, gyro)
-        return timestamps[-1]
+        return int(timestamps[-1])
 
     def verify_identity_pose(scan_num):
         pose = pipeline.lio.pose()
@@ -110,13 +110,13 @@ def test_identity_registration(
         ), f"Rotation error too high at scan {scan_num}: {rotation_angle} degrees"
 
     # First scan; base_time 0
-    last_lidar_end = add_scan_with_imu(0.0)
+    last_lidar_end = add_scan_with_imu(0)
     verify_identity_pose(1)
 
     # Second scan
     last_lidar_end = add_scan_with_imu(last_lidar_end)
     pipeline.add_imu(
-        last_lidar_end + 0.01, accel, gyro
+        last_lidar_end + 10_000_000, accel, gyro
     )  # ensure the second lidar gets processed
     verify_identity_pose(2)
 


### PR DESCRIPTION
Another big sweeping change thats been pending. At some point early in the project i decided to use doubles to represent time. But I realized later that was the wrong call, especially when i got bit by some tf lookups when i was doing nanoseconds -> double -> nanoseconds with some other shady casting in between and then my lookups were failing because of cast issues. Switching to using nanoseconds is just the cleaner way and is also the highest precision ros provides the timestamps in originally anyways. 

also something something nanoseconds count time since unix epoch more precisely than doubles at the current moment.

The ros utils api has also been cleaned up a bit following this.

Needless to say, this is a breaking change. a big one at that.