### PR TITLE
core, python, ros: a series of simplifications

### DIFF
--- a/config/ros_default.yaml
+++ b/config/ros_default.yaml
@@ -27,7 +27,7 @@ voxel_size: 1.0
 max_points_per_voxel: 20
 max_range: 100.0
 min_range: 1.0
-max_correspondance_distance: 0.5
+max_correspondence_distance: 0.5
 convergence_criterion: 0.00001
 max_num_threads: 0
 initialization_phase: false

--- a/docs/pages/config.rst
+++ b/docs/pages/config.rst
@@ -69,7 +69,7 @@ These show up under the top level of a Python config and as ROS launch arguments
   In case you need more runtime performance, you can reduce this.
   Odometry performance will be a bit affected, but how much depends on the environment.
 
-- **max_correspondance_distance** (`float`, default ``0.5``)
+- **max_correspondence_distance** (`float`, default ``0.5``)
 
   Maximum distance threshold (meters) for ICP data associations.
 

--- a/launch/odometry.launch.py
+++ b/launch/odometry.launch.py
@@ -145,7 +145,7 @@ configurable_parameters = [
         "description": "Min valid LiDAR range (meters)",
     },
     {
-        "name": "max_correspondance_distance",
+        "name": "max_correspondence_distance",
         "default": "0.5",
         "type": "float",
         "description": "ICP correspondence distance threshold (meters)",

--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -282,7 +282,7 @@ Vector3dVector LIO::bootstrap_first_scan(const Vector3dVector& scan, const Nsec 
   imu_state = lidar_state;
   auto preproc = preprocess_scan(scan, config);
   if (!config.initialization_phase) {
-    map.update(preproc.map_update_frame(), lidar_state.pose);
+    map.update(config.double_downsample ? preproc.map_frame : preproc.keypoints, lidar_state.pose);
     poses_with_timestamps.emplace_back(lidar_state.time, lidar_state.pose);
     std::cout << "[INFO] Odometry map frame initialized with first lidar scan.\n";
   }
@@ -453,6 +453,8 @@ Vector3dVector LIO::register_scan(const Vector3dVector& scan, const TimestampVec
     throw std::invalid_argument(error_msg);
   }
 
+  const Vector3dVector& map_input = config.double_downsample ? preproc_result.map_frame : preproc_result.keypoints;
+
   if (!map.empty()) {
     SCOPED_PROFILER("ICP");
     const Sophus::SE3d optimized_pose = icp(preproc_result.keypoints, map, initial_guess, config, kf_step.info);
@@ -477,7 +479,7 @@ Vector3dVector LIO::register_scan(const Vector3dVector& scan, const TimestampVec
   // reset imu averages
   interval_stats.reset();
 
-  map.update(preproc_result.map_update_frame(), lidar_state.pose);
+  map.update(map_input, lidar_state.pose);
 
   poses_with_timestamps.emplace_back(lidar_state.time, lidar_state.pose);
 

--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -122,7 +122,7 @@ using LinearSystem = std::tuple<Eigen::Matrix6d, Eigen::Vector6d, double>;
 LinearSystem build_icp_linear_system(const Sophus::SE3d& current_pose,
                                      const rko_lio::core::Vector3dVector& frame,
                                      const rko_lio::core::VoxelHashMap& voxel_map,
-                                     const double& max_correspondance_distance) {
+                                     const double& max_correspondence_distance) {
   auto linear_system_reduce = [](LinearSystem lhs, const LinearSystem& rhs) {
     auto& [lhs_H, lhs_b, lhs_chi] = lhs;
     const auto& [rhs_H, rhs_b, rhs_chi] = rhs;
@@ -144,7 +144,7 @@ LinearSystem build_icp_linear_system(const Sophus::SE3d& current_pose,
 
   // The only parallel part
   using points_iterator = std::vector<Eigen::Vector3d>::const_iterator;
-  std::atomic<int> correspondances_counter = 0;
+  std::atomic<int> correspondences_counter = 0;
   const auto& [H_icp, b_icp, chi_icp] = tbb::parallel_reduce(
       // Range
       tbb::blocked_range<points_iterator>{frame.cbegin(), frame.cend()},
@@ -156,8 +156,8 @@ LinearSystem build_icp_linear_system(const Sophus::SE3d& current_pose,
           // Compute data association and linear system
           const Eigen::Vector3d transformed_point = current_pose * point;
           const auto& [closest_neighbor, distance] = voxel_map.get_closest_neighbor(transformed_point);
-          if (distance < max_correspondance_distance) {
-            correspondances_counter++;
+          if (distance < max_correspondence_distance) {
+            correspondences_counter++;
             return linear_system_for_one_point(transformed_point, closest_neighbor);
           }
           // TODO (meher): additional 0 add flops, which may hurt single threaded perf slightly
@@ -167,11 +167,11 @@ LinearSystem build_icp_linear_system(const Sophus::SE3d& current_pose,
       // 2nd Lambda: Parallel reduction of the private Jacobians
       linear_system_reduce);
 
-  if (correspondances_counter == 0) {
+  if (correspondences_counter == 0) {
     throw std::runtime_error("Number of correspondences are 0.");
   }
 
-  return {H_icp / correspondances_counter, b_icp / correspondances_counter, 0.5 * chi_icp};
+  return {H_icp / correspondences_counter, b_icp / correspondences_counter, 0.5 * chi_icp};
 }
 
 LinearSystem build_orientation_linear_system(const Sophus::SE3d& current_pose,
@@ -202,7 +202,7 @@ Sophus::SE3d icp(const Vector3dVector& frame,
   for (size_t i = 0; i < config.max_iterations; ++i) {
     const auto& [H, b, chi] = std::invoke([&]() -> LinearSystem {
       const auto& [H_icp, b_icp, chi_icp] =
-          build_icp_linear_system(current_pose, frame, voxel_map, config.max_correspondance_distance);
+          build_icp_linear_system(current_pose, frame, voxel_map, config.max_correspondence_distance);
       if (beta >= 0) {
         const auto& [H_ori, b_ori, chi_ori] =
             build_orientation_linear_system(current_pose, optional_accel_info->local_gravity_estimate);

--- a/rko_lio/core/lio.hpp
+++ b/rko_lio/core/lio.hpp
@@ -60,7 +60,7 @@ public:
     double convergence_criterion = 1e-5;
 
     /** Max distance for correspondences (m). */
-    double max_correspondance_distance = 0.5;
+    double max_correspondence_distance = 0.5;
 
     /** Thread count for data association (0 = automatic). */
     int max_num_threads = 0;

--- a/rko_lio/core/preprocess_scan.cpp
+++ b/rko_lio/core/preprocess_scan.cpp
@@ -19,13 +19,11 @@ PreprocessingResult preprocess_scan(const Vector3dVector& frame, const LIO::Conf
     Vector3dVector downsampled_frame = voxel_down_sample(clipped_frame, config.voxel_size * 0.5);
     Vector3dVector keypoints = voxel_down_sample(downsampled_frame, config.voxel_size * 1.5);
     return {.filtered_frame = std::move(clipped_frame),
-            .map_frame = std::move(downsampled_frame),
-            .keypoints = std::move(keypoints)};
+            .keypoints = std::move(keypoints),
+            .map_frame = std::move(downsampled_frame)};
   }
   Vector3dVector keypoints = voxel_down_sample(clipped_frame, config.voxel_size);
-  return {.filtered_frame = std::move(clipped_frame),
-          .map_frame = std::nullopt,
-          .keypoints = std::move(keypoints)};
+  return {.filtered_frame = std::move(clipped_frame), .keypoints = std::move(keypoints), .map_frame = {}};
 }
 
 } // namespace rko_lio::core

--- a/rko_lio/core/preprocess_scan.hpp
+++ b/rko_lio/core/preprocess_scan.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <Eigen/Dense>
-#include <optional>
 #include <vector>
 
 #include "lio.hpp"
@@ -9,10 +8,8 @@ namespace rko_lio::core {
 
 struct PreprocessingResult {
   Vector3dVector filtered_frame;
-  std::optional<Vector3dVector> map_frame;
   Vector3dVector keypoints;
-
-  const Vector3dVector& map_update_frame() const { return map_frame ? *map_frame : keypoints; }
+  Vector3dVector map_frame; // populated only when config.double_downsample; empty otherwise
 };
 
 // clip and downsample the input cloud

--- a/rko_lio/core/voxel_down_sample.cpp
+++ b/rko_lio/core/voxel_down_sample.cpp
@@ -25,7 +25,7 @@
 #include <Eigen/Core>
 #include <algorithm>
 #include <sophus/se3.hpp>
-#include <unordered_map>
+#include <tsl/robin_map.h>
 #include <vector>
 
 namespace rko_lio::core {
@@ -35,7 +35,7 @@ namespace rko_lio::core {
 
 std::vector<Eigen::Vector3d> voxel_down_sample(const std::vector<Eigen::Vector3d>& frame, const double voxel_size) {
   const double inv_voxel_size = 1.0 / voxel_size;
-  std::unordered_map<Eigen::Vector3i, Eigen::Vector3d> grid;
+  tsl::robin_map<Eigen::Vector3i, Eigen::Vector3d> grid;
   grid.reserve(frame.size());
   std::for_each(frame.cbegin(), frame.cend(),
                 [&](const auto& point) { grid.try_emplace(point_to_voxel(point, inv_voxel_size), point); });

--- a/rko_lio/core/voxel_down_sample.cpp
+++ b/rko_lio/core/voxel_down_sample.cpp
@@ -25,7 +25,7 @@
 #include <Eigen/Core>
 #include <algorithm>
 #include <sophus/se3.hpp>
-#include <tsl/robin_map.h>
+#include <unordered_map>
 #include <vector>
 
 namespace rko_lio::core {
@@ -35,7 +35,7 @@ namespace rko_lio::core {
 
 std::vector<Eigen::Vector3d> voxel_down_sample(const std::vector<Eigen::Vector3d>& frame, const double voxel_size) {
   const double inv_voxel_size = 1.0 / voxel_size;
-  tsl::robin_map<Eigen::Vector3i, Eigen::Vector3d> grid;
+  std::unordered_map<Eigen::Vector3i, Eigen::Vector3d> grid;
   grid.reserve(frame.size());
   std::for_each(frame.cbegin(), frame.cend(),
                 [&](const auto& point) { grid.try_emplace(point_to_voxel(point, inv_voxel_size), point); });

--- a/rko_lio/core/voxel_down_sample.cpp
+++ b/rko_lio/core/voxel_down_sample.cpp
@@ -39,11 +39,11 @@ std::vector<Eigen::Vector3d> voxel_down_sample(const std::vector<Eigen::Vector3d
   grid.reserve(frame.size());
   std::for_each(frame.cbegin(), frame.cend(),
                 [&](const auto& point) { grid.try_emplace(point_to_voxel(point, inv_voxel_size), point); });
-  std::vector<Eigen::Vector3d> frame_dowsampled;
-  frame_dowsampled.reserve(grid.size());
+  std::vector<Eigen::Vector3d> frame_downsampled;
+  frame_downsampled.reserve(grid.size());
   std::for_each(grid.cbegin(), grid.cend(),
-                [&](const auto& voxel_and_point) { frame_dowsampled.emplace_back(voxel_and_point.second); });
-  return frame_dowsampled;
+                [&](const auto& voxel_and_point) { frame_downsampled.emplace_back(voxel_and_point.second); });
+  return frame_downsampled;
 }
 
 } // namespace rko_lio::core

--- a/rko_lio/core/voxel_down_sample.cpp
+++ b/rko_lio/core/voxel_down_sample.cpp
@@ -28,25 +28,17 @@
 #include <unordered_map>
 #include <vector>
 
-namespace {
-using Voxel = Eigen::Vector3i;
-
-inline Voxel PointToVoxel(const Eigen::Vector3d& point, const double voxel_size) {
-  return {static_cast<int>(std::floor(point.x() / voxel_size)), static_cast<int>(std::floor(point.y() / voxel_size)),
-          static_cast<int>(std::floor(point.z() / voxel_size))};
-}
-} // namespace
-
 namespace rko_lio::core {
 // if you need even better runtime-performance, consider using Luca Lobefaro's version of one cycle downsampling here:
 // https://github.com/PRBonn/kiss-icp/pull/347
 // although it does lead to worse odometry performance in certain situations
 
 std::vector<Eigen::Vector3d> voxel_down_sample(const std::vector<Eigen::Vector3d>& frame, const double voxel_size) {
-  std::unordered_map<Voxel, Eigen::Vector3d> grid;
+  const double inv_voxel_size = 1.0 / voxel_size;
+  std::unordered_map<Eigen::Vector3i, Eigen::Vector3d> grid;
   grid.reserve(frame.size());
   std::for_each(frame.cbegin(), frame.cend(),
-                [&](const auto& point) { grid.try_emplace(PointToVoxel(point, voxel_size), point); });
+                [&](const auto& point) { grid.try_emplace(point_to_voxel(point, inv_voxel_size), point); });
   std::vector<Eigen::Vector3d> frame_dowsampled;
   frame_dowsampled.reserve(grid.size());
   std::for_each(grid.cbegin(), grid.cend(),

--- a/rko_lio/core/voxel_down_sample.hpp
+++ b/rko_lio/core/voxel_down_sample.hpp
@@ -23,11 +23,18 @@
 #pragma once
 
 #include <Eigen/Core>
+#include <cmath>
 #include <sophus/se3.hpp>
 
 namespace rko_lio::core {
 /// Voxelize point cloud keeping the original coordinates
 std::vector<Eigen::Vector3d> voxel_down_sample(const std::vector<Eigen::Vector3d>& frame, const double voxel_size);
+
+inline Eigen::Vector3i point_to_voxel(const Eigen::Vector3d& point, const double inv_voxel_size) {
+  return {static_cast<int>(std::floor(point.x() * inv_voxel_size)),
+          static_cast<int>(std::floor(point.y() * inv_voxel_size)),
+          static_cast<int>(std::floor(point.z() * inv_voxel_size))};
+}
 } // namespace rko_lio::core
 
 template <>

--- a/rko_lio/core/voxel_hash_map.cpp
+++ b/rko_lio/core/voxel_hash_map.cpp
@@ -54,11 +54,6 @@ static const std::array<Voxel, 27> shifts{
     Voxel{1, 0, -1},   Voxel{1, 0, 0},   Voxel{1, 0, 1},  //
     Voxel{1, 1, -1},   Voxel{1, 1, 0},   Voxel{1, 1, 1}};
 
-inline Voxel point_to_voxel(const Eigen::Vector3d& point, const double inv_voxel_size) {
-  return Voxel(static_cast<int>(std::floor(point.x() * inv_voxel_size)),
-               static_cast<int>(std::floor(point.y() * inv_voxel_size)),
-               static_cast<int>(std::floor(point.z() * inv_voxel_size)));
-}
 } // namespace
 
 namespace rko_lio::core {

--- a/rko_lio/python/pybind/rko_lio_pybind.cpp
+++ b/rko_lio/python/pybind/rko_lio_pybind.cpp
@@ -66,7 +66,7 @@ PYBIND11_MODULE(rko_lio_pybind, m) {
       .def_readwrite("max_range", &LIO::Config::max_range)
       .def_readwrite("min_range", &LIO::Config::min_range)
       .def_readwrite("convergence_criterion", &LIO::Config::convergence_criterion)
-      .def_readwrite("max_correspondance_distance", &LIO::Config::max_correspondance_distance)
+      .def_readwrite("max_correspondence_distance", &LIO::Config::max_correspondence_distance)
       .def_readwrite("max_num_threads", &LIO::Config::max_num_threads)
       .def_readwrite("initialization_phase", &LIO::Config::initialization_phase)
       .def_readwrite("max_expected_jerk", &LIO::Config::max_expected_jerk)

--- a/rko_lio/python/rko_lio/cli.py
+++ b/rko_lio/python/rko_lio/cli.py
@@ -305,8 +305,6 @@ def cli(
             "Fatal: Could not obtain required IMU/Lidar extrinsics. Please specify in a config or as part of your data."
         )
 
-    from .util import transform_to_quat_xyzw_xyz
-
     print("Resolved extrinsics:")
     print("  IMU to Base:", pipeline_config.extrinsic_imu2base_quat_xyzw_xyz)
     print(

--- a/rko_lio/python/rko_lio/config.py
+++ b/rko_lio/python/rko_lio/config.py
@@ -117,7 +117,7 @@ class LIOConfig:
         Minimum usable range of lidar (meters).
     convergence_criterion : float, default 1e-5
         Convergence threshold for optimization.
-    max_correspondance_distance : float, default 0.5
+    max_correspondence_distance : float, default 0.5
         Max distance for associating points (meters).
     max_num_threads : int, default 0
         Max thread count (0 = autodetect).
@@ -138,7 +138,7 @@ class LIOConfig:
     max_range: float = 100.0
     min_range: float = 1.0
     convergence_criterion: float = 1e-5
-    max_correspondance_distance: float = 0.5
+    max_correspondence_distance: float = 0.5
     max_num_threads: int = 0
     initialization_phase: bool = False
     max_expected_jerk: float = 3.0

--- a/rko_lio/python/rko_lio/lio.py
+++ b/rko_lio/python/rko_lio/lio.py
@@ -99,6 +99,20 @@ class IntervalStats:
         return np.sqrt(self.accel_mag_variance())
 
 
+def _as_vec3(name: str, v: np.ndarray) -> np.ndarray:
+    arr = np.asarray(v, dtype=np.float64)
+    if arr.shape != (3,):
+        raise ValueError(f"{name}: expected shape (3,), got {arr.shape}")
+    return arr
+
+
+def _as_se3(name: str, T: np.ndarray) -> np.ndarray:
+    arr = np.asarray(T, dtype=np.float64)
+    if arr.shape != (4, 4):
+        raise ValueError(f"{name}: expected shape (4,4), got {arr.shape}")
+    return arr
+
+
 class LIO:
     def __init__(self, config: LIOConfig):
         self.config = config
@@ -126,20 +140,12 @@ class LIO:
         time: int,
         extrinsic_imu2base: np.ndarray | None = None,
     ):
-        acc = np.asarray(acceleration, dtype=np.float64)
-        gyro = np.asarray(angular_velocity, dtype=np.float64)
-        if acc.shape != (3,):
-            raise ValueError(f"acceleration: expected shape (3,), got {acc.shape}")
-        if gyro.shape != (3,):
-            raise ValueError(f"angular_velocity: expected shape (3,), got {gyro.shape}")
+        acc = _as_vec3("acceleration", acceleration)
+        gyro = _as_vec3("angular_velocity", angular_velocity)
         if extrinsic_imu2base is None:
             self._impl.add_imu_measurement(acc, gyro, int(time))
             return
-        extr = np.asarray(extrinsic_imu2base, dtype=np.float64)
-        if extr.shape != (4, 4):
-            raise ValueError(
-                f"extrinsic_imu2base: expected shape (4,4), got {extr.shape}"
-            )
+        extr = _as_se3("extrinsic_imu2base", extrinsic_imu2base)
         self._impl.add_imu_measurement(extr, acc, gyro, int(time))
 
     def register_scan(
@@ -161,11 +167,7 @@ class LIO:
         if extrinsic_lidar2base is None:
             ret_scan = self._impl.register_scan(scan_vec, time_vec)
             return np.asarray(ret_scan)
-        extr = np.asarray(extrinsic_lidar2base, dtype=np.float64)
-        if extr.shape != (4, 4):
-            raise ValueError(
-                f"extrinsic_lidar2base: expected shape (4,4), got {extr.shape}"
-            )
+        extr = _as_se3("extrinsic_lidar2base", extrinsic_lidar2base)
         ret_scan = self._impl.register_scan(extr, scan_vec, time_vec)
         return np.asarray(ret_scan)
 

--- a/rko_lio/python/rko_lio/lio.py
+++ b/rko_lio/python/rko_lio/lio.py
@@ -124,6 +124,7 @@ class LIO:
         acceleration: np.ndarray,
         angular_velocity: np.ndarray,
         time: int,
+        extrinsic_imu2base: np.ndarray | None = None,
     ):
         acc = np.asarray(acceleration, dtype=np.float64)
         gyro = np.asarray(angular_velocity, dtype=np.float64)
@@ -131,29 +132,22 @@ class LIO:
             raise ValueError(f"acceleration: expected shape (3,), got {acc.shape}")
         if gyro.shape != (3,):
             raise ValueError(f"angular_velocity: expected shape (3,), got {gyro.shape}")
-        self._impl.add_imu_measurement(acc, gyro, int(time))
-
-    def add_imu_measurement_with_extrinsic(
-        self,
-        extrinsic_imu2base: np.ndarray,
-        acceleration: np.ndarray,
-        angular_velocity: np.ndarray,
-        time: int,
-    ):
+        if extrinsic_imu2base is None:
+            self._impl.add_imu_measurement(acc, gyro, int(time))
+            return
         extr = np.asarray(extrinsic_imu2base, dtype=np.float64)
-        acc = np.asarray(acceleration, dtype=np.float64)
-        gyro = np.asarray(angular_velocity, dtype=np.float64)
         if extr.shape != (4, 4):
             raise ValueError(
                 f"extrinsic_imu2base: expected shape (4,4), got {extr.shape}"
             )
-        if acc.shape != (3,):
-            raise ValueError(f"acceleration: expected shape (3,), got {acc.shape}")
-        if gyro.shape != (3,):
-            raise ValueError(f"angular_velocity: expected shape (3,), got {gyro.shape}")
         self._impl.add_imu_measurement(extr, acc, gyro, int(time))
 
-    def register_scan(self, scan: np.ndarray, timestamps: np.ndarray):
+    def register_scan(
+        self,
+        scan: np.ndarray,
+        timestamps: np.ndarray,
+        extrinsic_lidar2base: np.ndarray | None = None,
+    ):
         scan_arr = np.asarray(scan, dtype=np.float64)
         times_arr = np.ascontiguousarray(np.asarray(timestamps), dtype=np.int64)
         if scan_arr.ndim != 2 or scan_arr.shape[1] != 3:
@@ -164,27 +158,14 @@ class LIO:
             )
         scan_vec = _Vector3dVector(scan_arr)
         time_vec = _VectorInt64(times_arr)
-        ret_scan = self._impl.register_scan(scan_vec, time_vec)
-        return np.asarray(ret_scan)
-
-    def register_scan_with_extrinsic(
-        self, extrinsic_lidar2base: np.ndarray, scan: np.ndarray, timestamps: np.ndarray
-    ):
+        if extrinsic_lidar2base is None:
+            ret_scan = self._impl.register_scan(scan_vec, time_vec)
+            return np.asarray(ret_scan)
         extr = np.asarray(extrinsic_lidar2base, dtype=np.float64)
-        scan_arr = np.asarray(scan, dtype=np.float64)
-        times_arr = np.ascontiguousarray(np.asarray(timestamps), dtype=np.int64)
         if extr.shape != (4, 4):
             raise ValueError(
                 f"extrinsic_lidar2base: expected shape (4,4), got {extr.shape}"
             )
-        if scan_arr.ndim != 2 or scan_arr.shape[1] != 3:
-            raise ValueError(f"scan: expected (N,3), got {scan_arr.shape}")
-        if times_arr.shape != (scan_arr.shape[0],):
-            raise ValueError(
-                f"timestamps: expected ({scan_arr.shape[0]},), got {times_arr.shape}"
-            )
-        scan_vec = _Vector3dVector(scan_arr)
-        time_vec = _VectorInt64(times_arr)
         ret_scan = self._impl.register_scan(extr, scan_vec, time_vec)
         return np.asarray(ret_scan)
 

--- a/rko_lio/python/rko_lio/lio_pipeline.py
+++ b/rko_lio/python/rko_lio/lio_pipeline.py
@@ -116,17 +116,12 @@ class LIOPipeline:
         angular_velocity : array of float, shape (3,)
             Angular velocity in rad/s.
         """
-        if self.extrinsic_imu2base is not None:
-            self.lio.add_imu_measurement_with_extrinsic(
-                self.extrinsic_imu2base,
-                time=time,
-                acceleration=acceleration,
-                angular_velocity=angular_velocity,
-            )
-        else:
-            self.lio.add_imu_measurement(
-                time=time, acceleration=acceleration, angular_velocity=angular_velocity
-            )
+        self.lio.add_imu_measurement(
+            acceleration=acceleration,
+            angular_velocity=angular_velocity,
+            time=time,
+            extrinsic_imu2base=self.extrinsic_imu2base,
+        )
 
         if self.config.viz:
             self.rerun.set_time("data_time", timestamp=time * 1e-9)
@@ -173,17 +168,11 @@ class LIOPipeline:
             log_vector(self.rerun, "imu/avg_ang_velocity", stats.avg_ang_vel())
 
         try:
-            if self.extrinsic_lidar2base is not None:
-                deskewed_scan = self.lio.register_scan_with_extrinsic(
-                    self.extrinsic_lidar2base,
-                    scan,
-                    timestamps,
-                )
-            else:
-                deskewed_scan = self.lio.register_scan(
-                    scan,
-                    timestamps,
-                )
+            deskewed_scan = self.lio.register_scan(
+                scan,
+                timestamps,
+                extrinsic_lidar2base=self.extrinsic_lidar2base,
+            )
         except ValueError as e:
             print(
                 "ERROR: Dropping LiDAR frame as there was an error. Odometry might suffer. Error:",

--- a/rko_lio/ros/base_node.cpp
+++ b/rko_lio/ros/base_node.cpp
@@ -45,7 +45,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LIO::Config,
                                    max_range,
                                    min_range,
                                    convergence_criterion,
-                                   max_correspondance_distance,
+                                   max_correspondence_distance,
                                    max_num_threads,
                                    initialization_phase,
                                    max_expected_jerk,
@@ -118,8 +118,8 @@ BaseNode::BaseNode(const std::string& node_name, const rclcpp::NodeOptions& opti
   lio_config.min_range = node->declare_parameter<double>("min_range", lio_config.min_range);
   lio_config.convergence_criterion =
       node->declare_parameter<double>("convergence_criterion", lio_config.convergence_criterion);
-  lio_config.max_correspondance_distance =
-      node->declare_parameter<double>("max_correspondance_distance", lio_config.max_correspondance_distance);
+  lio_config.max_correspondence_distance =
+      node->declare_parameter<double>("max_correspondence_distance", lio_config.max_correspondence_distance);
   lio_config.max_num_threads =
       static_cast<int>(node->declare_parameter<int>("max_num_threads", lio_config.max_num_threads));
   lio_config.initialization_phase =

--- a/rko_lio/ros/base_node.cpp
+++ b/rko_lio/ros/base_node.cpp
@@ -258,21 +258,22 @@ void BaseNode::publish_lidar_outputs(const core::Vector3dVector& deskewed_frame,
     header.stamp = utils::to_ros_time(stamp);
     frame_publisher->publish(utils::eigen_to_point_cloud2(deskewed_frame, header));
   }
-  publish_odometry(lio->lidar_state, stamp);
+  publish_odometry(lio->lidar_state, odom_publisher);
   if (publish_lidar_acceleration) {
     publish_lidar_accel(lio->lidar_state.linear_acceleration, stamp);
   }
 }
 
-void BaseNode::publish_odometry(const core::State& state, const core::Nsec stamp) const {
+void BaseNode::publish_odometry(const core::State& state,
+                                const rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr& publisher) const {
   nav_msgs::msg::Odometry odom_msg;
-  odom_msg.header.stamp = utils::to_ros_time(stamp);
+  odom_msg.header.stamp = utils::to_ros_time(state.time);
   odom_msg.header.frame_id = odom_frame;
   odom_msg.child_frame_id = base_frame;
   odom_msg.pose.pose = utils::sophus_to_pose(state.pose);
   utils::eigen_vector3d_to_ros_xyz(state.velocity, odom_msg.twist.twist.linear);
   utils::eigen_vector3d_to_ros_xyz(state.angular_velocity, odom_msg.twist.twist.angular);
-  odom_publisher->publish(odom_msg);
+  publisher->publish(odom_msg);
 }
 
 void BaseNode::publish_tf(const Sophus::SE3d& pose, const core::Nsec stamp) const {

--- a/rko_lio/ros/base_node.cpp
+++ b/rko_lio/ros/base_node.cpp
@@ -251,16 +251,16 @@ core::Vector3dVector BaseNode::register_scan_locked(const core::Vector3dVector& 
   return lio->register_scan(extrinsic_lidar2base, scan, time_vector);
 }
 
-void BaseNode::publish_lidar_outputs(const core::Vector3dVector& deskewed_frame, const core::Nsec stamp) const {
+void BaseNode::publish_lidar_outputs(const core::Vector3dVector& deskewed_frame) const {
   if (publish_deskewed_scan) {
     std_msgs::msg::Header header;
     header.frame_id = lidar_frame;
-    header.stamp = utils::to_ros_time(stamp);
+    header.stamp = utils::to_ros_time(lio->lidar_state.time);
     frame_publisher->publish(utils::eigen_to_point_cloud2(deskewed_frame, header));
   }
   publish_odometry(lio->lidar_state, odom_publisher);
   if (publish_lidar_acceleration) {
-    publish_lidar_accel(lio->lidar_state.linear_acceleration, stamp);
+    publish_lidar_accel(lio->lidar_state);
   }
 }
 
@@ -276,26 +276,26 @@ void BaseNode::publish_odometry(const core::State& state,
   publisher->publish(odom_msg);
 }
 
-void BaseNode::publish_tf(const Sophus::SE3d& pose, const core::Nsec stamp) const {
+void BaseNode::publish_tf(const core::State& state) const {
   geometry_msgs::msg::TransformStamped transform_msg;
-  transform_msg.header.stamp = utils::to_ros_time(stamp);
+  transform_msg.header.stamp = utils::to_ros_time(state.time);
   if (invert_odom_tf) {
     transform_msg.header.frame_id = base_frame;
     transform_msg.child_frame_id = odom_frame;
-    transform_msg.transform = utils::sophus_to_transform(pose.inverse());
+    transform_msg.transform = utils::sophus_to_transform(state.pose.inverse());
   } else {
     transform_msg.header.frame_id = odom_frame;
     transform_msg.child_frame_id = base_frame;
-    transform_msg.transform = utils::sophus_to_transform(pose);
+    transform_msg.transform = utils::sophus_to_transform(state.pose);
   }
   tf_broadcaster->sendTransform(transform_msg);
 }
 
-void BaseNode::publish_lidar_accel(const Eigen::Vector3d& acceleration, const core::Nsec stamp) const {
+void BaseNode::publish_lidar_accel(const core::State& state) const {
   auto accel_msg = geometry_msgs::msg::AccelStamped();
-  accel_msg.header.stamp = utils::to_ros_time(stamp);
+  accel_msg.header.stamp = utils::to_ros_time(state.time);
   accel_msg.header.frame_id = base_frame;
-  utils::eigen_vector3d_to_ros_xyz(acceleration, accel_msg.accel.linear);
+  utils::eigen_vector3d_to_ros_xyz(state.linear_acceleration, accel_msg.accel.linear);
   lidar_accel_publisher->publish(accel_msg);
 }
 

--- a/rko_lio/ros/base_node.cpp
+++ b/rko_lio/ros/base_node.cpp
@@ -196,6 +196,21 @@ void BaseNode::parse_cli_extrinsics() {
   extrinsics_set = imu_ok && lidar_ok;
 }
 
+bool BaseNode::ensure_frame_and_extrinsics(std::string& target_frame,
+                                           const std::string& msg_frame,
+                                           std::string_view kind) {
+  if (target_frame.empty()) {
+    if (msg_frame.empty() && !extrinsics_set) {
+      throw std::runtime_error(std::string(kind) +
+                               " message header has no frame id and we need it to query TF for the extrinsics. "
+                               "Either specify the frame id or the extrinsic manually.");
+    }
+    target_frame = msg_frame;
+    RCLCPP_INFO_STREAM(node->get_logger(), "Parsed the " << kind << " frame id as: " << target_frame);
+  }
+  return check_and_set_extrinsics();
+}
+
 bool BaseNode::check_and_set_extrinsics() {
   if (extrinsics_set) {
     return true;

--- a/rko_lio/ros/base_node.hpp
+++ b/rko_lio/ros/base_node.hpp
@@ -31,6 +31,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <tuple>
 // ros
@@ -100,6 +101,13 @@ public:
 
   void parse_cli_extrinsics();
   bool check_and_set_extrinsics();
+
+  // Parse the message's frame_id into target_frame on first sight, throw if neither header nor static extrinsics
+  // are usable, and report whether extrinsics are now set. Extrinsics are assumed static; if they change, switch
+  // to querying TF inline per-message.
+  bool ensure_frame_and_extrinsics(std::string& target_frame,
+                                   const std::string& msg_frame,
+                                   std::string_view kind);
 
   std::tuple<core::Timestamps, core::Vector3dVector>
   process_lidar_msg(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& lidar_msg) const;

--- a/rko_lio/ros/base_node.hpp
+++ b/rko_lio/ros/base_node.hpp
@@ -114,12 +114,12 @@ public:
 
   core::Vector3dVector register_scan_locked(const core::Vector3dVector& scan, const core::TimestampVector& time_vector);
 
-  void publish_lidar_outputs(const core::Vector3dVector& deskewed_frame, const core::Nsec stamp) const;
+  void publish_lidar_outputs(const core::Vector3dVector& deskewed_frame) const;
 
   void publish_odometry(const core::State& state,
                         const rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr& publisher) const;
-  void publish_tf(const Sophus::SE3d& pose, const core::Nsec stamp) const;
-  void publish_lidar_accel(const Eigen::Vector3d& acceleration, const core::Nsec stamp) const;
+  void publish_tf(const core::State& state) const;
+  void publish_lidar_accel(const core::State& state) const;
   void publish_map_loop();
   void dump_results_to_disk(const std::filesystem::path& results_dir, const std::string& run_name) const;
 

--- a/rko_lio/ros/base_node.hpp
+++ b/rko_lio/ros/base_node.hpp
@@ -116,7 +116,8 @@ public:
 
   void publish_lidar_outputs(const core::Vector3dVector& deskewed_frame, const core::Nsec stamp) const;
 
-  void publish_odometry(const core::State& state, const core::Nsec stamp) const;
+  void publish_odometry(const core::State& state,
+                        const rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr& publisher) const;
   void publish_tf(const Sophus::SE3d& pose, const core::Nsec stamp) const;
   void publish_lidar_accel(const Eigen::Vector3d& acceleration, const core::Nsec stamp) const;
   void publish_map_loop();

--- a/rko_lio/ros/offline_node.cpp
+++ b/rko_lio/ros/offline_node.cpp
@@ -38,27 +38,6 @@ std::shared_ptr<T> deserialize_next_msg(const rclcpp::SerializedMessage& seriali
 }
 
 using BagProgressPublisher = rclcpp::Publisher<std_msgs::msg::Float32MultiArray>;
-void publish_bag_progress(const BagProgressPublisher::SharedPtr& publisher,
-                          const size_t processed_bag_msgs,
-                          const size_t total_bag_msgs) {
-  if (total_bag_msgs == 0) {
-    return;
-  }
-  static const auto start_time = std::chrono::steady_clock::now();
-  const auto now = std::chrono::steady_clock::now();
-  const float elapsed_seconds = std::chrono::duration<float>(now - start_time).count();
-
-  const float percent_complete = 100.0F * processed_bag_msgs / total_bag_msgs;
-  const float avg_time_per_msg = (processed_bag_msgs > 0) ? elapsed_seconds / processed_bag_msgs : 0.0F;
-  const float seconds_remaining = avg_time_per_msg * (total_bag_msgs - processed_bag_msgs);
-
-  std_msgs::msg::Float32MultiArray progress_msg;
-  progress_msg.data.resize(2);
-  progress_msg.data[0] = percent_complete;
-  progress_msg.data[1] = seconds_remaining;
-
-  publisher->publish(progress_msg);
-}
 } // namespace
 
 namespace rko_lio::ros {
@@ -70,8 +49,10 @@ public:
 
   float total_bag_msgs = 0;
   float processed_bag_msgs = 0;
+  std::chrono::steady_clock::time_point bag_start_time;
 
-  explicit OfflineNode(const rclcpp::NodeOptions& options) : ThreadedNode("rko_lio_offline_node", options) {
+  explicit OfflineNode(const rclcpp::NodeOptions& options)
+      : ThreadedNode("rko_lio_offline_node", options), bag_start_time(std::chrono::steady_clock::now()) {
     // bag reading
     const tf2::Duration skip_to_time = tf2::durationFromSec(node->declare_parameter<double>("skip_to_time", 0.0));
     bag = std::make_unique<utils::BufferableBag>(node->declare_parameter<std::string>("bag_path"),
@@ -79,6 +60,24 @@ public:
                                                  std::vector<std::string>{imu_topic, lidar_topic}, skip_to_time);
     total_bag_msgs = bag->message_count();
     bag_progress_publisher = node->create_publisher<std_msgs::msg::Float32MultiArray>("rko_lio/bag_progress", 10);
+  }
+
+  void publish_bag_progress() const {
+    const auto now = std::chrono::steady_clock::now();
+    const float elapsed_seconds = std::chrono::duration<float>(now - bag_start_time).count();
+
+    const float percent_complete = 100.0F * processed_bag_msgs / total_bag_msgs;
+    const float avg_time_per_msg = (processed_bag_msgs > 0) ? elapsed_seconds / processed_bag_msgs : 0.0F;
+    const float seconds_remaining = avg_time_per_msg * (total_bag_msgs - processed_bag_msgs);
+
+    std_msgs::msg::Float32MultiArray progress_msg;
+    progress_msg.layout.dim.resize(1);
+    progress_msg.layout.dim[0].label = "percent_complete,seconds_remaining";
+    progress_msg.layout.dim[0].size = 2;
+    progress_msg.layout.dim[0].stride = 2;
+    progress_msg.data = {percent_complete, seconds_remaining};
+
+    bag_progress_publisher->publish(progress_msg);
   }
 
   void run() {
@@ -108,7 +107,7 @@ public:
       }
 
       processed_bag_msgs++;
-      publish_bag_progress(bag_progress_publisher, processed_bag_msgs, total_bag_msgs);
+      publish_bag_progress();
     }
     while (rclcpp::ok()) {
       {

--- a/rko_lio/ros/online_imu_rate_node.cpp
+++ b/rko_lio/ros/online_imu_rate_node.cpp
@@ -83,15 +83,7 @@ public:
   }
 
   void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr& imu_msg) {
-    if (imu_frame.empty()) {
-      if (imu_msg->header.frame_id.empty() && !extrinsics_set) {
-        throw std::runtime_error("IMU message header has no frame id and we need it to query TF for the extrinsics. "
-                                 "Either specify the frame id or the extrinsic manually.");
-      }
-      imu_frame = imu_msg->header.frame_id;
-      RCLCPP_INFO_STREAM(node->get_logger(), "Parsed the imu frame id as: " << imu_frame);
-    }
-    if (!check_and_set_extrinsics()) {
+    if (!ensure_frame_and_extrinsics(imu_frame, imu_msg->header.frame_id, "IMU")) {
       return;
     }
 
@@ -111,15 +103,7 @@ public:
   }
 
   void lidar_callback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& lidar_msg) {
-    if (lidar_frame.empty()) {
-      if (lidar_msg->header.frame_id.empty() && !extrinsics_set) {
-        throw std::runtime_error("LiDAR message header has no frame id and we need it to query TF for the extrinsics. "
-                                 "Either specify the frame id or the extrinsic manually.");
-      }
-      lidar_frame = lidar_msg->header.frame_id;
-      RCLCPP_INFO_STREAM(node->get_logger(), "Parsed the lidar frame id as: " << lidar_frame);
-    }
-    if (!check_and_set_extrinsics()) {
+    if (!ensure_frame_and_extrinsics(lidar_frame, lidar_msg->header.frame_id, "LiDAR")) {
       return;
     }
 

--- a/rko_lio/ros/online_imu_rate_node.cpp
+++ b/rko_lio/ros/online_imu_rate_node.cpp
@@ -98,7 +98,7 @@ public:
     }
     publish_odometry(lio->imu_state, odom_at_imu_rate_publisher);
     if (tf_at_imu_rate) {
-      publish_tf(lio->imu_state.pose, lio->imu_state.time);
+      publish_tf(lio->imu_state);
     }
   }
 
@@ -114,8 +114,8 @@ public:
         // first frame is skipped and an empty frame is returned. nothing to publish.
         return;
       }
-      publish_lidar_outputs(deskewed_frame, timestamps.max);
-      publish_tf(lio->lidar_state.pose, timestamps.max);
+      publish_lidar_outputs(deskewed_frame);
+      publish_tf(lio->lidar_state);
     } catch (const std::invalid_argument& ex) {
       RCLCPP_ERROR_STREAM(node->get_logger(), "Encountered error, dropping frame. Error: " << ex.what());
     }

--- a/rko_lio/ros/online_imu_rate_node.cpp
+++ b/rko_lio/ros/online_imu_rate_node.cpp
@@ -96,7 +96,7 @@ public:
       // leaves imu_state.time at zero in that pre-init phase.
       return;
     }
-    publish_imu_rate_odometry(lio->imu_state);
+    publish_odometry(lio->imu_state, odom_at_imu_rate_publisher);
     if (tf_at_imu_rate) {
       publish_tf(lio->imu_state.pose, lio->imu_state.time);
     }
@@ -121,16 +121,6 @@ public:
     }
   }
 
-  void publish_imu_rate_odometry(const core::State& state) const {
-    nav_msgs::msg::Odometry msg;
-    msg.header.stamp = utils::to_ros_time(state.time);
-    msg.header.frame_id = odom_frame;
-    msg.child_frame_id = base_frame;
-    msg.pose.pose = utils::sophus_to_pose(state.pose);
-    utils::eigen_vector3d_to_ros_xyz(state.velocity, msg.twist.twist.linear);
-    utils::eigen_vector3d_to_ros_xyz(state.angular_velocity, msg.twist.twist.angular);
-    odom_at_imu_rate_publisher->publish(msg);
-  }
 };
 
 } // namespace rko_lio::ros

--- a/rko_lio/ros/threaded_node.cpp
+++ b/rko_lio/ros/threaded_node.cpp
@@ -109,8 +109,8 @@ void ThreadedNode::registration_loop() {
       const core::Vector3dVector deskewed_frame = register_scan_locked(scan, time_vector);
       if (!deskewed_frame.empty()) {
         // TODO: first frame is skipped and an empty frame is returned. improve how we handle this
-        publish_lidar_outputs(deskewed_frame, end_stamp);
-        publish_tf(lio->lidar_state.pose, end_stamp);
+        publish_lidar_outputs(deskewed_frame);
+        publish_tf(lio->lidar_state);
       }
     } catch (const std::invalid_argument& ex) {
       RCLCPP_ERROR_STREAM(node->get_logger(), "Encountered error, dropping frame. Error: " << ex.what());

--- a/rko_lio/ros/threaded_node.cpp
+++ b/rko_lio/ros/threaded_node.cpp
@@ -42,17 +42,7 @@ ThreadedNode::ThreadedNode(const std::string& node_name, const rclcpp::NodeOptio
 }
 
 void ThreadedNode::imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr& imu_msg) {
-  if (imu_frame.empty()) {
-    if (imu_msg->header.frame_id.empty() && !extrinsics_set) {
-      throw std::runtime_error("IMU message header has no frame id and we need it to query TF for the extrinsics. "
-                               "Either specify the frame id or the extrinsic manually.");
-    }
-    imu_frame = imu_msg->header.frame_id;
-    RCLCPP_INFO_STREAM(node->get_logger(), "Parsed the imu frame id as: " << imu_frame);
-  }
-  if (!check_and_set_extrinsics()) {
-    // we assume that extrinsics are static. if they change, its better to query the tf directly in the registration
-    // loop for each message being processed asynchronously.
+  if (!ensure_frame_and_extrinsics(imu_frame, imu_msg->header.frame_id, "IMU")) {
     return;
   }
   {
@@ -66,15 +56,7 @@ void ThreadedNode::imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr& imu
 }
 
 void ThreadedNode::lidar_callback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& lidar_msg) {
-  if (lidar_frame.empty()) {
-    if (lidar_msg->header.frame_id.empty() && !extrinsics_set) {
-      throw std::runtime_error("LiDAR message header has no frame id and we need it to query TF for the extrinsics. "
-                               "Either specify the frame id or the extrinsic manually.");
-    }
-    lidar_frame = lidar_msg->header.frame_id;
-    RCLCPP_INFO_STREAM(node->get_logger(), "Parsed the lidar frame id as: " << lidar_frame);
-  }
-  if (!check_and_set_extrinsics()) {
+  if (!ensure_frame_and_extrinsics(lidar_frame, lidar_msg->header.frame_id, "LiDAR")) {
     return;
   }
   {

--- a/tests/core/test_preprocess_scan.cpp
+++ b/tests/core/test_preprocess_scan.cpp
@@ -76,10 +76,9 @@ TEST_CASE("preprocess_scan: double_downsample = false -> no map_frame", "[prepro
   }
 
   const auto result = preprocess_scan(frame, cfg);
-  REQUIRE_FALSE(result.map_frame.has_value());
+  REQUIRE(result.map_frame.empty());
   REQUIRE(result.keypoints.size() > 0);
   REQUIRE(result.filtered_frame.size() == frame.size());
-  REQUIRE(result.map_update_frame().size() == result.keypoints.size());
 }
 
 TEST_CASE("preprocess_scan: double_downsample = true -> all three populated", "[preprocess_scan]") {
@@ -94,9 +93,8 @@ TEST_CASE("preprocess_scan: double_downsample = true -> all three populated", "[
   }
 
   const auto result = preprocess_scan(frame, cfg);
-  REQUIRE(result.map_frame.has_value());
-  REQUIRE(result.map_frame->size() >= result.keypoints.size());
+  REQUIRE_FALSE(result.map_frame.empty());
+  REQUIRE(result.map_frame.size() >= result.keypoints.size());
   REQUIRE(result.filtered_frame.size() == frame.size());
-  REQUIRE(result.map_update_frame().size() == result.map_frame->size());
 }
 


### PR DESCRIPTION
should not be behaviour changing but just negative LoC and a bit simpler overall.
a few api changes, and a major one is the mistake i made with using "correspondance" before instead of "correspondence". please excuse the embarassing mistake...

the commit titles cover all the minor changes.

and the revert pertains to an upcoming pr on the voxel down sampling