### PR TITLE
Reject empty input vectors instead of dereferencing end()

### DIFF
--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -406,6 +406,9 @@ void LIO::add_imu_measurement(const Sophus::SE3d& extrinsic_imu2base, const ImuC
 // ============================ lidar ===============================
 
 Vector3dVector LIO::register_scan(const Vector3dVector& scan, const TimestampVector& timestamps) {
+  if (timestamps.empty()) {
+    throw std::invalid_argument("LIO::register_scan: timestamps must not be empty.");
+  }
   // TODO: redundant max compute as its available after process_timestamps
   const Nsec current_lidar_time = *std::max_element(timestamps.cbegin(), timestamps.cend());
 

--- a/rko_lio/core/process_timestamps.cpp
+++ b/rko_lio/core/process_timestamps.cpp
@@ -77,6 +77,9 @@ namespace rko_lio::core {
 Timestamps process_timestamps(const std::vector<double>& raw_timestamps,
                               const Nsec header_stamp,
                               const TimestampProcessingConfig& config) {
+  if (raw_timestamps.empty()) {
+    throw std::invalid_argument("process_timestamps: raw_timestamps must not be empty.");
+  }
   Timestamps timestamps = timestamps_from_raw(raw_timestamps, config.multiplier_to_seconds);
 
   const bool absolute_stamps = config.force_absolute || (std::chrono::abs(header_stamp - timestamps.min) < 1ms) ||

--- a/tests/core/test_process_timestamps.cpp
+++ b/tests/core/test_process_timestamps.cpp
@@ -133,3 +133,11 @@ TEST_CASE("process_timestamps: ambiguous case throws", "[process_timestamps]") {
   const Nsec header = ns_from_seconds(1000.0);
   REQUIRE_THROWS_AS(process_timestamps(raw, header, {}), std::runtime_error);
 }
+
+TEST_CASE("process_timestamps: empty raw_timestamps throws instead of UB", "[process_timestamps]") {
+  // Regression: previously timestamps_from_raw called std::minmax_element on an
+  // empty range and dereferenced end(), which is undefined behaviour.
+  const std::vector<double> empty;
+  const Nsec header = ns_from_seconds(1234.0);
+  REQUIRE_THROWS_AS(process_timestamps(empty, header, {}), std::invalid_argument);
+}

--- a/tests/core/test_process_timestamps.cpp
+++ b/tests/core/test_process_timestamps.cpp
@@ -135,8 +135,6 @@ TEST_CASE("process_timestamps: ambiguous case throws", "[process_timestamps]") {
 }
 
 TEST_CASE("process_timestamps: empty raw_timestamps throws instead of UB", "[process_timestamps]") {
-  // Regression: previously timestamps_from_raw called std::minmax_element on an
-  // empty range and dereferenced end(), which is undefined behaviour.
   const std::vector<double> empty;
   const Nsec header = ns_from_seconds(1234.0);
   REQUIRE_THROWS_AS(process_timestamps(empty, header, {}), std::invalid_argument);

--- a/tests/core/test_register_scan.cpp
+++ b/tests/core/test_register_scan.cpp
@@ -28,6 +28,7 @@
 #include <cmath>
 #include <cstdint>
 #include <random>
+#include <stdexcept>
 
 using rko_lio::core::GRAVITY_MAG;
 using rko_lio::core::ImuControl;
@@ -319,4 +320,13 @@ TEST_CASE("Noisy: full SE(3) translation + rotation", "[register_scan][!mayfail]
   CAPTURE(lio.lidar_state.pose.translation().transpose(),
           lio.lidar_state.pose.so3().log().transpose());
   CHECK(approx_equal(lio.lidar_state.pose, T_expected, 1e-2));
+}
+
+TEST_CASE("register_scan: empty timestamps throws instead of UB", "[register_scan]") {
+  // Regression: previously `*std::max_element(timestamps.cbegin(), timestamps.cend())`
+  // dereferenced end() on an empty vector, which is undefined behaviour.
+  LIO lio((LIO::Config{}));
+  const auto cloud = make_hollow_cube();
+  const TimestampVector empty_timestamps;
+  REQUIRE_THROWS_AS(lio.register_scan(cloud, empty_timestamps), std::invalid_argument);
 }

--- a/tests/core/test_register_scan.cpp
+++ b/tests/core/test_register_scan.cpp
@@ -323,8 +323,6 @@ TEST_CASE("Noisy: full SE(3) translation + rotation", "[register_scan][!mayfail]
 }
 
 TEST_CASE("register_scan: empty timestamps throws instead of UB", "[register_scan]") {
-  // Regression: previously `*std::max_element(timestamps.cbegin(), timestamps.cend())`
-  // dereferenced end() on an empty vector, which is undefined behaviour.
   LIO lio((LIO::Config{}));
   const auto cloud = make_hollow_cube();
   const TimestampVector empty_timestamps;


### PR DESCRIPTION
## Summary

Two public entry points in `rko_lio::core` dereference iterators returned by `std::max_element` / `std::minmax_element` on caller-provided vectors without first checking that the vectors are non-empty.

Calling either function with an empty vector is undefined behavior:

- `LIO::register_scan` (`rko_lio/core/lio.cpp`) dereferences `*std::max_element(timestamps.cbegin(), timestamps.cend())` on the `timestamps` argument.
- `process_timestamps` (`rko_lio/core/process_timestamps.cpp`), via the file-local `timestamps_from_raw`, dereferences `*min_it` and `*max_it` after `std::minmax_element` on `raw_timestamps`.

Both paths are reachable from real ROS message handling. An empty `PointCloud2`, or one missing a usable time field, can propagate into these functions. Instead of a clear validation error, the process hits undefined behavior and typically crashes inside a templated reduction path with a stack trace that does not point at the actual cause.

## Fix

Validate inputs at the public entry points and throw `std::invalid_argument` with descriptive messages.

This matches the convention already used in `LIO::register_scan` for other input-validation cases.

```diff
 Vector3dVector LIO::register_scan(
     const Vector3dVector& scan,
     const TimestampVector& timestamps) {
+  if (timestamps.empty()) {
+    throw std::invalid_argument("LIO::register_scan: timestamps must not be empty.");
+  }
+
   const Nsec current_lidar_time =
       *std::max_element(timestamps.cbegin(), timestamps.cend());

 Timestamps process_timestamps(
     const std::vector<double>& raw_timestamps,
     const Nsec header_stamp,
     const TimestampProcessingConfig& config) {
+  if (raw_timestamps.empty()) {
+    throw std::invalid_argument("process_timestamps: raw_timestamps must not be empty.");
+  }
+
   Timestamps timestamps =
       timestamps_from_raw(raw_timestamps, config.multiplier_to_seconds);
```

## Tests

Adds two regression tests using the existing Catch2 setup:

- `tests/core/test_register_scan.cpp`
  - `register_scan`: empty `timestamps` throws instead of triggering undefined behavior.
- `tests/core/test_process_timestamps.cpp`
  - `process_timestamps`: empty `raw_timestamps` throws instead of triggering undefined behavior.

Both tests use `REQUIRE_THROWS_AS(..., std::invalid_argument)`, consistent with the existing `process_timestamps` ambiguous-case test.

## Compatibility

- No public API or wire-format change.
- No new production includes are required; `<stdexcept>` was already included in both source files.
- `test_register_scan.cpp` adds `<stdexcept>` for `std::invalid_argument`.
- Behavior changes only for previously undefined calls: those now produce a recoverable exception instead of crashing.
