### PR TITLE
core: improved voxel down sampling, use robin set, explicit hash sorting

### DIFF
--- a/rko_lio/core/preprocess_scan.cpp
+++ b/rko_lio/core/preprocess_scan.cpp
@@ -16,7 +16,9 @@ PreprocessingResult preprocess_scan(const Vector3dVector& frame, const LIO::Conf
   clipped_frame.shrink_to_fit();
 
   if (config.double_downsample) {
-    Vector3dVector downsampled_frame = voxel_down_sample(clipped_frame, config.voxel_size * 0.5);
+    // pass 1 feeds pass 2, and sorting (shuffling) breaks lidar scan pattern leading to improved registration
+    Vector3dVector downsampled_frame = voxel_down_sample_sorted(clipped_frame, config.voxel_size * 0.5);
+    // pass 2 feeds icp, so unsorted is fine.
     Vector3dVector keypoints = voxel_down_sample(downsampled_frame, config.voxel_size * 1.5);
     return {.filtered_frame = std::move(clipped_frame),
             .keypoints = std::move(keypoints),

--- a/rko_lio/core/voxel_down_sample.cpp
+++ b/rko_lio/core/voxel_down_sample.cpp
@@ -24,25 +24,50 @@
 #include "voxel_down_sample.hpp"
 #include <Eigen/Core>
 #include <algorithm>
-#include <sophus/se3.hpp>
-#include <unordered_map>
+#include <cstddef>
+#include <functional>
+#include <tsl/robin_set.h>
+#include <utility>
 #include <vector>
 
 namespace rko_lio::core {
-// if you need even better runtime-performance, consider using Luca Lobefaro's version of one cycle downsampling here:
-// https://github.com/PRBonn/kiss-icp/pull/347
-// although it does lead to worse odometry performance in certain situations
 
 std::vector<Eigen::Vector3d> voxel_down_sample(const std::vector<Eigen::Vector3d>& frame, const double voxel_size) {
   const double inv_voxel_size = 1.0 / voxel_size;
-  std::unordered_map<Eigen::Vector3i, Eigen::Vector3d> grid;
-  grid.reserve(frame.size());
-  std::for_each(frame.cbegin(), frame.cend(),
-                [&](const auto& point) { grid.try_emplace(point_to_voxel(point, inv_voxel_size), point); });
+  tsl::robin_set<Eigen::Vector3i> seen;
+  seen.reserve(frame.size());
   std::vector<Eigen::Vector3d> frame_downsampled;
-  frame_downsampled.reserve(grid.size());
-  std::for_each(grid.cbegin(), grid.cend(),
-                [&](const auto& voxel_and_point) { frame_downsampled.emplace_back(voxel_and_point.second); });
+  frame_downsampled.reserve(frame.size());
+  for (const auto& point : frame) {
+    if (seen.insert(point_to_voxel(point, inv_voxel_size)).second) {
+      frame_downsampled.emplace_back(point);
+    }
+  }
+  return frame_downsampled;
+}
+
+std::vector<Eigen::Vector3d> voxel_down_sample_sorted(const std::vector<Eigen::Vector3d>& frame,
+                                                     const double voxel_size) {
+  const double inv_voxel_size = 1.0 / voxel_size;
+  tsl::robin_set<Eigen::Vector3i> seen;
+  seen.reserve(frame.size());
+  std::vector<std::pair<std::size_t, Eigen::Vector3d>> hashed;
+  hashed.reserve(frame.size());
+  const std::hash<Eigen::Vector3i> hasher{};
+  for (const auto& point : frame) {
+    const auto voxel = point_to_voxel(point, inv_voxel_size);
+    if (seen.insert(voxel).second) {
+      hashed.emplace_back(hasher(voxel), point);
+    }
+  }
+  std::sort(hashed.begin(), hashed.end(),
+            [](const auto& a, const auto& b) { return a.first < b.first; });
+
+  std::vector<Eigen::Vector3d> frame_downsampled;
+  frame_downsampled.reserve(hashed.size());
+  for (auto& [_, v] : hashed) {
+    frame_downsampled.emplace_back(std::move(v));
+  }
   return frame_downsampled;
 }
 

--- a/rko_lio/core/voxel_down_sample.hpp
+++ b/rko_lio/core/voxel_down_sample.hpp
@@ -27,8 +27,15 @@
 #include <sophus/se3.hpp>
 
 namespace rko_lio::core {
-/// Voxelize point cloud keeping the original coordinates
+// single cycle voxel downsample, see https://github.com/PRBonn/kiss-icp/pull/347
 std::vector<Eigen::Vector3d> voxel_down_sample(const std::vector<Eigen::Vector3d>& frame, const double voxel_size);
+
+// like voxel_down_sample but output sorted by hash(voxel). used when the output feeds another downsample pass.
+// the spatial hash scatters adjacent voxels far apart, so the next pass's first-write-wins per voxel sees a
+// diverse pick of points instead of one biased by the lidar sweep order, essentially breaking that regular pattern.
+// leads to an improvement in registration performance, see https://github.com/PRBonn/rko_lio/pull/136
+std::vector<Eigen::Vector3d> voxel_down_sample_sorted(const std::vector<Eigen::Vector3d>& frame,
+                                                      const double voxel_size);
 
 inline Eigen::Vector3i point_to_voxel(const Eigen::Vector3d& point, const double inv_voxel_size) {
   return {static_cast<int>(std::floor(point.x() * inv_voxel_size)),

--- a/tests/core/test_voxel_down_sample.cpp
+++ b/tests/core/test_voxel_down_sample.cpp
@@ -23,11 +23,15 @@
 #include "rko_lio/core/voxel_down_sample.hpp"
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
+#include <cstddef>
+#include <functional>
 #include <set>
 #include <tuple>
 #include <vector>
 
+using rko_lio::core::point_to_voxel;
 using rko_lio::core::voxel_down_sample;
+using rko_lio::core::voxel_down_sample_sorted;
 
 namespace {
 std::set<std::tuple<int, int, int>> as_voxel_set(const std::vector<Eigen::Vector3d>& points, double voxel_size) {
@@ -83,4 +87,35 @@ TEST_CASE("voxel_down_sample: doubling voxel size collapses points", "[voxel_dow
   const auto large = voxel_down_sample(points, 1.0);
   REQUIRE(small.size() == 2);
   REQUIRE(large.size() == 1);
+}
+
+TEST_CASE("voxel_down_sample_sorted: empty input -> empty output", "[voxel_down_sample_sorted]") {
+  const std::vector<Eigen::Vector3d> empty;
+  const auto result = voxel_down_sample_sorted(empty, 0.5);
+  REQUIRE(result.empty());
+}
+
+TEST_CASE("voxel_down_sample_sorted: same occupied voxels as voxel_down_sample", "[voxel_down_sample_sorted]") {
+  const double voxel_size = 0.5;
+  const std::vector<Eigen::Vector3d> points = {{0.1, 0.1, 0.1}, {3.2, 1.1, 0.7}, {7.5, 4.5, 2.3},
+                                               {0.4, 0.4, 0.4}, {3.3, 1.2, 0.8}, {-2.1, 5.6, -3.4}};
+  const auto plain = voxel_down_sample(points, voxel_size);
+  const auto sorted = voxel_down_sample_sorted(points, voxel_size);
+  REQUIRE(plain.size() == sorted.size());
+  REQUIRE(as_voxel_set(plain, voxel_size) == as_voxel_set(sorted, voxel_size));
+}
+
+TEST_CASE("voxel_down_sample_sorted: output is sorted by hash(voxel)", "[voxel_down_sample_sorted]") {
+  const double voxel_size = 0.5;
+  const double inv_voxel_size = 1.0 / voxel_size;
+  // a spread of points across distinct voxels so the hash order isn't trivially monotonic in input order
+  const std::vector<Eigen::Vector3d> points = {{0.1, 0.1, 0.1},  {3.2, 1.1, 0.7},  {7.5, 4.5, 2.3}, {-2.1, 5.6, -3.4},
+                                               {1.7, -2.4, 4.0}, {-4.4, -4.4, 1.1}};
+  const auto result = voxel_down_sample_sorted(points, voxel_size);
+  REQUIRE(result.size() >= 2);
+  const std::hash<Eigen::Vector3i> hasher{};
+  for (std::size_t i = 1; i < result.size(); ++i) {
+    REQUIRE(hasher(point_to_voxel(result[i - 1], inv_voxel_size)) <=
+            hasher(point_to_voxel(result[i], inv_voxel_size)));
+  }
 }


### PR DESCRIPTION
#133 had the previous attempt at switching voxel_down_sample's grid from std::unordered_map to tsl::robin_map, and that blew up some sequences in some regression tests i always do on PRs, i.e. oxford spires and leg kilo datasets. With the specific sequences being blenheim_05 (0.21 → 2.68 APE) and christ_01 (0.13 → 0.31). 
So it got reverted before merge. 

the cause is double downsampling and the fact that the order of points from the first pass is shuffled based on the hash map data structure (down sampling iterates over the hash map to collect the final points). voxel_down_sample's emission order affects pass 2 of double-downsample, where pass 1's output order picks which point survives in each pass-2 voxel. swap the hash map type and you swap that order, and a couple of sequences happened to blow up because of this. bad luck perhaps, but this map-type dependent down sampling is definitely not a good "its a feature, not a bug" i want.

instead, I tried to make the shuffle independent of the map type and tried two variations. 1, a lex-sort by voxel key. this was predictably bad since spatially-adjacent points stream out together, which retains that lidar scan pattern we want to break (see https://github.com/PRBonn/kiss-icp/pull/347 for some images). blenheim came down to 0.84 from 2.68 but was still worse than master, christ was stuck at 0.31. second, and the one that i kept, hash-sort the output by hash(voxel). christ fully recovers, and blenheim got down to 0.32.

with the shuffling now deterministic, i can now do single-cycle voxel down sampling _and_ record the hash inline so we can sort by it before emitting. and since shuffling only matters when the output feeds another downsample pass, the unsorted `voxel_down_sample` goes to ICP directly and `voxel_down_sample_sorted` is only used for pass 1 of double-downsample.

on the 17-sequence regression suite, mean APE drops from master's 0.1945 to 0.1671. 12 sequences improve, three are within a few mm of master, and only blenheim_05 (0.21 → 0.32) and blenheim_02 (0.17 → 0.20) regress. wall time on the suite drops by roughly 3.5%, ~6 min/run on the 17 sequences.