### PR TITLE
use VoxelHash struct to avoid ODR violations

### DIFF
--- a/rko_lio/core/voxel_down_sample.cpp
+++ b/rko_lio/core/voxel_down_sample.cpp
@@ -34,7 +34,7 @@ namespace rko_lio::core {
 
 std::vector<Eigen::Vector3d> voxel_down_sample(const std::vector<Eigen::Vector3d>& frame, const double voxel_size) {
   const double inv_voxel_size = 1.0 / voxel_size;
-  tsl::robin_set<Eigen::Vector3i> seen;
+  tsl::robin_set<Eigen::Vector3i, VoxelHash> seen;
   seen.reserve(frame.size());
   std::vector<Eigen::Vector3d> frame_downsampled;
   frame_downsampled.reserve(frame.size());
@@ -49,11 +49,11 @@ std::vector<Eigen::Vector3d> voxel_down_sample(const std::vector<Eigen::Vector3d
 std::vector<Eigen::Vector3d> voxel_down_sample_sorted(const std::vector<Eigen::Vector3d>& frame,
                                                      const double voxel_size) {
   const double inv_voxel_size = 1.0 / voxel_size;
-  tsl::robin_set<Eigen::Vector3i> seen;
+  tsl::robin_set<Eigen::Vector3i, VoxelHash> seen;
   seen.reserve(frame.size());
   std::vector<std::pair<std::size_t, Eigen::Vector3d>> hashed;
   hashed.reserve(frame.size());
-  const std::hash<Eigen::Vector3i> hasher{};
+  const VoxelHash hasher{};
   for (const auto& point : frame) {
     const auto voxel = point_to_voxel(point, inv_voxel_size);
     if (seen.insert(voxel).second) {

--- a/rko_lio/core/voxel_down_sample.hpp
+++ b/rko_lio/core/voxel_down_sample.hpp
@@ -42,12 +42,11 @@ inline Eigen::Vector3i point_to_voxel(const Eigen::Vector3d& point, const double
           static_cast<int>(std::floor(point.y() * inv_voxel_size)),
           static_cast<int>(std::floor(point.z() * inv_voxel_size))};
 }
-} // namespace rko_lio::core
 
-template <>
-struct std::hash<Eigen::Vector3i> {
-  std::size_t operator()(const Eigen::Vector3i& voxel) const {
-    const uint32_t* vec = reinterpret_cast<const uint32_t*>(voxel.data());
-    return (vec[0] * 73856093 ^ vec[1] * 19349669 ^ vec[2] * 83492791);
-  }
+struct VoxelHash {
+    std::size_t operator()(const Eigen::Vector3i &voxel) const {
+        const uint32_t *vec = reinterpret_cast<const uint32_t *>(voxel.data());
+        return (vec[0] * 73856093 ^ vec[1] * 19349669 ^ vec[2] * 83492791);
+    }
 };
+} // namespace rko_lio::core

--- a/rko_lio/core/voxel_hash_map.hpp
+++ b/rko_lio/core/voxel_hash_map.hpp
@@ -59,7 +59,7 @@ struct VoxelHashMap {
   double inv_voxel_size_;
   double clipping_distance_;
   unsigned int max_points_per_voxel_;
-  tsl::robin_map<Voxel, VoxelBlock> map_;
+  tsl::robin_map<Voxel, VoxelBlock, VoxelHash> map_;
 };
 
 } // namespace rko_lio::core

--- a/tests/core/test_voxel_down_sample.cpp
+++ b/tests/core/test_voxel_down_sample.cpp
@@ -29,6 +29,7 @@
 #include <tuple>
 #include <vector>
 
+using rko_lio::core::VoxelHash;
 using rko_lio::core::point_to_voxel;
 using rko_lio::core::voxel_down_sample;
 using rko_lio::core::voxel_down_sample_sorted;
@@ -113,7 +114,7 @@ TEST_CASE("voxel_down_sample_sorted: output is sorted by hash(voxel)", "[voxel_d
                                                {1.7, -2.4, 4.0}, {-4.4, -4.4, 1.1}};
   const auto result = voxel_down_sample_sorted(points, voxel_size);
   REQUIRE(result.size() >= 2);
-  const std::hash<Eigen::Vector3i> hasher{};
+  const VoxelHash hasher{};
   for (std::size_t i = 1; i < result.size(); ++i) {
     REQUIRE(hasher(point_to_voxel(result[i - 1], inv_voxel_size)) <=
             hasher(point_to_voxel(result[i], inv_voxel_size)));


### PR DESCRIPTION
This pull request updates the voxel hashing approach in the core voxel downsampling and hash map logic. The main change is to replace the use of a standard library hash specialization for `Eigen::Vector3i` with a custom `VoxelHash` struct, and to ensure all relevant hash-based containers use this new hash.

This prevents downstream ODR violations when multiple core libraries (read KISS-ICP, Open3D) contain redefinitions of the std::hash<Eigen::Vector3i>.