### PR TITLE
core: revert voxel down sample sorted

### DIFF
--- a/rko_lio/core/preprocess_scan.cpp
+++ b/rko_lio/core/preprocess_scan.cpp
@@ -16,9 +16,7 @@ PreprocessingResult preprocess_scan(const Vector3dVector& frame, const LIO::Conf
   clipped_frame.shrink_to_fit();
 
   if (config.double_downsample) {
-    // pass 1 feeds pass 2, and sorting (shuffling) breaks lidar scan pattern leading to improved registration
-    Vector3dVector downsampled_frame = voxel_down_sample_sorted(clipped_frame, config.voxel_size * 0.5);
-    // pass 2 feeds icp, so unsorted is fine.
+    Vector3dVector downsampled_frame = voxel_down_sample(clipped_frame, config.voxel_size * 0.5);
     Vector3dVector keypoints = voxel_down_sample(downsampled_frame, config.voxel_size * 1.5);
     return {.filtered_frame = std::move(clipped_frame),
             .keypoints = std::move(keypoints),

--- a/rko_lio/core/voxel_down_sample.cpp
+++ b/rko_lio/core/voxel_down_sample.cpp
@@ -24,50 +24,25 @@
 #include "voxel_down_sample.hpp"
 #include <Eigen/Core>
 #include <algorithm>
-#include <cstddef>
-#include <functional>
-#include <tsl/robin_set.h>
-#include <utility>
+#include <sophus/se3.hpp>
+#include <unordered_map>
 #include <vector>
 
 namespace rko_lio::core {
+// if you need even better runtime-performance, consider using Luca Lobefaro's version of one cycle downsampling here:
+// https://github.com/PRBonn/kiss-icp/pull/347
+// although it does lead to worse odometry performance in certain situations
 
 std::vector<Eigen::Vector3d> voxel_down_sample(const std::vector<Eigen::Vector3d>& frame, const double voxel_size) {
   const double inv_voxel_size = 1.0 / voxel_size;
-  tsl::robin_set<Eigen::Vector3i> seen;
-  seen.reserve(frame.size());
+  std::unordered_map<Eigen::Vector3i, Eigen::Vector3d> grid;
+  grid.reserve(frame.size());
+  std::for_each(frame.cbegin(), frame.cend(),
+                [&](const auto& point) { grid.try_emplace(point_to_voxel(point, inv_voxel_size), point); });
   std::vector<Eigen::Vector3d> frame_downsampled;
-  frame_downsampled.reserve(frame.size());
-  for (const auto& point : frame) {
-    if (seen.insert(point_to_voxel(point, inv_voxel_size)).second) {
-      frame_downsampled.emplace_back(point);
-    }
-  }
-  return frame_downsampled;
-}
-
-std::vector<Eigen::Vector3d> voxel_down_sample_sorted(const std::vector<Eigen::Vector3d>& frame,
-                                                     const double voxel_size) {
-  const double inv_voxel_size = 1.0 / voxel_size;
-  tsl::robin_set<Eigen::Vector3i> seen;
-  seen.reserve(frame.size());
-  std::vector<std::pair<std::size_t, Eigen::Vector3d>> hashed;
-  hashed.reserve(frame.size());
-  const std::hash<Eigen::Vector3i> hasher{};
-  for (const auto& point : frame) {
-    const auto voxel = point_to_voxel(point, inv_voxel_size);
-    if (seen.insert(voxel).second) {
-      hashed.emplace_back(hasher(voxel), point);
-    }
-  }
-  std::sort(hashed.begin(), hashed.end(),
-            [](const auto& a, const auto& b) { return a.first < b.first; });
-
-  std::vector<Eigen::Vector3d> frame_downsampled;
-  frame_downsampled.reserve(hashed.size());
-  for (auto& [_, v] : hashed) {
-    frame_downsampled.emplace_back(std::move(v));
-  }
+  frame_downsampled.reserve(grid.size());
+  std::for_each(grid.cbegin(), grid.cend(),
+                [&](const auto& voxel_and_point) { frame_downsampled.emplace_back(voxel_and_point.second); });
   return frame_downsampled;
 }
 

--- a/rko_lio/core/voxel_down_sample.hpp
+++ b/rko_lio/core/voxel_down_sample.hpp
@@ -27,15 +27,8 @@
 #include <sophus/se3.hpp>
 
 namespace rko_lio::core {
-// single cycle voxel downsample, see https://github.com/PRBonn/kiss-icp/pull/347
+/// Voxelize point cloud keeping the original coordinates
 std::vector<Eigen::Vector3d> voxel_down_sample(const std::vector<Eigen::Vector3d>& frame, const double voxel_size);
-
-// like voxel_down_sample but output sorted by hash(voxel). used when the output feeds another downsample pass.
-// the spatial hash scatters adjacent voxels far apart, so the next pass's first-write-wins per voxel sees a
-// diverse pick of points instead of one biased by the lidar sweep order, essentially breaking that regular pattern.
-// leads to an improvement in registration performance, see https://github.com/PRBonn/rko_lio/pull/136
-std::vector<Eigen::Vector3d> voxel_down_sample_sorted(const std::vector<Eigen::Vector3d>& frame,
-                                                      const double voxel_size);
 
 inline Eigen::Vector3i point_to_voxel(const Eigen::Vector3d& point, const double inv_voxel_size) {
   return {static_cast<int>(std::floor(point.x() * inv_voxel_size)),

--- a/tests/core/test_voxel_down_sample.cpp
+++ b/tests/core/test_voxel_down_sample.cpp
@@ -23,15 +23,11 @@
 #include "rko_lio/core/voxel_down_sample.hpp"
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
-#include <cstddef>
-#include <functional>
 #include <set>
 #include <tuple>
 #include <vector>
 
-using rko_lio::core::point_to_voxel;
 using rko_lio::core::voxel_down_sample;
-using rko_lio::core::voxel_down_sample_sorted;
 
 namespace {
 std::set<std::tuple<int, int, int>> as_voxel_set(const std::vector<Eigen::Vector3d>& points, double voxel_size) {
@@ -87,35 +83,4 @@ TEST_CASE("voxel_down_sample: doubling voxel size collapses points", "[voxel_dow
   const auto large = voxel_down_sample(points, 1.0);
   REQUIRE(small.size() == 2);
   REQUIRE(large.size() == 1);
-}
-
-TEST_CASE("voxel_down_sample_sorted: empty input -> empty output", "[voxel_down_sample_sorted]") {
-  const std::vector<Eigen::Vector3d> empty;
-  const auto result = voxel_down_sample_sorted(empty, 0.5);
-  REQUIRE(result.empty());
-}
-
-TEST_CASE("voxel_down_sample_sorted: same occupied voxels as voxel_down_sample", "[voxel_down_sample_sorted]") {
-  const double voxel_size = 0.5;
-  const std::vector<Eigen::Vector3d> points = {{0.1, 0.1, 0.1}, {3.2, 1.1, 0.7}, {7.5, 4.5, 2.3},
-                                               {0.4, 0.4, 0.4}, {3.3, 1.2, 0.8}, {-2.1, 5.6, -3.4}};
-  const auto plain = voxel_down_sample(points, voxel_size);
-  const auto sorted = voxel_down_sample_sorted(points, voxel_size);
-  REQUIRE(plain.size() == sorted.size());
-  REQUIRE(as_voxel_set(plain, voxel_size) == as_voxel_set(sorted, voxel_size));
-}
-
-TEST_CASE("voxel_down_sample_sorted: output is sorted by hash(voxel)", "[voxel_down_sample_sorted]") {
-  const double voxel_size = 0.5;
-  const double inv_voxel_size = 1.0 / voxel_size;
-  // a spread of points across distinct voxels so the hash order isn't trivially monotonic in input order
-  const std::vector<Eigen::Vector3d> points = {{0.1, 0.1, 0.1},  {3.2, 1.1, 0.7},  {7.5, 4.5, 2.3}, {-2.1, 5.6, -3.4},
-                                               {1.7, -2.4, 4.0}, {-4.4, -4.4, 1.1}};
-  const auto result = voxel_down_sample_sorted(points, voxel_size);
-  REQUIRE(result.size() >= 2);
-  const std::hash<Eigen::Vector3i> hasher{};
-  for (std::size_t i = 1; i < result.size(); ++i) {
-    REQUIRE(hasher(point_to_voxel(result[i - 1], inv_voxel_size)) <=
-            hasher(point_to_voxel(result[i], inv_voxel_size)));
-  }
 }


### PR DESCRIPTION
essentially reverts #136 as during testing on more sequences and datasets, i got regressions in ape perf and found out that what i thought was similar ordering (through the deterministic hash sort) to the unordered_map internal emit order, was actually not the same. And after trying a bunch of different ideas to emulate that emit order, and successfully failing, I revert back to earlier behaviour. In the end its std::unordered_map and i expect it to be stable for my lifetime at least.