### PR TITLE
misc: adds testing for lyrical, fixes the current ci fails

### DIFF
--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -29,16 +29,15 @@ jobs:
     needs: check_relevant_changes
     if: needs.check_relevant_changes.outputs.continue_run == 'true'
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { ros_distro: humble,  container_image: "ros:humble-ros-base" }
-          - { ros_distro: jazzy,   container_image: "ros:jazzy-ros-base" }
-          - { ros_distro: kilted,  container_image: "ros:kilted-ros-base" }
-          - { ros_distro: lyrical, container_image: "ros:lyrical-ros-base" }
-          - { ros_distro: rolling, container_image: "ros:rolling-ros-base", experimental: true }
+          - {ros_distro: humble, container_image: "ros:humble-ros-base"}
+          - {ros_distro: jazzy, container_image: "ros:jazzy-ros-base"}
+          - {ros_distro: kilted, container_image: "ros:kilted-ros-base"}
+          - {ros_distro: lyrical, container_image: "ros:lyrical-ros-base",}
+          # - { ros_distro: rolling, container_image: "ros:rolling-ros-base"}
     container:
       image: ${{ matrix.container_image }}
     steps:
@@ -62,11 +61,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { ros_distro: humble,  container_image: "ros:humble-ros-base" }
-          - { ros_distro: jazzy,   container_image: "ros:jazzy-ros-base" }
-          - { ros_distro: kilted,  container_image: "ros:kilted-ros-base" }
-          - { ros_distro: lyrical, container_image: "ros:lyrical-ros-base" }
-          - { ros_distro: rolling, container_image: "ros:rolling-ros-base" }
+          - {ros_distro: humble, container_image: "ros:humble-ros-base"}
+          - {ros_distro: jazzy, container_image: "ros:jazzy-ros-base"}
+          - {ros_distro: kilted, container_image: "ros:kilted-ros-base"}
+          - {ros_distro: lyrical, container_image: "ros:lyrical-ros-base"}
+          - {ros_distro: rolling, container_image: "ros:rolling-ros-base"}
     container:
       image: ${{ matrix.container_image }}
     steps:

--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -29,14 +29,16 @@ jobs:
     needs: check_relevant_changes
     if: needs.check_relevant_changes.outputs.continue_run == 'true'
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { ros_distro: humble,  container_image: "osrf/ros:humble-desktop" }
-          - { ros_distro: jazzy,   container_image: "osrf/ros:jazzy-desktop" }
-          - { ros_distro: kilted,  container_image: "osrf/ros:kilted-desktop" }
-          - { ros_distro: rolling, container_image: "osrf/ros:rolling-desktop" }
+          - { ros_distro: humble,  container_image: "ros:humble-ros-base" }
+          - { ros_distro: jazzy,   container_image: "ros:jazzy-ros-base" }
+          - { ros_distro: kilted,  container_image: "ros:kilted-ros-base" }
+          - { ros_distro: lyrical, container_image: "ros:lyrical-ros-base" }
+          - { ros_distro: rolling, container_image: "ros:rolling-ros-base", experimental: true }
     container:
       image: ${{ matrix.container_image }}
     steps:
@@ -44,7 +46,7 @@ jobs:
       - name: Install build tools
         run: |
           apt-get update
-          apt-get install -y build-essential cmake
+          apt-get install -y build-essential cmake git
       - name: Source ROS environment, install dependencies, and build
         run: |
           . /opt/ros/${{ matrix.ros_distro }}/setup.sh
@@ -60,10 +62,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { ros_distro: humble,  container_image: "osrf/ros:humble-desktop" }
-          - { ros_distro: jazzy,   container_image: "osrf/ros:jazzy-desktop" }
-          - { ros_distro: kilted,  container_image: "osrf/ros:kilted-desktop" }
-          - { ros_distro: rolling, container_image: "osrf/ros:rolling-desktop" }
+          - { ros_distro: humble,  container_image: "ros:humble-ros-base" }
+          - { ros_distro: jazzy,   container_image: "ros:jazzy-ros-base" }
+          - { ros_distro: kilted,  container_image: "ros:kilted-ros-base" }
+          - { ros_distro: lyrical, container_image: "ros:lyrical-ros-base" }
+          - { ros_distro: rolling, container_image: "ros:rolling-ros-base" }
     container:
       image: ${{ matrix.container_image }}
     steps:
@@ -71,7 +74,7 @@ jobs:
       - name: Install build tools
         run: |
           apt-get update
-          apt-get install -y build-essential cmake
+          apt-get install -y build-essential cmake git
       - name: Source ROS environment and build with extra CMake args
         run: |
           . /opt/ros/${{ matrix.ros_distro }}/setup.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.22.0)
-project(rko_lio LANGUAGES CXX)
+project(rko_lio LANGUAGES CXX C)
 
 if(POLICY CMP0135)
   cmake_policy(SET CMP0135 NEW)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![IEEE RA-L](https://img.shields.io/badge/IEEE_RA--L-10.1109%2FLRA.2026.3685966-00629B.svg)](https://doi.org/10.1109/LRA.2026.3685966) [![arXiv](https://img.shields.io/badge/arXiv-2509.06593-b31b1b.svg)](https://arxiv.org/abs/2509.06593) [![GitHub License](https://img.shields.io/github/license/PRBonn/rko_lio)](/LICENSE) [![GitHub last commit](https://img.shields.io/github/last-commit/PRBonn/rko_lio)](/)
 
-[![PyPI - Version](https://img.shields.io/pypi/v/rko_lio?color=blue)](https://pypi.org/project/rko-lio/) [![ROS Package Index](https://img.shields.io/ros/v/humble/rko_lio?color=blue)](https://index.ros.org/p/rko_lio/#humble) [![ROS Package Index](https://img.shields.io/ros/v/jazzy/rko_lio?color=blue)](https://index.ros.org/p/rko_lio/#jazzy) [![ROS Package Index](https://img.shields.io/ros/v/kilted/rko_lio?color=blue)](https://index.ros.org/p/rko_lio/#kilted) [![ROS Package Index](https://img.shields.io/ros/v/rolling/rko_lio?color=blue)](https://index.ros.org/p/rko_lio/#rolling)
+[![PyPI - Version](https://img.shields.io/pypi/v/rko_lio?color=blue)](https://pypi.org/project/rko-lio/) [![ROS Package Index](https://img.shields.io/ros/v/humble/rko_lio?color=blue)](https://index.ros.org/p/rko_lio/#humble) [![ROS Package Index](https://img.shields.io/ros/v/jazzy/rko_lio?color=blue)](https://index.ros.org/p/rko_lio/#jazzy) [![ROS Package Index](https://img.shields.io/ros/v/kilted/rko_lio?color=blue)](https://index.ros.org/p/rko_lio/#kilted) [![ROS Package Index](https://img.shields.io/ros/v/lyrical/rko_lio?color=blue)](https://index.ros.org/p/rko_lio/#lyrical) [![ROS Package Index](https://img.shields.io/ros/v/rolling/rko_lio?color=blue)](https://index.ros.org/p/rko_lio/#rolling)
 
 </div>
 
@@ -67,7 +67,7 @@ The superscript on the vector indicates the frame in which the vector is express
 
 ## ROS
 
-Supported distros: Humble, Jazzy, Kilted, Rolling.
+Supported distros: Humble, Jazzy, Kilted, Lyrical, Rolling.
 
 ```bash
 sudo apt install ros-$ROS_DISTRO-rko-lio

--- a/docs/pages/quickstart.rst
+++ b/docs/pages/quickstart.rst
@@ -20,7 +20,7 @@ See :doc:`Python <python>` for detailed examples and the full CLI surface.
 ROS
 ---
 
-Supported distros: Humble, Jazzy, Kilted, Rolling.
+Supported distros: Humble, Jazzy, Kilted, Lyrical, Rolling.
 
 .. code-block:: bash
 

--- a/docs/pages/ros.rst
+++ b/docs/pages/ros.rst
@@ -10,7 +10,7 @@ ROS
   </p>
   </div>
 
-Supported distros: Humble, Jazzy, Kilted, Rolling.
+Supported distros: Humble, Jazzy, Kilted, Lyrical, Rolling.
 
 .. contents::
    :local:


### PR DESCRIPTION
ros rolling docker images are still on noble right now, but the packages are released for resolute. which leads to the constant ci build failure thats been happening for the past month or so. ros upstream still hasnt figured out their process for rolling going forward, and i cba to wait anymore. so rolling with rosdep builds are conditionally ok to fail from now on. till i notice ros has their thing together, then i make it binding again.

apart from that, added lyrical testing since rko lio was automatically released there as well (yay). 

one small patch to the cmake as cmake 4.2 tightens policies on how it builds projects (need C features for tbb builds on the fetch dependencies path which was silently passing earlier).