### PR TITLE
ros: fix rolling compat break, plus a bunch of deprecation warnings

### DIFF
--- a/.github/workflows/ros_nightly.yaml
+++ b/.github/workflows/ros_nightly.yaml
@@ -1,0 +1,23 @@
+name: ROS Nightly Job (Weekly)
+# Canary against ROS built fresh from master, which is what the ROS build farm does. If this has failed likely the build farm already has much earlier. This just lets me know for certain as sometimes the build farm fails due to their infra reasons.
+on:
+  workflow_dispatch:
+  schedule:
+    # Mondays 06:00 UTC
+    - cron: "0 6 * * 1"
+jobs:
+  ros_nightly_build:
+    runs-on: ubuntu-latest
+    container:
+      image: osrf/ros2:nightly
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install build tools
+        run: |
+          apt-get update
+          apt-get install -y build-essential cmake git
+      - name: Source ROS environment and build
+        run: |
+          . /opt/ros/rolling/setup.sh
+          colcon build --event-handlers console_direct+ \
+            --cmake-args -DRKO_LIO_FETCH_CONTENT_DEPS=ON

--- a/rko_lio/ros/base_node.hpp
+++ b/rko_lio/ros/base_node.hpp
@@ -42,9 +42,9 @@
 #include <rclcpp/node_options.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.hpp>
+#include <tf2_ros/transform_broadcaster.hpp>
+#include <tf2_ros/transform_listener.hpp>
 
 namespace rko_lio::ros {
 // Shared helper used by both the threaded and sequential nodes.

--- a/rko_lio/ros/offline_node.cpp
+++ b/rko_lio/ros/offline_node.cpp
@@ -56,7 +56,7 @@ public:
     // bag reading
     const tf2::Duration skip_to_time = tf2::durationFromSec(node->declare_parameter<double>("skip_to_time", 0.0));
     bag = std::make_unique<utils::BufferableBag>(node->declare_parameter<std::string>("bag_path"),
-                                                 std::make_shared<utils::BufferableBag::TFBridge>(node),
+                                                 std::make_shared<utils::BufferableBag::TFBridge>(*node),
                                                  std::vector<std::string>{imu_topic, lidar_topic}, skip_to_time);
     total_bag_msgs = bag->message_count();
     bag_progress_publisher = node->create_publisher<std_msgs::msg::Float32MultiArray>("rko_lio/bag_progress", 10);

--- a/rko_lio/ros/utils/rosbag.cpp
+++ b/rko_lio/ros/utils/rosbag.cpp
@@ -43,7 +43,7 @@ inline auto GetTimestampsFromRosbagSerializedMsg(const rosbag2_storage::Serializ
 
 namespace rko_lio::ros::utils {
 // TFBridge----------------------------------------------------------------------------------------
-BufferableBag::TFBridge::TFBridge(rclcpp::Node::SharedPtr node) {
+BufferableBag::TFBridge::TFBridge(rclcpp::Node& node) {
   tf_broadcaster = std::make_unique<tf2_ros::TransformBroadcaster>(node);
   tf_static_broadcaster = std::make_unique<tf2_ros::StaticTransformBroadcaster>(node);
   serializer = rclcpp::Serialization<tf2_msgs::msg::TFMessage>();

--- a/rko_lio/ros/utils/rosbag.hpp
+++ b/rko_lio/ros/utils/rosbag.hpp
@@ -25,8 +25,8 @@
 #pragma once
 // tf2
 #include <tf2/time.hpp>
-#include <tf2_ros/static_transform_broadcaster.h>
-#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/static_transform_broadcaster.hpp>
+#include <tf2_ros/transform_broadcaster.hpp>
 // ROS
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/serialization.hpp>
@@ -46,7 +46,7 @@ class BufferableBag {
 public:
   // Wrapper node to process the transforamtions present in the bagfile
   struct TFBridge {
-    explicit TFBridge(rclcpp::Node::SharedPtr node);
+    explicit TFBridge(rclcpp::Node& node);
     void ProcessTFMessage(std::shared_ptr<rosbag2_storage::SerializedBagMessage> msg) const;
     std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster;
     std::unique_ptr<tf2_ros::StaticTransformBroadcaster> tf_static_broadcaster;

--- a/rko_lio/ros/utils/transforms.hpp
+++ b/rko_lio/ros/utils/transforms.hpp
@@ -33,7 +33,7 @@
 #include <sophus/se3.hpp>
 #include <tf2/exceptions.hpp>
 #include <tf2/time.hpp>
-#include <tf2_ros/buffer.h>
+#include <tf2_ros/buffer.hpp>
 
 namespace rko_lio::ros::utils {
 template <typename Scalar = double>


### PR DESCRIPTION
and add a ros nightly weekly ci job so i have my own signal of api changes upstream.

the break is due to how the TFBridge gets initialized.