### PR TITLE
ros, launch: autodetect topics and frames similar to the python side

### DIFF
--- a/launch/autodetect.py
+++ b/launch/autodetect.py
@@ -195,9 +195,9 @@ def resolve(graph, params):
 
 def autodetect_or_exit(params, mode, bag_path, timeout):
     if all(params.get(name) for name in AUTODETECTED):
-        return {}
+        return params
     if mode == "offline" and not bag_path:
-        return {}
+        return params
 
     context = rclpy.Context()
     rclpy.init(context=context)
@@ -229,4 +229,4 @@ def autodetect_or_exit(params, mode, bag_path, timeout):
         print("\nAutodetected:")
         for name, value in found.items():
             print(f"    {name}: {value}")
-    return found
+    return {**params, **found}

--- a/launch/autodetect.py
+++ b/launch/autodetect.py
@@ -1,0 +1,232 @@
+# all hail the power of vibe coding
+
+import sys
+import time
+
+import rclpy
+import rosbag2_py
+import tf2_ros
+import yaml
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.qos import QoSHistoryPolicy, QoSProfile, QoSReliabilityPolicy
+from rclpy.serialization import deserialize_message
+from rclpy.time import Time
+from rosidl_runtime_py.utilities import get_message
+
+IMU_TYPE = "sensor_msgs/msg/Imu"
+LIDAR_TYPE = "sensor_msgs/msg/PointCloud2"
+BASE_FRAME_CANDIDATES = ("base_link", "base_footprint", "base")
+AUTODETECTED = ("imu_topic", "lidar_topic", "imu_frame", "lidar_frame", "base_frame")
+TF_SCAN_WINDOW_NS = 5 * 10**9
+
+
+class AutodetectError(Exception):
+    pass
+
+
+def tf_frames(buffer):
+    tree = yaml.safe_load(buffer.all_frames_as_yaml()) or {}
+    return set(tree) | {
+        entry["parent"]
+        for entry in tree.values()
+        if isinstance(entry, dict) and entry.get("parent")
+    }
+
+
+class LiveGraph:
+    def __init__(self, node, buffer, executor, timeout):
+        self.node = node
+        self.buffer = buffer
+        self.executor = executor
+        self.timeout = timeout
+
+    def spin_until(self, predicate, what):
+        deadline = time.monotonic() + self.timeout
+        while time.monotonic() < deadline:
+            self.executor.spin_once(timeout_sec=0.1)
+            result = predicate()
+            if result:
+                return result
+        raise AutodetectError(
+            f"timed out after {self.timeout:.0f}s waiting for {what}. "
+            "Is the data flowing? Raise autodetect_timeout, or pass the values explicitly."
+        )
+
+    def topics(self, msgtype):
+        return self.spin_until(
+            lambda: sorted(
+                name
+                for name, types in self.node.get_topic_names_and_types()
+                if msgtype in types
+                and not any(part.startswith("_") for part in name.split("/"))
+            ),
+            f"a {msgtype} publisher",
+        )
+
+    def frame_id(self, topic, msgtype):
+        received = []
+        subscription = self.node.create_subscription(
+            get_message(msgtype),
+            topic,
+            lambda msg: received.append(msg.header.frame_id),
+            QoSProfile(
+                depth=1,
+                history=QoSHistoryPolicy.KEEP_LAST,
+                reliability=QoSReliabilityPolicy.BEST_EFFORT,
+            ),
+        )
+        try:
+            return self.spin_until(
+                lambda: received[0] if received else None, f"a message on {topic}"
+            )
+        finally:
+            self.node.destroy_subscription(subscription)
+
+    def frames(self):
+        return self.spin_until(lambda: tf_frames(self.buffer), "a TF tree")
+
+
+class BagGraph:
+    def __init__(self, bag_path, buffer):
+        reader = rosbag2_py.SequentialReader()
+        try:
+            reader.open(
+                rosbag2_py.StorageOptions(uri=str(bag_path)),
+                rosbag2_py.ConverterOptions("", ""),
+            )
+        except Exception as error:
+            raise AutodetectError(f"could not read the bag at {bag_path}: {error}")
+        self.types = {t.name: t.type for t in reader.get_all_topics_and_types()}
+        self.buffer = buffer
+        self.frame_of = {}
+
+        wanted = {
+            topic
+            for topic, type_ in self.types.items()
+            if type_ in (IMU_TYPE, LIDAR_TYPE)
+        }
+        tf_topics = {
+            topic
+            for topic, type_ in self.types.items()
+            if type_ == "tf2_msgs/msg/TFMessage"
+        }
+        start = None
+        while reader.has_next() and (wanted or tf_topics):
+            topic, data, stamp = reader.read_next()
+            start = stamp if start is None else start
+            if stamp - start > TF_SCAN_WINDOW_NS:
+                tf_topics.clear()
+            if topic in tf_topics:
+                for transform in deserialize_message(
+                    data, get_message(self.types[topic])
+                ).transforms:
+                    self.buffer.set_transform_static(transform, "rko_lio_autodetect")
+            elif topic in wanted:
+                message = deserialize_message(data, get_message(self.types[topic]))
+                self.frame_of[topic] = message.header.frame_id
+                wanted.discard(topic)
+
+    def topics(self, msgtype):
+        return sorted(topic for topic, type_ in self.types.items() if type_ == msgtype)
+
+    def frame_id(self, topic, msgtype):
+        if topic not in self.frame_of:
+            raise AutodetectError(f"the bag holds no messages on {topic}")
+        return self.frame_of[topic]
+
+    def frames(self):
+        return tf_frames(self.buffer)
+
+
+def pick_topic(graph, msgtype, argument):
+    candidates = graph.topics(msgtype)
+    if not candidates:
+        raise AutodetectError(f"found no {msgtype} topic to use for {argument}")
+    if len(candidates) > 1:
+        raise AutodetectError(
+            f"found several {msgtype} topics, so {argument} cannot be guessed. "
+            f"Pass one of: {', '.join(candidates)}"
+        )
+    return candidates[0]
+
+
+def resolve(graph, params):
+    found = {}
+
+    imu_topic = params.get("imu_topic")
+    if not imu_topic:
+        imu_topic = pick_topic(graph, IMU_TYPE, "imu_topic")
+        found["imu_topic"] = imu_topic
+
+    lidar_topic = params.get("lidar_topic")
+    if not lidar_topic:
+        lidar_topic = pick_topic(graph, LIDAR_TYPE, "lidar_topic")
+        found["lidar_topic"] = lidar_topic
+
+    imu_frame = params.get("imu_frame")
+    if not imu_frame:
+        imu_frame = graph.frame_id(imu_topic, IMU_TYPE)
+        found["imu_frame"] = imu_frame
+
+    lidar_frame = params.get("lidar_frame")
+    if not lidar_frame:
+        lidar_frame = graph.frame_id(lidar_topic, LIDAR_TYPE)
+        found["lidar_frame"] = lidar_frame
+
+    known_frames = graph.frames()
+    base_frame = params.get("base_frame")
+    if not base_frame:
+        guessed = next((f for f in BASE_FRAME_CANDIDATES if f in known_frames), None)
+        base_frame = guessed or lidar_frame
+        found["base_frame"] = base_frame
+        if not guessed and "invert_odom_tf" not in params:
+            found["invert_odom_tf"] = True
+
+    for frame in {imu_frame, lidar_frame} - {base_frame}:
+        if not graph.buffer.can_transform(base_frame, frame, Time()):
+            raise AutodetectError(
+                f"the TF tree has no transform between {frame} and the base frame "
+                f"{base_frame}, which the odometry needs. Known frames: "
+                f"{', '.join(sorted(known_frames)) or '<none>'}. Publish the transform, "
+                "or give the extrinsics in a config file."
+            )
+    return found
+
+
+def autodetect_or_exit(params, mode, bag_path, timeout):
+    if all(params.get(name) for name in AUTODETECTED):
+        return {}
+    if mode == "offline" and not bag_path:
+        return {}
+
+    context = rclpy.Context()
+    rclpy.init(context=context)
+    try:
+        node = rclpy.create_node("rko_lio_autodetect", context=context)
+        buffer = tf2_ros.Buffer()
+        try:
+            if mode == "offline":
+                graph = BagGraph(bag_path, buffer)
+            else:
+                executor = SingleThreadedExecutor(context=context)
+                executor.add_node(node)
+                graph = LiveGraph(node, buffer, executor, timeout)
+                listener = tf2_ros.TransformListener(buffer, node, spin_thread=False)
+            found = resolve(graph, params)
+        except AutodetectError as error:
+            print("\n" + "=" * 40)
+            print("[ERROR] autodetect failed:")
+            print(error)
+            print("Pass the values explicitly, or set autodetect:=false.")
+            print("=" * 40 + "\n")
+            sys.exit(1)
+        finally:
+            node.destroy_node()
+    finally:
+        rclpy.shutdown(context=context)
+
+    if found:
+        print("\nAutodetected:")
+        for name, value in found.items():
+            print(f"    {name}: {value}")
+    return found

--- a/launch/odometry.launch.py
+++ b/launch/odometry.launch.py
@@ -550,15 +550,11 @@ def launch_setup(context, *args, **kwargs):
         )
         print("Anything you did set is used as is. Turn this off with autodetect:=false.")
         print("=" * 40)
-        final_params.update(
-            load_sibling("autodetect").autodetect_or_exit(
-                final_params,
-                mode=mode,
-                bag_path=final_params.get("bag_path"),
-                timeout=float(
-                    LaunchConfiguration("autodetect_timeout").perform(context)
-                ),
-            )
+        final_params = load_sibling("autodetect").autodetect_or_exit(
+            final_params,
+            mode=mode,
+            bag_path=final_params.get("bag_path"),
+            timeout=float(LaunchConfiguration("autodetect_timeout").perform(context)),
         )
 
     final_params = validate_parameters(

--- a/launch/odometry.launch.py
+++ b/launch/odometry.launch.py
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import importlib.util
+import sys
 from pathlib import Path
 
 import launch_ros.actions
@@ -49,14 +51,28 @@ configurable_parameters = [
     {
         "name": "imu_topic",
         "default": "",
-        "description": "IMU input topic (required)",
+        "description": "IMU input topic (required, unless a single one can be autodetected)",
         "required": True,
     },
     {
         "name": "lidar_topic",
         "default": "",
-        "description": "LiDAR pointcloud topic (required)",
+        "description": "LiDAR pointcloud topic (required, unless a single one can be autodetected)",
         "required": True,
+    },
+    {
+        "launch_only": True,
+        "name": "autodetect",
+        "default": "true",
+        "type": "bool",
+        "description": "[EXPERIMENTAL] Fill in imu_topic, lidar_topic, the frames and base_frame from the running graph (online) or the bag (offline), whenever they were not given. Anything you specify is used as is.",
+    },
+    {
+        "launch_only": True,
+        "name": "autodetect_timeout",
+        "default": "10.0",
+        "type": "float",
+        "description": "[EXPERIMENTAL] Seconds to wait for the topics, messages and TF tree needed by autodetect (online mode only)",
     },
     {
         "name": "imu_frame",
@@ -71,7 +87,7 @@ configurable_parameters = [
     {
         "name": "base_frame",
         "default": "",
-        "description": "Robot base frame, or the frame of estimation for odometry (required)",
+        "description": "Robot base frame, or the frame of estimation for odometry (required, unless it can be autodetected from the TF tree)",
         "required": True,
     },
     {
@@ -243,17 +259,20 @@ configurable_parameters = [
     },
     # ros params
     {
+        "launch_only": True,
         "name": "mode",
         "default": "online",
         "description": "Launch mode: 'online' (subscribe to live topics) or 'offline' (drain a rosbag at full speed).",
     },
     {
+        "launch_only": True,
         "name": "odom_at_imu_rate",
         "default": "false",
         "type": "bool",
         "description": "When true (and mode:=online), launch the sequential variant which additionally publishes IMU-rate odometry on seq.odom_at_imu_rate_topic. Has no effect when mode:=offline.",
     },
     {
+        "launch_only": True,
         "name": "config_file",
         "default": "",
         "description": "YAML config file to load parameters from",
@@ -271,21 +290,24 @@ configurable_parameters = [
     },
     {
         "name": "run_name",
-        "default": "rko_lio_odometry_run",
+        "default": "rko_lio_run",
         "description": "Run name, used when saving results to <results_dir>. See `dump_results` which has to be true.",
     },
     {
+        "launch_only": True,
         "name": "rviz",
         "default": "false",
         "type": "bool",
         "description": "Launch RViz simultaneously",
     },
     {
+        "launch_only": True,
         "name": "rviz_config_file",
         "default": "config/default.rviz",
         "description": "RViz config file path. If it's not the default value, note that it will be passed to rviz as is.",
     },
     {
+        "launch_only": True,
         "name": "log_level",
         "default": "info",
         "description": "ROS Log level [DEBUG|INFO|WARN|ERROR|FATAL]",
@@ -297,11 +319,25 @@ def declare_configurable_parameters(parameters):
     return [
         DeclareLaunchArgument(
             param["name"],
-            default_value=param["default"],
+            default_value=param.get("default", ""),
             description=param.get("description", ""),
         )
         for param in parameters
     ]
+
+
+def node_parameters(merged: dict) -> dict:
+    launch_only = {p["name"] for p in configurable_parameters if p.get("launch_only")}
+    return {name: value for name, value in merged.items() if name not in launch_only}
+
+
+def load_sibling(name: str):
+    spec = importlib.util.spec_from_file_location(
+        name, Path(__file__).parent / f"{name}.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def auto_cast_params(params, param_defs):
@@ -349,26 +385,15 @@ def get_config_file_parameters(context):
         return yaml.safe_load(f)
 
 
-def merge_and_validate_parameters(
-    cli_params: dict,
-    file_params: dict,
-    mode: str,
-    odom_at_imu_rate: bool,
-) -> dict:
-    """
-    Merge CLI and file parameters:
-      - CLI overrides file values only if non-empty
-      - Validate required params are provided (depending on mode)
-    """
-    merged = {}
-
-    merged.update(file_params)
-
-    # override with cli only if non-empty
+def merge_parameters(cli_params: dict, file_params: dict) -> dict:
+    merged = dict(file_params)
     for k, v in cli_params.items():
         if v not in ("", None):
             merged[k] = v
+    return merged
 
+
+def validate_parameters(merged: dict, mode: str, odom_at_imu_rate: bool) -> dict:
     # mode + flag determines which pipeline runs
     is_offline = mode == "offline"
     is_seq = mode == "online" and odom_at_imu_rate
@@ -502,6 +527,8 @@ def prepare_rviz_config(rviz_config_file: Path, parameters: dict) -> Path:
 
 def launch_setup(context, *args, **kwargs):
     mode = LaunchConfiguration("mode").perform(context).lower()
+    if mode not in ("online", "offline"):
+        raise RuntimeError(f"Unknown mode '{mode}'. Valid: online | offline.")
     odom_at_imu_rate = (
         LaunchConfiguration("odom_at_imu_rate").perform(context).lower() == "true"
     )
@@ -509,11 +536,33 @@ def launch_setup(context, *args, **kwargs):
     # Prepare parameters
     cli_params = get_configured_cli_parameters(configurable_parameters, context=context)
     params_from_file = get_config_file_parameters(context)
-    final_params = merge_and_validate_parameters(
-        cli_params=cli_params,
-        file_params=params_from_file,
-        mode=mode,
-        odom_at_imu_rate=odom_at_imu_rate,
+    final_params = merge_parameters(
+        cli_params=cli_params, file_params=params_from_file
+    )
+
+    if LaunchConfiguration("autodetect").perform(context).lower() == "true":
+        print("\n" + "=" * 40)
+        print("[EXPERIMENTAL] autodetect is enabled.")
+        print(
+            f"Whatever you did not set is guessed from "
+            f"{'the bag' if mode == 'offline' else 'the running graph'}: "
+            "imu_topic, lidar_topic, imu_frame, lidar_frame, base_frame."
+        )
+        print("Anything you did set is used as is. Turn this off with autodetect:=false.")
+        print("=" * 40)
+        final_params.update(
+            load_sibling("autodetect").autodetect_or_exit(
+                final_params,
+                mode=mode,
+                bag_path=final_params.get("bag_path"),
+                timeout=float(
+                    LaunchConfiguration("autodetect_timeout").perform(context)
+                ),
+            )
+        )
+
+    final_params = validate_parameters(
+        final_params, mode=mode, odom_at_imu_rate=odom_at_imu_rate
     )
 
     print("\n" + "=" * 40 + "\n")
@@ -539,7 +588,7 @@ def launch_setup(context, *args, **kwargs):
         launch_ros.actions.Node(
             package="rko_lio",
             executable=node_executable,
-            parameters=[final_params],
+            parameters=[node_parameters(final_params)],
             output="screen",
             arguments=[
                 "--ros-args",

--- a/launch/odometry.launch.py
+++ b/launch/odometry.launch.py
@@ -315,6 +315,14 @@ configurable_parameters = [
 ] + offline_only_parameters
 
 
+def fail(*lines):
+    print("\n\n" + "=" * 40)
+    for line in lines:
+        print(line)
+    print("=" * 40 + "\n\n")
+    sys.exit(1)
+
+
 def declare_configurable_parameters(parameters):
     return [
         DeclareLaunchArgument(
@@ -364,7 +372,7 @@ def auto_cast_params(params, param_defs):
     return out
 
 
-def get_configured_cli_parameters(configurable_parameters, context):
+def get_configured_cli_parameters(context):
     "Return only CLI parameters that were explicitly set by the user"
     explicit_params = {
         arg.split(":=")[0] for arg in getattr(context, "argv", []) if ":=" in arg
@@ -393,18 +401,18 @@ def merge_parameters(cli_params: dict, file_params: dict) -> dict:
     return merged
 
 
-def validate_parameters(merged: dict, mode: str, odom_at_imu_rate: bool) -> dict:
+def validate_parameters(merged: dict, mode: str, odom_at_imu_rate: bool) -> None:
     # mode + flag determines which pipeline runs
     is_offline = mode == "offline"
     is_seq = mode == "online" and odom_at_imu_rate
-    is_async = not is_seq  # offline + online-without-flag both run async
 
+    offline_only = {p["name"] for p in offline_only_parameters}
     missing = []
     for param in configurable_parameters:
         name = param["name"]
 
         # offline-only params are required only in offline mode
-        if not is_offline and param in offline_only_parameters:
+        if not is_offline and name in offline_only:
             continue
 
         if param.get("required", False):
@@ -412,14 +420,11 @@ def validate_parameters(merged: dict, mode: str, odom_at_imu_rate: bool) -> dict
                 missing.append(name)
 
     if missing:
-        print("\n\n" + "=" * 40)
-        print("[ERROR] missing required parameter(s):")
-        print(", ".join(missing))
-        print("Please provide them via cli (param:=value) or a config file.")
-        print("=" * 40 + "\n\n")
-        import sys
-
-        sys.exit(1)
+        fail(
+            "[ERROR] missing required parameter(s):",
+            ", ".join(missing),
+            "Please provide them via cli (param:=value) or a config file.",
+        )
 
     # warn if odom_at_imu_rate=true is paired with offline (no offline seq variant)
     if is_offline and odom_at_imu_rate:
@@ -433,7 +438,7 @@ def validate_parameters(merged: dict, mode: str, odom_at_imu_rate: bool) -> dict
         leaked_seq = [p for p in merged if p.startswith("seq.")]
         if leaked_seq:
             print(f"[WARN] seq.* params ignored (not running seq pipeline): {leaked_seq}")
-    if not is_async:
+    if is_seq:
         leaked_async = [p for p in merged if p.startswith("async.")]
         if leaked_async:
             print(f"[WARN] async.* params ignored (not running async pipeline): {leaked_async}")
@@ -456,22 +461,13 @@ def validate_parameters(merged: dict, mode: str, odom_at_imu_rate: bool) -> dict
         p in merged and merged[p] not in ("", None) for p in extrinsic_params
     ]
     if any(extrinsic_set) and not all(extrinsic_set):
-        print("\n\n" + "=" * 40)
-        print("[ERROR] extrinsic parameters incomplete:")
-        print(
+        fail(
+            "[ERROR] extrinsic parameters incomplete:",
             "If one of {} is specified, both must be provided.".format(
                 ", ".join(extrinsic_params)
-            )
+            ),
+            "Please provide them via a config file. If you only need one, then explicitly set the other to identity.",
         )
-        print(
-            "Please provide them via a config file. If you only need one, then explicitly set the other to identity."
-        )
-        print("=" * 40 + "\n\n")
-        import sys
-
-        sys.exit(1)
-
-    return merged
 
 
 def prepare_rviz_config(rviz_config_file: Path, parameters: dict) -> Path:
@@ -534,7 +530,7 @@ def launch_setup(context, *args, **kwargs):
     )
 
     # Prepare parameters
-    cli_params = get_configured_cli_parameters(configurable_parameters, context=context)
+    cli_params = get_configured_cli_parameters(context)
     params_from_file = get_config_file_parameters(context)
     final_params = merge_parameters(
         cli_params=cli_params, file_params=params_from_file
@@ -557,9 +553,7 @@ def launch_setup(context, *args, **kwargs):
             timeout=float(LaunchConfiguration("autodetect_timeout").perform(context)),
         )
 
-    final_params = validate_parameters(
-        final_params, mode=mode, odom_at_imu_rate=odom_at_imu_rate
-    )
+    validate_parameters(final_params, mode=mode, odom_at_imu_rate=odom_at_imu_rate)
 
     print("\n" + "=" * 40 + "\n")
     print("Using Launch configuration:\n")

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,11 @@
   <depend>rosbag2_cpp</depend>
   <depend>rosbag2_storage</depend>
   <depend>rclcpp_components</depend>
+  <!-- launch-time autodetection of topics and the tf tree -->
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>tf2_ros_py</exec_depend>
+  <exec_depend>rosbag2_py</exec_depend>
+  <exec_depend>rosidl_runtime_py</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
ros launch improvements, to make it convenient to use in the cases where much of the required parameters (imu topic, lidar topic, base frame) can be auto-detected in case there's only one imu topic, or lidar topic, or there's the canonical `base`, `base_link`, `base_footprint` frames in the tf tree. 
plus in case of multiple imu or lidar topics, the list is printed to console on launch.

marked experimental, as this is largely vibe coded, and while i've reviewed it, i'll wait on some testing in the wild before a version release.