### PR TITLE
Bump version 0.3.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rko_lio
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* ros, launch: autodetect topics and frames (`#152 <https://github.com/PRBonn/rko_lio/issues/152>`_)
+  the imu and lidar topics, the sensor frames and the base frame are filled in from the running graph, or from the bag in offline mode
+
 0.3.1 (2026-07-16)
 ------------------
 * ros: fix rolling compat break, plus a bunch of deprecation warnings (`#149 <https://github.com/PRBonn/rko_lio/issues/149>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rko_lio
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.3.2 (2026-07-28)
+------------------
 * ros, launch: autodetect topics and frames (`#152 <https://github.com/PRBonn/rko_lio/issues/152>`_)
   the imu and lidar topics, the sensor frames and the base frame are filled in from the running graph, or from the bag in offline mode
 

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?><package format="3">
   <name>rko_lio</name>
-  <version>0.3.1</version>
+  <version>0.3.2</version>
   <description>A Robust Approach for LiDAR-Inertial Odometry Without Sensor-Specific Modelling</description>
   <maintainer email="rm.meher97@gmail.com">Meher Malladi</maintainer>
   <license>MIT</license>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "rko_lio"
-version = "0.3.1"
+version = "0.3.2"
 description = "A Robust Approach for LiDAR-Inertial Odometry Without Sensor-Specific Modelling"
 authors = [{ name = "Meher Malladi", email = "rm.meher97@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
Release 0.3.2.

- changelog for the ros launch parameter autodetection (#152)
- `package.xml` and `pyproject.toml` to 0.3.2, tag `v0.3.2`