### PR TITLE
ros: drop the oldest frame on the online node instead of the latest scan

### DIFF
--- a/docs/pages/config.rst
+++ b/docs/pages/config.rst
@@ -255,7 +255,7 @@ These take effect only in the corresponding mode and otherwise warn that they ar
 
 - **async.max_lidar_buffer_size** (`int`, default ``10``)
 
-  Threaded path only. Caps the lidar buffer; incoming frames are dropped once it is full.
+  Threaded path only. Caps the lidar buffer; the oldest buffered frame is dropped once it is full.
 
 - **seq.odom_at_imu_rate_topic** (default ``rko_lio/odom_at_imu_rate``)
 

--- a/launch/odometry.launch.py
+++ b/launch/odometry.launch.py
@@ -240,7 +240,7 @@ configurable_parameters = [
         "name": "async.max_lidar_buffer_size",
         "default": "10",
         "type": "int",
-        "description": "[threaded only] Max lidar frames buffered before incoming frames are dropped.",
+        "description": "[threaded only] Max lidar frames buffered before the oldest frame is dropped.",
     },
     # seq-pipeline-specific parameters (online with odom_at_imu_rate:=true)
     {

--- a/rko_lio/ros/threaded_node.cpp
+++ b/rko_lio/ros/threaded_node.cpp
@@ -60,18 +60,15 @@ void ThreadedNode::lidar_callback(const sensor_msgs::msg::PointCloud2::ConstShar
   if (!ensure_frame_and_extrinsics(lidar_frame, lidar_msg->header.frame_id, "LiDAR")) {
     return;
   }
-  {
-    const std::scoped_lock lock(buffer_mutex);
-    if (lidar_buffer.size() >= max_lidar_buffer_size) {
-      RCLCPP_WARN_STREAM(node->get_logger(), "Registration lidar buffer limit reached. Dropping frame.");
-      sync_condition_variable.notify_one();
-      return;
-    }
-  }
   try {
     LidarFrame frame = process_lidar_msg(lidar_msg);
     {
       const std::scoped_lock lock(buffer_mutex);
+      if (lidar_buffer.size() >= max_lidar_buffer_size) {
+        RCLCPP_WARN_STREAM(node->get_logger(),
+                           "Registration lidar buffer limit reached. Dropping oldest buffered frame.");
+        lidar_buffer.pop();
+      }
       lidar_buffer.push(std::move(frame));
       atomic_can_process = !imu_buffer.empty() && imu_buffer.back().time > lidar_buffer.front().timestamps.max;
     }


### PR DESCRIPTION
a small change, that can lead to a big difference in runtime behaviour. especially in the less tested case where there are consecutive frame drops and the system still has to keep up. addresses #154 but i'm going to leave this open until i have confidence this doesn't break things unexpectedly.