### PR TITLE
core, perf: improve closest neighbour search by early pruning voxels

### DIFF
--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -154,10 +154,10 @@ LinearSystem build_icp_linear_system(const Sophus::SE3d& current_pose,
         return std::transform_reduce(r.begin(), r.end(), J, linear_system_reduce, [&](const auto& point) {
           // Compute data association and linear system
           const Eigen::Vector3d transformed_point = current_pose * point;
-          const auto& [closest_neighbor, distance] = voxel_map.get_closest_neighbor(transformed_point);
-          if (distance < max_correspondence_distance) {
+          const auto closest_neighbor = voxel_map.get_closest_neighbor(transformed_point, max_correspondence_distance);
+          if (closest_neighbor.has_value()) {
             correspondences_counter++;
-            return linear_system_for_one_point(transformed_point, closest_neighbor);
+            return linear_system_for_one_point(transformed_point, **closest_neighbor);
           }
           // TODO (meher): additional 0 add flops, which may hurt single threaded perf slightly
           return LinearSystem(Eigen::Matrix6d::Zero(), Eigen::Vector6d::Zero(), 0.0);

--- a/rko_lio/core/voxel_hash_map.cpp
+++ b/rko_lio/core/voxel_hash_map.cpp
@@ -25,7 +25,7 @@
 // although it was heavily modifed and drastically simplified, but if you are using this module you
 // should at least acknoowledge the work from CT-ICP by giving a star on GitHub.
 //
-// Ported to rko_lio from kiss-icp (kiss_icp/cpp/kiss_icp/core/VoxelHashMap.{hpp,cpp}).
+// Modified from kiss-icp (kiss_icp/cpp/kiss_icp/core/VoxelHashMap.{hpp,cpp}).
 
 #include "voxel_hash_map.hpp"
 
@@ -41,18 +41,19 @@
 namespace {
 using rko_lio::core::Voxel;
 
+// the order of the shifts is deliberate
 static const std::array<Voxel, 27> shifts{
-    Voxel{-1, -1, -1}, Voxel{-1, -1, 0}, Voxel{-1, -1, 1}, //
-    Voxel{-1, 0, -1},  Voxel{-1, 0, 0},  Voxel{-1, 0, 1},  //
-    Voxel{-1, 1, -1},  Voxel{-1, 1, 0},  Voxel{-1, 1, 1},  //
+    Voxel{0, 0, 0}, // home
 
-    Voxel{0, -1, -1},  Voxel{0, -1, 0},  Voxel{0, -1, 1},  //
-    Voxel{0, 0, -1},   Voxel{0, 0, 0},   Voxel{0, 0, 1},   //
-    Voxel{0, 1, -1},   Voxel{0, 1, 0},   Voxel{0, 1, 1},   //
+    Voxel{-1, 0, 0},   Voxel{0, -1, 0},  Voxel{0, 0, -1}, // faces
+    Voxel{0, 0, 1},    Voxel{0, 1, 0},   Voxel{1, 0, 0},
 
-    Voxel{1, -1, -1},  Voxel{1, -1, 0},  Voxel{1, -1, 1}, //
-    Voxel{1, 0, -1},   Voxel{1, 0, 0},   Voxel{1, 0, 1},  //
-    Voxel{1, 1, -1},   Voxel{1, 1, 0},   Voxel{1, 1, 1}};
+    Voxel{-1, -1, 0},  Voxel{-1, 0, -1}, Voxel{-1, 0, 1}, // edges
+    Voxel{-1, 1, 0},   Voxel{0, -1, -1}, Voxel{0, -1, 1},  Voxel{0, 1, -1}, Voxel{0, 1, 1},
+    Voxel{1, -1, 0},   Voxel{1, 0, -1},  Voxel{1, 0, 1},   Voxel{1, 1, 0},
+
+    Voxel{-1, -1, -1}, Voxel{-1, -1, 1}, Voxel{-1, 1, -1}, // corners
+    Voxel{-1, 1, 1},   Voxel{1, -1, -1}, Voxel{1, -1, 1},  Voxel{1, 1, -1}, Voxel{1, 1, 1}};
 
 } // namespace
 
@@ -66,27 +67,43 @@ VoxelHashMap::VoxelHashMap(const double voxel_size,
       clipping_distance_(clipping_distance),
       max_points_per_voxel_(max_points_per_voxel) {}
 
-std::tuple<Eigen::Vector3d, double> VoxelHashMap::get_closest_neighbor(const Eigen::Vector3d& query) const {
-  Eigen::Vector3d closest_neighbor = Eigen::Vector3d::Zero();
-  double closest_distance = std::numeric_limits<double>::max();
+std::optional<VoxelBlock::const_iterator> VoxelHashMap::get_closest_neighbor(const Eigen::Vector3d& query,
+                                                                             const double max_distance) const {
+  double closest_distance_sq = max_distance * max_distance;
+  std::optional<VoxelBlock::const_iterator> closest;
   const Voxel voxel = point_to_voxel(query, inv_voxel_size_);
-  std::for_each(shifts.cbegin(), shifts.cend(), [&](const Voxel& voxel_shift) {
-    const Voxel query_voxel = voxel + voxel_shift;
-    const auto search = map_.find(query_voxel);
-    if (search != map_.end()) {
-      const VoxelBlock& voxel_points = search.value();
-      const Eigen::Vector3d& neighbor =
-          *std::min_element(voxel_points.cbegin(), voxel_points.cend(), [&](const auto& lhs, const auto& rhs) {
-            return (lhs - query).squaredNorm() < (rhs - query).squaredNorm();
-          });
-      double distance = (neighbor - query).norm();
-      if (distance < closest_distance) {
-        closest_neighbor = neighbor;
-        closest_distance = distance;
+
+  // lower_bounds is squared distance from the query to the near face of a neighbouring voxel, per axis.
+  // Columns are indexed by voxel shift + 1, rows are axes
+  const Eigen::Vector3d offset = query - voxel.cast<double>() * voxel_size_;
+  const Eigen::Vector3d to_far = Eigen::Vector3d::Constant(voxel_size_) - offset;
+  Eigen::Matrix3d lower_bounds;
+  lower_bounds.col(0) = offset.array().square();
+  lower_bounds.col(1).setZero();
+  lower_bounds.col(2) = to_far.array().square();
+
+  for (const Voxel& shift : shifts) {
+    // lower bound on the distance to query within this voxel + shift
+    const double lower_bound_sq =
+        lower_bounds(0, shift.x() + 1) + lower_bounds(1, shift.y() + 1) + lower_bounds(2, shift.z() + 1);
+    if (lower_bound_sq >= closest_distance_sq) {
+      continue;
+    }
+    const auto search = map_.find(voxel + shift);
+    if (search == map_.end()) {
+      continue;
+    }
+    // returning an iterator rather than a copy reduces branching (with the usual compiler caveats)
+    const VoxelBlock& voxel_points = search.value();
+    for (auto neighbor = voxel_points.cbegin(); neighbor != voxel_points.cend(); ++neighbor) {
+      const double distance_sq = (*neighbor - query).squaredNorm();
+      if (distance_sq < closest_distance_sq) {
+        closest_distance_sq = distance_sq;
+        closest = neighbor;
       }
     }
-  });
-  return std::make_tuple(closest_neighbor, closest_distance);
+  }
+  return closest;
 }
 
 void VoxelHashMap::add_points(const std::vector<Eigen::Vector3d>& points) {

--- a/rko_lio/core/voxel_hash_map.hpp
+++ b/rko_lio/core/voxel_hash_map.hpp
@@ -25,13 +25,14 @@
 // although it was heavily modifed and drastically simplified, but if you are using this module you
 // should at least acknoowledge the work from CT-ICP by giving a star on GitHub.
 //
-// Ported to rko_lio from kiss-icp (kiss_icp/cpp/kiss_icp/core/VoxelHashMap.{hpp,cpp}).
+// modified from kiss-icp (kiss_icp/cpp/kiss_icp/core/VoxelHashMap.{hpp,cpp}).
 #pragma once
 
 // brings VoxelHash and point_to_voxel
 #include "voxel_down_sample.hpp"
 
 #include <Eigen/Core>
+#include <optional>
 #include <sophus/se3.hpp>
 #include <tsl/robin_map.h>
 #include <tuple>
@@ -53,7 +54,10 @@ struct VoxelHashMap {
   void add_points(const std::vector<Eigen::Vector3d>& points);
   void remove_points_far_from_location(const Eigen::Vector3d& origin);
   std::vector<Eigen::Vector3d> pointcloud() const;
-  std::tuple<Eigen::Vector3d, double> get_closest_neighbor(const Eigen::Vector3d& query) const;
+
+  /// Iterator to nearest point to `query` strictly within `max_distance`, or nullopt if there is none.
+  std::optional<VoxelBlock::const_iterator> get_closest_neighbor(const Eigen::Vector3d& query,
+                                                                 const double max_distance) const;
 
   double voxel_size_;
   double inv_voxel_size_;


### PR DESCRIPTION
First of a series of prs targeting performance improvements. By the end of this, I aim to significantly improve single threaded performance at least on the ROS side of things (the goal is OS0 single thread at sensor frame rate).

This one is about the correspondence search, **the** dominant bottleneck in the entire registration loop. Correspondence search is dominantly memory bound, as accessing one neighbor is a hash table lookup and a memory fetch (pointer chasing and subsequent cache misses). Obviously, the less number of buckets we look up, the better the performance. Consider also that typical voxel size is 1m. As through all my testing, smaller voxel sizes are rarely required. And max correspondence distance is 0.5m. Ever since I dropped the adaptive distance threshold from kiss as 0.5m just worked everywhere (i will look into bringing back the adaptive search a la lio-ekf fashion). Thats a ball of 1m diameter for the neighbor search, and its easy to see that for a query point only a limited number of cells and not all 27 will matter.

So the first trick is to compute which cell can even possibly contain a point within 0.5m from the query. 
The second trick is to order the search in increasing distance to the query point, i.e. start from the home cell and then go outward. As soon as a close(r) point is found, the pruning above gets more aggresive.

The last two tricks in this pr, are minor compute improvements, where the distance comparison is done once instead of twice, and using an iterator to the closest map point leads to better code gen over making copies (obviously there was some profiling going on to figure out these were even a thing and then it was improved). 

has an api change for the nearest neighbor search.
the output is also verified byte-identical on some testing sequences.

Following are results on one bag with a hesai jt128 and an ouster os0. both scans pre-deskewed. so that part is not exercised, but it should be a linear delta on top, and relatively small.

<img width="1168" height="407" alt="image" src="https://github.com/user-attachments/assets/df8a3532-0a4f-4d55-b1d7-989217b56163" />

the m + 1 sigma is the mean time plus 1 sigma std dev per scan registration (note, not just the icp, thats even higher multipliers). the goal as i said at the start by the end of more prs, is to get to m + 2 sigma under 100ms for single threaded os0 (at default voxel size and map range).