### PR TITLE
core, cleanup: linear system build cleanup, and voxel map op unification

### DIFF
--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -122,49 +122,54 @@ LinearSystem build_icp_linear_system(const Sophus::SE3d& current_pose,
                                      const rko_lio::core::Vector3dVector& frame,
                                      const rko_lio::core::VoxelHashMap& voxel_map,
                                      const double& max_correspondence_distance) {
-  auto linear_system_reduce = [](LinearSystem lhs, const LinearSystem& rhs) {
-    auto& [lhs_H, lhs_b, lhs_chi] = lhs;
-    const auto& [rhs_H, rhs_b, rhs_chi] = rhs;
-    lhs_H += rhs_H;
-    lhs_b += rhs_b;
-    lhs_chi += rhs_chi;
-    return lhs;
-  };
+  using IcpAccum = std::tuple<Eigen::Matrix6d, Eigen::Vector6d, double, int>;
 
   auto linear_system_for_one_point = [](const Eigen::Vector3d& source, const Eigen::Vector3d& target) {
     Eigen::Matrix3_6d J_r;
     J_r.block<3, 3>(0, 0) = Eigen::Matrix3d::Identity();
     J_r.block<3, 3>(0, 3) = -1.0 * Sophus::SO3d::hat(source);
     const Eigen::Vector3d residual = source - target;
-    return LinearSystem(J_r.transpose() * J_r,      // JTJ
-                        J_r.transpose() * residual, // JTr
-                        residual.squaredNorm());    // chi
+    return IcpAccum(J_r.transpose() * J_r,      // JTJ
+                    J_r.transpose() * residual, // JTr
+                    residual.squaredNorm(),     // chi
+                    1);                         // correspondence
   };
 
   // The only parallel part
   using points_iterator = std::vector<Eigen::Vector3d>::const_iterator;
-  std::atomic<int> correspondences_counter = 0;
-  const auto& [H_icp, b_icp, chi_icp] = tbb::parallel_reduce(
+  const auto& [H_icp, b_icp, chi_icp, correspondences_counter] = tbb::parallel_reduce(
       // Range
       tbb::blocked_range<points_iterator>{frame.cbegin(), frame.cend()},
       // Identity
-      LinearSystem(Eigen::Matrix6d::Zero(), Eigen::Vector6d::Zero(), 0.0),
+      IcpAccum(Eigen::Matrix6d::Zero(), Eigen::Vector6d::Zero(), 0.0, 0),
       // 1st Lambda: Parallel computation
-      [&](const tbb::blocked_range<points_iterator>& r, LinearSystem J) -> LinearSystem {
-        return std::transform_reduce(r.begin(), r.end(), J, linear_system_reduce, [&](const auto& point) {
-          // Compute data association and linear system
+      [&](const tbb::blocked_range<points_iterator>& r, IcpAccum J) -> IcpAccum {
+        auto& [H, b, chi, correspondences] = J;
+        for (const Eigen::Vector3d& point : r) {
           const Eigen::Vector3d transformed_point = current_pose * point;
           const auto& [closest_neighbor, distance] = voxel_map.get_closest_neighbor(transformed_point);
-          if (distance < max_correspondence_distance) {
-            correspondences_counter++;
-            return linear_system_for_one_point(transformed_point, closest_neighbor);
+          if (distance >= max_correspondence_distance) {
+            continue;
           }
-          // TODO (meher): additional 0 add flops, which may hurt single threaded perf slightly
-          return LinearSystem(Eigen::Matrix6d::Zero(), Eigen::Vector6d::Zero(), 0.0);
-        });
+          const auto& [point_H, point_b, point_chi, point_n] =
+              linear_system_for_one_point(transformed_point, closest_neighbor);
+          H += point_H;
+          b += point_b;
+          chi += point_chi;
+          correspondences += point_n;
+        }
+        return J;
       },
       // 2nd Lambda: Parallel reduction of the private Jacobians
-      linear_system_reduce);
+      [](IcpAccum lhs, const IcpAccum& rhs) {
+        auto& [lhs_H, lhs_b, lhs_chi, lhs_n] = lhs;
+        const auto& [rhs_H, rhs_b, rhs_chi, rhs_n] = rhs;
+        lhs_H += rhs_H;
+        lhs_b += rhs_b;
+        lhs_chi += rhs_chi;
+        lhs_n += rhs_n;
+        return lhs;
+      });
 
   if (correspondences_counter == 0) {
     throw std::runtime_error("Number of correspondences are 0.");

--- a/rko_lio/core/voxel_hash_map.cpp
+++ b/rko_lio/core/voxel_hash_map.cpp
@@ -41,18 +41,17 @@
 namespace {
 using rko_lio::core::Voxel;
 
-static const std::array<Voxel, 27> shifts{
-    Voxel{-1, -1, -1}, Voxel{-1, -1, 0}, Voxel{-1, -1, 1}, //
-    Voxel{-1, 0, -1},  Voxel{-1, 0, 0},  Voxel{-1, 0, 1},  //
-    Voxel{-1, 1, -1},  Voxel{-1, 1, 0},  Voxel{-1, 1, 1},  //
+static const std::array<Voxel, 27> shifts{Voxel{-1, -1, -1}, Voxel{-1, -1, 0}, Voxel{-1, -1, 1}, //
+                                          Voxel{-1, 0, -1},  Voxel{-1, 0, 0},  Voxel{-1, 0, 1},  //
+                                          Voxel{-1, 1, -1},  Voxel{-1, 1, 0},  Voxel{-1, 1, 1},  //
 
-    Voxel{0, -1, -1},  Voxel{0, -1, 0},  Voxel{0, -1, 1},  //
-    Voxel{0, 0, -1},   Voxel{0, 0, 0},   Voxel{0, 0, 1},   //
-    Voxel{0, 1, -1},   Voxel{0, 1, 0},   Voxel{0, 1, 1},   //
+                                          Voxel{0, -1, -1},  Voxel{0, -1, 0},  Voxel{0, -1, 1}, //
+                                          Voxel{0, 0, -1},   Voxel{0, 0, 0},   Voxel{0, 0, 1},  //
+                                          Voxel{0, 1, -1},   Voxel{0, 1, 0},   Voxel{0, 1, 1},  //
 
-    Voxel{1, -1, -1},  Voxel{1, -1, 0},  Voxel{1, -1, 1}, //
-    Voxel{1, 0, -1},   Voxel{1, 0, 0},   Voxel{1, 0, 1},  //
-    Voxel{1, 1, -1},   Voxel{1, 1, 0},   Voxel{1, 1, 1}};
+                                          Voxel{1, -1, -1},  Voxel{1, -1, 0},  Voxel{1, -1, 1}, //
+                                          Voxel{1, 0, -1},   Voxel{1, 0, 0},   Voxel{1, 0, 1},  //
+                                          Voxel{1, 1, -1},   Voxel{1, 1, 0},   Voxel{1, 1, 1}};
 
 } // namespace
 
@@ -89,9 +88,10 @@ std::tuple<Eigen::Vector3d, double> VoxelHashMap::get_closest_neighbor(const Eig
   return std::make_tuple(closest_neighbor, closest_distance);
 }
 
-void VoxelHashMap::add_points(const std::vector<Eigen::Vector3d>& points) {
+void VoxelHashMap::add_points(const std::vector<Eigen::Vector3d>& points, const Sophus::SE3d& pose) {
   const double map_resolution_sq = voxel_size_ * voxel_size_ / max_points_per_voxel_;
-  std::for_each(points.cbegin(), points.cend(), [&](const Eigen::Vector3d& p) {
+  std::for_each(points.cbegin(), points.cend(), [&](const Eigen::Vector3d& point) {
+    const Eigen::Vector3d p = pose * point;
     const Voxel voxel = point_to_voxel(p, inv_voxel_size_);
     auto it = map_.try_emplace(voxel).first;
     VoxelBlock& voxel_points = it.value();
@@ -118,12 +118,8 @@ void VoxelHashMap::remove_points_far_from_location(const Eigen::Vector3d& origin
 }
 
 void VoxelHashMap::update(const std::vector<Eigen::Vector3d>& points, const Sophus::SE3d& pose) {
-  std::vector<Eigen::Vector3d> points_transformed(points.size());
-  std::transform(points.cbegin(), points.cend(), points_transformed.begin(),
-                 [&](const auto& point) { return pose * point; });
-  const Eigen::Vector3d& origin = pose.translation();
-  add_points(points_transformed);
-  remove_points_far_from_location(origin);
+  add_points(points, pose);
+  remove_points_far_from_location(pose.translation());
 }
 
 std::vector<Eigen::Vector3d> VoxelHashMap::pointcloud() const {

--- a/rko_lio/core/voxel_hash_map.hpp
+++ b/rko_lio/core/voxel_hash_map.hpp
@@ -50,7 +50,7 @@ struct VoxelHashMap {
   void clear() { map_.clear(); }
   bool empty() const { return map_.empty(); }
   void update(const std::vector<Eigen::Vector3d>& points, const Sophus::SE3d& pose);
-  void add_points(const std::vector<Eigen::Vector3d>& points);
+  void add_points(const std::vector<Eigen::Vector3d>& points, const Sophus::SE3d& pose);
   void remove_points_far_from_location(const Eigen::Vector3d& origin);
   std::vector<Eigen::Vector3d> pointcloud() const;
   std::tuple<Eigen::Vector3d, double> get_closest_neighbor(const Eigen::Vector3d& query) const;


### PR DESCRIPTION
minor clean up that honestly doesnt really do much on top of #157. in fact, this hurts on single thread, because in the icp build system loop where earlier was a simple correspondence counter, is now a more elaborate tuple structure that adds overhead and hurts. nevertheless, the atomic counter was hurting in multi thread situations. in the end a tradeoff, and i prefer the current one where we dont have concurrency primitives on the hot path.

probably at some point i can even drop the tbb stuff entirely, as prs from #157 upwards are to improve single threaded performance for ROS. nevertheless, multi threaded will be faster for offline processing, and if available, why not use it. hence it remains.