### PR TITLE
core, perf: reducing scan copies

### DIFF
--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -104,17 +104,15 @@ template <typename Functor>
   requires requires(Functor f, Nsec stamp) {
     { f(stamp) } -> std::same_as<Sophus::SE3d>;
   }
-Vector3dVector deskew_scan(const Vector3dVector& frame,
-                           const TimestampVector& timestamps,
-                           const Nsec end_time,
-                           const Functor& relative_pose_at_time) {
+void deskew_scan(Vector3dVector& frame,
+                 const TimestampVector& timestamps,
+                 const Nsec end_time,
+                 const Functor& relative_pose_at_time) {
   const Sophus::SE3d scan_to_scan_motion_inverse = relative_pose_at_time(end_time).inverse();
-  Vector3dVector deskewed(frame.size());
-  std::transform(frame.cbegin(), frame.cend(), timestamps.cbegin(), deskewed.begin(),
+  std::transform(frame.cbegin(), frame.cend(), timestamps.cbegin(), frame.begin(),
                  [&](const Eigen::Vector3d& point, const Nsec timestamp) {
                    return (scan_to_scan_motion_inverse * relative_pose_at_time(timestamp)) * point;
                  });
-  return deskewed;
 }
 
 using LinearSystem = std::tuple<Eigen::Matrix6d, Eigen::Vector6d, double>;
@@ -418,7 +416,7 @@ void LIO::add_imu_measurement(const Sophus::SE3d& extrinsic_imu2base, const ImuC
 
 // ============================ lidar ===============================
 
-Vector3dVector LIO::register_scan(const Vector3dVector& scan, const TimestampVector& timestamps) {
+Vector3dVector LIO::register_scan(Vector3dVector scan, const TimestampVector& timestamps) {
   if (timestamps.empty()) {
     throw std::invalid_argument("LIO::register_scan: timestamps must not be empty.");
   }
@@ -456,14 +454,16 @@ Vector3dVector LIO::register_scan(const Vector3dVector& scan, const TimestampVec
   mean_body_acceleration = kf_step.updated.mean;
   body_acceleration_covariance = kf_step.updated.covariance;
 
-  auto preproc_result =
-      config.deskew ? preprocess_scan(deskew_scan(scan, timestamps, current_lidar_time, relative_pose_at_time), config)
-                    : preprocess_scan(scan, config);
+  if (config.deskew) {
+    deskew_scan(scan, timestamps, current_lidar_time, relative_pose_at_time);
+  }
+  const std::size_t input_scan_size = scan.size();
+  auto preproc_result = preprocess_scan(std::move(scan), config);
 
   if (preproc_result.keypoints.size() < 10) {
     const std::string error_msg =
         "Keypoints for ICP registration = " + std::to_string(preproc_result.keypoints.size()) +
-        ", this is too little for ICP and likely unintended. Input scan size = " + std::to_string(scan.size()) +
+        ", this is too little for ICP and likely unintended. Input scan size = " + std::to_string(input_scan_size) +
         ". Config voxel size = " + std::to_string(config.voxel_size) +
         ". Either the input scan is corrupt (empty) or the downsampling is too aggressive.";
     throw std::invalid_argument(error_msg);
@@ -502,17 +502,13 @@ Vector3dVector LIO::register_scan(const Vector3dVector& scan, const TimestampVec
   return std::move(preproc_result.filtered_frame);
 }
 
-Vector3dVector LIO::register_scan(const Sophus::SE3d& extrinsic_lidar2base,
-                                  const Vector3dVector& scan,
-                                  const TimestampVector& timestamps) {
+Vector3dVector
+LIO::register_scan(const Sophus::SE3d& extrinsic_lidar2base, Vector3dVector scan, const TimestampVector& timestamps) {
   if (extrinsic_lidar2base.log().norm() < EPSILON) {
-    return register_scan(scan, timestamps);
+    return register_scan(std::move(scan), timestamps);
   }
-
-  Vector3dVector transformed_scan(scan.size());
-  std::transform(scan.cbegin(), scan.cend(), transformed_scan.begin(),
-                 [&](const Eigen::Vector3d& p) { return extrinsic_lidar2base * p; });
-  Vector3dVector frame = register_scan(transformed_scan, timestamps);
+  transform_points(extrinsic_lidar2base, scan);
+  Vector3dVector frame = register_scan(std::move(scan), timestamps);
   transform_points(extrinsic_lidar2base.inverse(), frame);
   return frame;
 }

--- a/rko_lio/core/lio.hpp
+++ b/rko_lio/core/lio.hpp
@@ -119,7 +119,7 @@ public:
    * @param timestamps Absolute timestamps corresponding to each scan point.
    * @return Deskewed and clipped point cloud.
    */
-  Vector3dVector register_scan(const Vector3dVector& scan, const TimestampVector& timestamps);
+  Vector3dVector register_scan(Vector3dVector scan, const TimestampVector& timestamps);
 
   /**
    * Register a LiDAR scan for which the extrinsic calibration from lidar to base
@@ -130,7 +130,7 @@ public:
    * @return Deskewed and clipped scan in the original lidar frame.
    */
   Vector3dVector register_scan(const Sophus::SE3d& extrinsic_lidar2base,
-                               const Vector3dVector& scan,
+                               Vector3dVector scan,
                                const TimestampVector& timestamps);
 
   /** Sequence of registered scan poses with corresponding timestamps. */

--- a/rko_lio/core/preprocess_scan.cpp
+++ b/rko_lio/core/preprocess_scan.cpp
@@ -3,27 +3,22 @@
 
 namespace rko_lio::core {
 
-PreprocessingResult preprocess_scan(const Vector3dVector& frame, const LIO::Config& config) {
-  Vector3dVector clipped_frame;
-  clipped_frame.reserve(frame.size());
-
-  std::for_each(frame.cbegin(), frame.cend(), [&](const auto& point) {
+PreprocessingResult preprocess_scan(Vector3dVector frame, const LIO::Config& config) {
+  std::erase_if(frame, [&](const auto& point) {
     const double point_range = point.norm();
-    if (point_range > config.min_range && point_range < config.max_range) {
-      clipped_frame.emplace_back(point);
-    }
+    // negation handles nans as well
+    return !(point_range > config.min_range && point_range < config.max_range);
   });
-  clipped_frame.shrink_to_fit();
 
   if (config.double_downsample) {
-    Vector3dVector downsampled_frame = voxel_down_sample(clipped_frame, config.voxel_size * 0.5);
+    Vector3dVector downsampled_frame = voxel_down_sample(frame, config.voxel_size * 0.5);
     Vector3dVector keypoints = voxel_down_sample(downsampled_frame, config.voxel_size * 1.5);
-    return {.filtered_frame = std::move(clipped_frame),
+    return {.filtered_frame = std::move(frame),
             .keypoints = std::move(keypoints),
             .map_frame = std::move(downsampled_frame)};
   }
-  Vector3dVector keypoints = voxel_down_sample(clipped_frame, config.voxel_size);
-  return {.filtered_frame = std::move(clipped_frame), .keypoints = std::move(keypoints), .map_frame = {}};
+  Vector3dVector keypoints = voxel_down_sample(frame, config.voxel_size);
+  return {.filtered_frame = std::move(frame), .keypoints = std::move(keypoints), .map_frame = {}};
 }
 
 } // namespace rko_lio::core

--- a/rko_lio/core/preprocess_scan.hpp
+++ b/rko_lio/core/preprocess_scan.hpp
@@ -13,6 +13,6 @@ struct PreprocessingResult {
 };
 
 // clip and downsample the input cloud
-PreprocessingResult preprocess_scan(const Vector3dVector& frame, const LIO::Config& config);
+PreprocessingResult preprocess_scan(Vector3dVector frame, const LIO::Config& config);
 
 } // namespace rko_lio::core

--- a/rko_lio/core/process_timestamps.cpp
+++ b/rko_lio/core/process_timestamps.cpp
@@ -62,14 +62,14 @@ Timestamps timestamps_from_raw(const std::vector<double>& raw_timestamps, const 
     multiplier_to_ns = multiplier_to_seconds * 1e9;
   }
 
-  TimestampVector times_ns(raw_timestamps.size());
-  std::transform(raw_timestamps.cbegin(), raw_timestamps.cend(), times_ns.begin(),
+  Timestamps timestamps{.min = raw_to_ns(min_stamp, multiplier_to_ns, source_is_ns),
+                        .max = raw_to_ns(max_stamp, multiplier_to_ns, source_is_ns),
+                        .per_point = TimestampVector(raw_timestamps.size())};
+  std::transform(raw_timestamps.cbegin(), raw_timestamps.cend(), timestamps.per_point.begin(),
                  [multiplier_to_ns, source_is_ns](const double ts) {
                    return raw_to_ns(ts, multiplier_to_ns, source_is_ns);
                  });
-  return {.min = raw_to_ns(min_stamp, multiplier_to_ns, source_is_ns),
-          .max = raw_to_ns(max_stamp, multiplier_to_ns, source_is_ns),
-          .times = times_ns};
+  return timestamps;
 }
 } // namespace
 
@@ -93,7 +93,7 @@ Timestamps process_timestamps(const std::vector<double>& raw_timestamps,
       config.force_relative || (std::chrono::abs(timestamps.min) < 1ms) || (std::chrono::abs(timestamps.max) < 10ms);
 
   if (relative_stamps) {
-    std::transform(timestamps.times.cbegin(), timestamps.times.cend(), timestamps.times.begin(),
+    std::transform(timestamps.per_point.cbegin(), timestamps.per_point.cend(), timestamps.per_point.begin(),
                    [header_stamp](const Nsec ts) { return ts + header_stamp; });
     timestamps.min += header_stamp;
     timestamps.max += header_stamp;

--- a/rko_lio/core/process_timestamps.hpp
+++ b/rko_lio/core/process_timestamps.hpp
@@ -37,7 +37,7 @@ namespace rko_lio::core {
 struct Timestamps {
   Nsec min;
   Nsec max;
-  TimestampVector times;
+  TimestampVector per_point;
 };
 
 /**

--- a/rko_lio/ros/base_node.cpp
+++ b/rko_lio/ros/base_node.cpp
@@ -229,26 +229,27 @@ bool BaseNode::check_and_set_extrinsics() {
   return true;
 }
 
-std::tuple<core::Timestamps, core::Vector3dVector>
-BaseNode::process_lidar_msg(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& lidar_msg) const {
+LidarFrame BaseNode::process_lidar_msg(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& lidar_msg) const {
   const core::Nsec header_stamp = utils::to_ns(lidar_msg->header.stamp);
   if (lio->config.deskew) {
-    const auto& [scan, raw_timestamps] = utils::point_cloud2_to_eigen_with_timestamps(lidar_msg);
-    const core::Timestamps& timestamps = core::process_timestamps(raw_timestamps, header_stamp, timestamp_proc_config);
-    return {timestamps, scan};
+    utils::RawScan scan = utils::point_cloud2_to_eigen_with_timestamps(lidar_msg);
+    return {.timestamps = core::process_timestamps(scan.timestamps, header_stamp, timestamp_proc_config),
+            .points = std::move(scan.points)};
   }
   RCLCPP_WARN_STREAM_ONCE(node->get_logger(), "Deskewing is disabled. Populating timestamps with static header time.");
-  const core::Vector3dVector scan = utils::point_cloud2_to_eigen(lidar_msg);
-  return {{.min = header_stamp, .max = header_stamp, .times = core::TimestampVector(scan.size(), header_stamp)}, scan};
+  LidarFrame frame{.timestamps = {.min = header_stamp, .max = header_stamp},
+                   .points = utils::point_cloud2_to_eigen(lidar_msg)};
+  frame.timestamps.per_point.assign(frame.points.size(), header_stamp);
+  return frame;
 }
 
-core::Vector3dVector BaseNode::register_scan_locked(const core::Vector3dVector& scan,
+core::Vector3dVector BaseNode::register_scan_locked(core::Vector3dVector scan,
                                                     const core::TimestampVector& time_vector) {
+  std::unique_lock lock(local_map_mutex, std::defer_lock);
   if (publish_local_map) {
-    std::lock_guard lock(local_map_mutex); // map publish thread may access map simultaneously
-    return lio->register_scan(extrinsic_lidar2base, scan, time_vector);
+    lock.lock(); // map publish thread may access map simultaneously
   }
-  return lio->register_scan(extrinsic_lidar2base, scan, time_vector);
+  return lio->register_scan(extrinsic_lidar2base, std::move(scan), time_vector);
 }
 
 void BaseNode::publish_lidar_outputs(const core::Vector3dVector& deskewed_frame) const {

--- a/rko_lio/ros/base_node.hpp
+++ b/rko_lio/ros/base_node.hpp
@@ -33,7 +33,6 @@
 #include <string>
 #include <string_view>
 #include <thread>
-#include <tuple>
 // ros
 #include <geometry_msgs/msg/accel_stamped.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
@@ -47,6 +46,11 @@
 #include <tf2_ros/transform_listener.hpp>
 
 namespace rko_lio::ros {
+
+struct LidarFrame {
+  core::Timestamps timestamps;
+  core::Vector3dVector points;
+};
 // Shared helper used by both the threaded and sequential nodes.
 core::ImuControl imu_msg_to_imu_data(const sensor_msgs::msg::Imu& imu_msg);
 
@@ -109,10 +113,9 @@ public:
                                    const std::string& msg_frame,
                                    std::string_view kind);
 
-  std::tuple<core::Timestamps, core::Vector3dVector>
-  process_lidar_msg(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& lidar_msg) const;
+  LidarFrame process_lidar_msg(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& lidar_msg) const;
 
-  core::Vector3dVector register_scan_locked(const core::Vector3dVector& scan, const core::TimestampVector& time_vector);
+  core::Vector3dVector register_scan_locked(core::Vector3dVector scan, const core::TimestampVector& time_vector);
 
   void publish_lidar_outputs(const core::Vector3dVector& deskewed_frame) const;
 

--- a/rko_lio/ros/online_imu_rate_node.cpp
+++ b/rko_lio/ros/online_imu_rate_node.cpp
@@ -108,8 +108,9 @@ public:
     }
 
     try {
-      const auto [timestamps, scan] = process_lidar_msg(lidar_msg);
-      const core::Vector3dVector deskewed_frame = register_scan_locked(scan, timestamps.times);
+      LidarFrame frame = process_lidar_msg(lidar_msg);
+      const core::Vector3dVector deskewed_frame =
+          register_scan_locked(std::move(frame.points), frame.timestamps.per_point);
       if (deskewed_frame.empty()) {
         // first frame is skipped and an empty frame is returned. nothing to publish.
         return;

--- a/rko_lio/ros/threaded_node.cpp
+++ b/rko_lio/ros/threaded_node.cpp
@@ -35,9 +35,10 @@ using namespace std::literals;
 
 namespace rko_lio::ros {
 
-ThreadedNode::ThreadedNode(const std::string& node_name, const rclcpp::NodeOptions& options) : BaseNode(node_name, options) {
-  max_lidar_buffer_size = static_cast<size_t>(node->declare_parameter<int>(
-      "async.max_lidar_buffer_size", static_cast<int>(max_lidar_buffer_size)));
+ThreadedNode::ThreadedNode(const std::string& node_name, const rclcpp::NodeOptions& options)
+    : BaseNode(node_name, options) {
+  max_lidar_buffer_size = static_cast<size_t>(
+      node->declare_parameter<int>("async.max_lidar_buffer_size", static_cast<int>(max_lidar_buffer_size)));
   registration_thread = std::jthread([this]() { registration_loop(); });
 }
 
@@ -68,10 +69,10 @@ void ThreadedNode::lidar_callback(const sensor_msgs::msg::PointCloud2::ConstShar
     }
   }
   try {
-    const auto [timestamps, scan] = process_lidar_msg(lidar_msg);
+    LidarFrame frame = process_lidar_msg(lidar_msg);
     {
       std::lock_guard lock(buffer_mutex);
-      lidar_buffer.emplace(timestamps, scan);
+      lidar_buffer.push(std::move(frame));
       atomic_can_process = !imu_buffer.empty() && imu_buffer.back().time > lidar_buffer.front().timestamps.max;
     }
     if (atomic_can_process) {
@@ -94,8 +95,7 @@ void ThreadedNode::registration_loop() {
     LidarFrame frame = std::move(lidar_buffer.front());
     lidar_buffer.pop();
     registration_busy = true;
-    const auto& [timestamps, scan] = frame;
-    const auto& [start_stamp, end_stamp, time_vector] = timestamps;
+    const core::Nsec end_stamp = frame.timestamps.max;
     for (; !imu_buffer.empty() && imu_buffer.front().time < end_stamp; imu_buffer.pop()) {
       const core::ImuControl& imu_data = imu_buffer.front();
       lio->add_imu_measurement(extrinsic_imu2base, imu_data);
@@ -106,7 +106,8 @@ void ThreadedNode::registration_loop() {
     buffer_lock.unlock(); // we dont touch the buffers anymore
 
     try {
-      const core::Vector3dVector deskewed_frame = register_scan_locked(scan, time_vector);
+      const core::Vector3dVector deskewed_frame =
+          register_scan_locked(std::move(frame.points), frame.timestamps.per_point);
       if (!deskewed_frame.empty()) {
         // TODO: first frame is skipped and an empty frame is returned. improve how we handle this
         publish_lidar_outputs(deskewed_frame);

--- a/rko_lio/ros/threaded_node.hpp
+++ b/rko_lio/ros/threaded_node.hpp
@@ -36,11 +36,6 @@
 
 namespace rko_lio::ros {
 
-struct LidarFrame {
-  core::Timestamps timestamps;
-  core::Vector3dVector points;
-};
-
 class ThreadedNode : public BaseNode {
 public:
   std::jthread registration_thread;

--- a/rko_lio/ros/utils/point_cloud_read.cpp
+++ b/rko_lio/ros/utils/point_cloud_read.cpp
@@ -46,19 +46,16 @@ Vector3dVector point_cloud2_to_eigen(const sensor_msgs::msg::PointCloud2::ConstS
   return points;
 }
 
-std::tuple<Vector3dVector, std::vector<double>>
-point_cloud2_to_eigen_with_timestamps(const PointCloud2::ConstSharedPtr& msg) {
+RawScan point_cloud2_to_eigen_with_timestamps(const PointCloud2::ConstSharedPtr& msg) {
   using sensor_msgs::PointCloud2ConstIterator;
   // getting points and time in a single cycle loop
   const size_t point_count = static_cast<size_t>(msg->height) * msg->width;
-  Vector3dVector points;
-  points.reserve(point_count);
+  RawScan scan;
+  scan.points.reserve(point_count);
+  scan.timestamps.reserve(point_count);
   PointCloud2ConstIterator<float> msg_x(*msg, "x");
   PointCloud2ConstIterator<float> msg_y(*msg, "y");
   PointCloud2ConstIterator<float> msg_z(*msg, "z");
-
-  std::vector<double> raw_timestamps;
-  raw_timestamps.reserve(point_count);
 
   const auto& timestamp_field = std::invoke([&msg]() -> PointField {
     for (const PointField& field : msg->fields) {
@@ -74,8 +71,8 @@ point_cloud2_to_eigen_with_timestamps(const PointCloud2::ConstSharedPtr& msg) {
   // templated lambda (auto) ftw
   auto extract_points_and_timestamps = [&](auto&& time_iter) {
     for (size_t i = 0; i < point_count; ++i, ++msg_x, ++msg_y, ++msg_z, ++time_iter) {
-      points.emplace_back(*msg_x, *msg_y, *msg_z);
-      raw_timestamps.emplace_back(static_cast<double>(*time_iter));
+      scan.points.emplace_back(*msg_x, *msg_y, *msg_z);
+      scan.timestamps.emplace_back(static_cast<double>(*time_iter));
     }
   };
 
@@ -99,6 +96,6 @@ point_cloud2_to_eigen_with_timestamps(const PointCloud2::ConstSharedPtr& msg) {
     throw std::invalid_argument("Unsupported timestamp field datatype. Please open an issue.");
   }
 
-  return {points, raw_timestamps};
+  return scan;
 }
 } // namespace rko_lio::ros::utils

--- a/rko_lio/ros/utils/point_cloud_read.hpp
+++ b/rko_lio/ros/utils/point_cloud_read.hpp
@@ -32,6 +32,10 @@
 namespace rko_lio::ros::utils {
 std::vector<Eigen::Vector3d> point_cloud2_to_eigen(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& msg);
 
-std::tuple<std::vector<Eigen::Vector3d>, std::vector<double>>
-point_cloud2_to_eigen_with_timestamps(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& msg);
+struct RawScan {
+  std::vector<Eigen::Vector3d> points;
+  std::vector<double> timestamps;
+};
+
+RawScan point_cloud2_to_eigen_with_timestamps(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& msg);
 }; // namespace rko_lio::ros::utils

--- a/tests/core/test_process_timestamps.cpp
+++ b/tests/core/test_process_timestamps.cpp
@@ -58,9 +58,9 @@ TEST_CASE("process_timestamps: absolute seconds, header ~= min -> unchanged", "[
 
   REQUIRE_THAT(to_seconds(result.min), WithinAbs(1234.0, 1e-9));
   REQUIRE_THAT(to_seconds(result.max), WithinAbs(1234.1, 1e-9));
-  REQUIRE(result.times.size() == raw.size());
-  REQUIRE_THAT(to_seconds(result.times.front()), WithinAbs(1234.0, 1e-9));
-  REQUIRE_THAT(to_seconds(result.times.back()), WithinAbs(1234.1, 1e-9));
+  REQUIRE(result.per_point.size() == raw.size());
+  REQUIRE_THAT(to_seconds(result.per_point.front()), WithinAbs(1234.0, 1e-9));
+  REQUIRE_THAT(to_seconds(result.per_point.back()), WithinAbs(1234.1, 1e-9));
 }
 
 TEST_CASE("process_timestamps: relative seconds, min ~= 0 -> header offset added", "[process_timestamps]") {
@@ -70,8 +70,8 @@ TEST_CASE("process_timestamps: relative seconds, min ~= 0 -> header offset added
 
   REQUIRE_THAT(to_seconds(result.min), WithinAbs(1234.5, 1e-9));
   REQUIRE_THAT(to_seconds(result.max), WithinAbs(1234.6, 1e-9));
-  REQUIRE_THAT(to_seconds(result.times.front()), WithinAbs(1234.5, 1e-9));
-  REQUIRE_THAT(to_seconds(result.times.back()), WithinAbs(1234.6, 1e-9));
+  REQUIRE_THAT(to_seconds(result.per_point.front()), WithinAbs(1234.5, 1e-9));
+  REQUIRE_THAT(to_seconds(result.per_point.back()), WithinAbs(1234.6, 1e-9));
 }
 
 TEST_CASE("process_timestamps: absolute nanoseconds -> heuristic infers ns source", "[process_timestamps]") {


### PR DESCRIPTION
a number of minor, but api breaking, changes that aim at reducing needless copies of the scan and try to do the ops (preprocessing especially) on essentially one copy of the scan after its processed from the ros message. 

doesn't lead to a significant performance boost, but it does help in multi threaded setups where preprocessing starts becoming more prominent. the effect is less pronounced in the single thread situation as association search is still the dominant cost there.

outputs are byte identical after this pr.

verified by looking at emitted assembly that most of these changes actually lead to less copies or temporaries. so we take what we get. 