### PR TITLE
all: floating point type is now configurable to float or double

### DIFF
--- a/.github/workflows/core_tests.yaml
+++ b/.github/workflows/core_tests.yaml
@@ -39,6 +39,9 @@ jobs:
           - ubuntu-24.04-arm
           - macos-14
           - macos-15
+        scalar:
+          - float
+          - double
     env:
       GIT_LFS_SKIP_SMUDGE: 1
     steps:
@@ -52,7 +55,8 @@ jobs:
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
             -DRKO_LIO_FETCH_CONTENT_DEPS=ON \
             -DRKO_LIO_BUILD_ROS=OFF \
-            -DRKO_LIO_BUILD_TESTS=ON
+            -DRKO_LIO_BUILD_TESTS=ON \
+            -DRKO_LIO_SCALAR=${{ matrix.scalar }}
       - name: Build
         shell: bash
         run: cmake --build build/core

--- a/.github/workflows/python_bindings.yaml
+++ b/.github/workflows/python_bindings.yaml
@@ -40,6 +40,9 @@ jobs:
           - macos-14
           - macos-15
           - windows-2022
+        scalar:
+          - float
+          - double
     env:
       GIT_LFS_SKIP_SMUDGE: 1
     steps:
@@ -52,6 +55,8 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Build with pip
         run: python -m pip install --verbose . pytest
+        env:
+          SKBUILD_CMAKE_DEFINE: RKO_LIO_SCALAR=${{ matrix.scalar }}
       - name: Run pytest
         run: pytest -v -rs
   python_bindings_optional:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,8 @@ else()
     install(
       TARGETS rko_lio.core rko_lio.ros rko_lio.ros.utils
       EXPORT rko_lioTargets
-      FILE_SET HEADERS)
+      FILE_SET HEADERS
+      FILE_SET generated_headers)
 
     ament_export_targets(rko_lioTargets HAS_LIBRARY_TARGET)
     ament_export_dependencies(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ build-type = "Release"
 CMAKE_EXPORT_COMPILE_COMMANDS = "ON"
 RKO_LIO_FETCH_CONTENT_DEPS = "ON"
 RKO_LIO_BUILD_ROS = "OFF"
+RKO_LIO_SCALAR = "double"
 
 [tool.cibuildwheel]
 environment = { GIT_LFS_SKIP_SMUDGE = "1" }

--- a/rko_lio/core/CMakeLists.txt
+++ b/rko_lio/core/CMakeLists.txt
@@ -20,6 +20,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+set(RKO_LIO_SCALAR
+    "float"
+    CACHE STRING
+          "Floating point type used throughout rko_lio (float or double)")
+message(STATUS "rko_lio scalar type: ${RKO_LIO_SCALAR}")
+
+set(GENERATED_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/include)
+configure_file(scalar.hpp.in
+               ${GENERATED_INCLUDE_DIR}/rko_lio/core/scalar.hpp @ONLY)
+
 add_library(rko_lio.core STATIC)
 
 add_library(rko_lio::core ALIAS rko_lio.core)
@@ -42,6 +52,23 @@ compat_target_sources(
         ../../rko_lio/core/util.hpp
         ../../rko_lio/core/voxel_down_sample.hpp
   BASE_DIRS ../..)
+
+# the generated header lives in the build tree, so it needs its own base dir
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.23")
+  target_sources(
+    rko_lio.core
+    PUBLIC FILE_SET
+           generated_headers
+           TYPE
+           HEADERS
+           BASE_DIRS
+           ${GENERATED_INCLUDE_DIR}
+           FILES
+           ${GENERATED_INCLUDE_DIR}/rko_lio/core/scalar.hpp)
+else()
+  target_include_directories(
+    rko_lio.core PUBLIC $<BUILD_INTERFACE:${GENERATED_INCLUDE_DIR}>)
+endif()
 
 target_link_libraries(
   rko_lio.core

--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -42,22 +42,23 @@
 #include <stdexcept>
 
 namespace {
-constexpr double EPSILON = 1e-8;
-constexpr auto EPSILON_TIME = std::chrono::nanoseconds(10);
 using namespace rko_lio::core;
 
-inline void transform_points(const Sophus::SE3d& T, Vector3dVector& points) {
+constexpr Scalar EPSILON = 1e-8;
+constexpr auto EPSILON_TIME = std::chrono::nanoseconds(10);
+
+inline void transform_points(const Sophus::SE3s& T, Vector3sVector& points) {
   std::transform(points.begin(), points.end(), points.begin(), [&](const auto& point) { return T * point; });
 }
 
 struct AccelInfo {
-  double accel_mag_variance;
-  Eigen::Vector3d local_gravity_estimate;
+  Scalar accel_mag_variance;
+  Eigen::Vector3s local_gravity_estimate;
 };
 
 struct BodyAccelKF {
-  Eigen::Vector3d mean;
-  Eigen::Matrix3d covariance;
+  Eigen::Vector3s mean;
+  Eigen::Matrix3s covariance;
 };
 
 struct AccelFilterStep {
@@ -67,9 +68,9 @@ struct AccelFilterStep {
 
 AccelFilterStep step_body_accel_filter(const BodyAccelKF& prev,
                                        const IntervalStats& stats,
-                                       const Sophus::SO3d& rotation_estimate,
+                                       const Sophus::SO3s& rotation_estimate,
                                        const Nsec dt,
-                                       const double max_expected_jerk) {
+                                       const Scalar max_expected_jerk) {
   if (stats.imu_count <= 1) {
     std::cerr << "[WARNING] " << stats.imu_count
               << " IMU message(s) in interval between two lidar scans. Cannot compute "
@@ -78,55 +79,55 @@ AccelFilterStep step_body_accel_filter(const BodyAccelKF& prev,
     return {std::nullopt, prev};
   }
 
-  const Eigen::Vector3d avg_imu_accel = stats.imu_acceleration_sum / stats.imu_count;
-  const double accel_mag_variance = stats.welford_sum_of_squares / (stats.imu_count - 1);
-  const Eigen::Vector3d body_accel_measurement = avg_imu_accel + rotation_estimate.inverse() * gravity();
+  const Eigen::Vector3s avg_imu_accel = stats.imu_acceleration_sum / stats.imu_count;
+  const Scalar accel_mag_variance = stats.welford_sum_of_squares / (stats.imu_count - 1);
+  const Eigen::Vector3s body_accel_measurement = avg_imu_accel + rotation_estimate.inverse() * gravity();
 
-  const double max_acceleration_change = max_expected_jerk * to_seconds(dt);
+  const Scalar max_acceleration_change = max_expected_jerk * to_seconds(dt);
   // assume [j, -j] range for uniform dist. on jerk. variance is (2j)^2 / 12 = j^2/3. multiply by dt^2 for accel
-  const Eigen::Matrix3d process_noise = square(max_acceleration_change) / 3 * Eigen::Matrix3d::Identity();
-  const Eigen::Matrix3d cov_pred = prev.covariance + process_noise;
+  const Eigen::Matrix3s process_noise = square(max_acceleration_change) / 3 * Eigen::Matrix3s::Identity();
+  const Eigen::Matrix3s cov_pred = prev.covariance + process_noise;
 
   // isotropic accel mag variance
-  const Eigen::Matrix3d measurement_noise = accel_mag_variance / 3 * Eigen::Matrix3d::Identity();
-  const Eigen::Matrix3d S = cov_pred + measurement_noise;
-  const Eigen::Matrix3d kalman_gain = cov_pred * S.inverse();
+  const Eigen::Matrix3s measurement_noise = accel_mag_variance / 3 * Eigen::Matrix3s::Identity();
+  const Eigen::Matrix3s S = cov_pred + measurement_noise;
+  const Eigen::Matrix3s kalman_gain = cov_pred * S.inverse();
 
-  const Eigen::Vector3d new_mean = prev.mean + kalman_gain * (body_accel_measurement - prev.mean);
-  const Eigen::Matrix3d new_cov = cov_pred - kalman_gain * cov_pred;
+  const Eigen::Vector3s new_mean = prev.mean + kalman_gain * (body_accel_measurement - prev.mean);
+  const Eigen::Matrix3s new_cov = cov_pred - kalman_gain * cov_pred;
 
-  const Eigen::Vector3d local_gravity_estimate = avg_imu_accel - new_mean; // points upwards
+  const Eigen::Vector3s local_gravity_estimate = avg_imu_accel - new_mean; // points upwards
   return {AccelInfo{.accel_mag_variance = accel_mag_variance, .local_gravity_estimate = local_gravity_estimate},
           BodyAccelKF{new_mean, new_cov}};
 }
 
 template <typename Functor>
   requires requires(Functor f, Nsec stamp) {
-    { f(stamp) } -> std::same_as<Sophus::SE3d>;
+    { f(stamp) } -> std::same_as<Sophus::SE3s>;
   }
-void deskew_scan(Vector3dVector& frame,
+void deskew_scan(Vector3sVector& frame,
                  const TimestampVector& timestamps,
                  const Nsec end_time,
                  const Functor& relative_pose_at_time) {
-  const Sophus::SE3d scan_to_scan_motion_inverse = relative_pose_at_time(end_time).inverse();
+  const Sophus::SE3s scan_to_scan_motion_inverse = relative_pose_at_time(end_time).inverse();
   std::transform(frame.cbegin(), frame.cend(), timestamps.cbegin(), frame.begin(),
-                 [&](const Eigen::Vector3d& point, const Nsec timestamp) {
+                 [&](const Eigen::Vector3s& point, const Nsec timestamp) {
                    return (scan_to_scan_motion_inverse * relative_pose_at_time(timestamp)) * point;
                  });
 }
 
-using LinearSystem = std::tuple<Eigen::Matrix6d, Eigen::Vector6d, double>;
-LinearSystem build_icp_linear_system(const Sophus::SE3d& current_pose,
-                                     const rko_lio::core::Vector3dVector& frame,
+using LinearSystem = std::tuple<Eigen::Matrix6s, Eigen::Vector6s, Scalar>;
+LinearSystem build_icp_linear_system(const Sophus::SE3s& current_pose,
+                                     const rko_lio::core::Vector3sVector& frame,
                                      const rko_lio::core::VoxelHashMap& voxel_map,
-                                     const double& max_correspondence_distance) {
-  using IcpAccum = std::tuple<Eigen::Matrix6d, Eigen::Vector6d, double, int>;
+                                     const Scalar& max_correspondence_distance) {
+  using IcpAccum = std::tuple<Eigen::Matrix6s, Eigen::Vector6s, Scalar, int>;
 
-  auto linear_system_for_one_point = [](const Eigen::Vector3d& source, const Eigen::Vector3d& target) {
-    Eigen::Matrix3_6d J_r;
-    J_r.block<3, 3>(0, 0) = Eigen::Matrix3d::Identity();
-    J_r.block<3, 3>(0, 3) = -1.0 * Sophus::SO3d::hat(source);
-    const Eigen::Vector3d residual = source - target;
+  auto linear_system_for_one_point = [](const Eigen::Vector3s& source, const Eigen::Vector3s& target) {
+    Eigen::Matrix3_6s J_r;
+    J_r.block<3, 3>(0, 0) = Eigen::Matrix3s::Identity();
+    J_r.block<3, 3>(0, 3) = -1.0 * Sophus::SO3s::hat(source);
+    const Eigen::Vector3s residual = source - target;
     return IcpAccum(J_r.transpose() * J_r,      // JTJ
                     J_r.transpose() * residual, // JTr
                     residual.squaredNorm(),     // chi
@@ -134,17 +135,17 @@ LinearSystem build_icp_linear_system(const Sophus::SE3d& current_pose,
   };
 
   // The only parallel part
-  using points_iterator = std::vector<Eigen::Vector3d>::const_iterator;
+  using points_iterator = std::vector<Eigen::Vector3s>::const_iterator;
   const auto& [H_icp, b_icp, chi_icp, correspondences_counter] = tbb::parallel_reduce(
       // Range
       tbb::blocked_range<points_iterator>{frame.cbegin(), frame.cend()},
       // Identity
-      IcpAccum(Eigen::Matrix6d::Zero(), Eigen::Vector6d::Zero(), 0.0, 0),
+      IcpAccum(Eigen::Matrix6s::Zero(), Eigen::Vector6s::Zero(), 0.0, 0),
       // 1st Lambda: Parallel computation
       [&](const tbb::blocked_range<points_iterator>& r, IcpAccum J) -> IcpAccum {
         auto& [H, b, chi, correspondences] = J;
-        for (const Eigen::Vector3d& point : r) {
-          const Eigen::Vector3d transformed_point = current_pose * point;
+        for (const Eigen::Vector3s& point : r) {
+          const Eigen::Vector3s transformed_point = current_pose * point;
           const auto closest_neighbor = voxel_map.get_closest_neighbor(transformed_point, max_correspondence_distance);
           if (!closest_neighbor.has_value()) {
             continue;
@@ -176,30 +177,30 @@ LinearSystem build_icp_linear_system(const Sophus::SE3d& current_pose,
   return {H_icp / correspondences_counter, b_icp / correspondences_counter, 0.5 * chi_icp};
 }
 
-LinearSystem build_orientation_linear_system(const Sophus::SE3d& current_pose,
-                                             const Eigen::Vector3d& local_gravity_estimate) {
-  const Sophus::SO3d& current_rotation = current_pose.so3();
-  const Eigen::Vector3d predicted_gravity =
+LinearSystem build_orientation_linear_system(const Sophus::SE3s& current_pose,
+                                             const Eigen::Vector3s& local_gravity_estimate) {
+  const Sophus::SO3s& current_rotation = current_pose.so3();
+  const Eigen::Vector3s predicted_gravity =
       current_rotation.inverse() * (-1 * gravity()); // points upwards, same as local_gravity_estimate
-  const Eigen::Vector3d residual = predicted_gravity - local_gravity_estimate;
+  const Eigen::Vector3s residual = predicted_gravity - local_gravity_estimate;
 
-  Eigen::Matrix3_6d J_ori = Eigen::Matrix3_6d::Zero();
-  J_ori.block<3, 3>(0, 3) = current_rotation.inverse().matrix() * Sophus::SO3d::hat(-1 * gravity()).matrix();
+  Eigen::Matrix3_6s J_ori = Eigen::Matrix3_6s::Zero();
+  J_ori.block<3, 3>(0, 3) = current_rotation.inverse().matrix() * Sophus::SO3s::hat(-1 * gravity()).matrix();
 
   return LinearSystem{J_ori.transpose() * J_ori, J_ori.transpose() * residual, 0.5 * residual.squaredNorm()};
 }
 
-Sophus::SE3d icp(const Vector3dVector& frame,
+Sophus::SE3s icp(const Vector3sVector& frame,
                  const VoxelHashMap& voxel_map,
-                 const Sophus::SE3d& initial_guess,
+                 const Sophus::SE3s& initial_guess,
                  const LIO::Config& config,
                  const std::optional<AccelInfo>& optional_accel_info) {
   // in case config disables it, or we don't have valid IMU information for this icp loop, beta is -1
-  const double beta = (config.min_beta > 0 && optional_accel_info.has_value())
+  const Scalar beta = (config.min_beta > 0 && optional_accel_info.has_value())
                           ? (config.min_beta * (1 + optional_accel_info->accel_mag_variance))
                           : -1;
 
-  Sophus::SE3d current_pose = initial_guess;
+  Sophus::SE3s current_pose = initial_guess;
 
   for (size_t i = 0; i < config.max_iterations; ++i) {
     const auto& [H, b, chi] = std::invoke([&]() -> LinearSystem {
@@ -213,8 +214,8 @@ Sophus::SE3d icp(const Vector3dVector& frame,
       return {H_icp, b_icp, chi_icp};
     });
 
-    const Eigen::Vector6d dx = H.ldlt().solve(-b);
-    current_pose = Sophus::SE3d::exp(dx) * current_pose;
+    const Eigen::Vector6s dx = H.ldlt().solve(-b);
+    current_pose = Sophus::SE3s::exp(dx) * current_pose;
 
     if (dx.norm() < config.convergence_criterion || i == (config.max_iterations - 1)) {
       // TODO: proper debug logging
@@ -226,11 +227,11 @@ Sophus::SE3d icp(const Vector3dVector& frame,
   return current_pose;
 }
 
-inline Sophus::SO3d align_accel_to_z_world(const Eigen::Vector3d& accel) {
+inline Sophus::SO3s align_accel_to_z_world(const Eigen::Vector3s& accel) {
   //  unobservable in the gravity direction, and the z in R.log() will always be 0
-  const Eigen::Vector3d z_world = {0.0, 0.0, 1.0};
-  const Eigen::Quaterniond quat_accel = Eigen::Quaterniond::FromTwoVectors(accel, z_world);
-  return Sophus::SO3d(quat_accel);
+  const Eigen::Vector3s z_world = {0.0, 0.0, 1.0};
+  const Eigen::Quaternions quat_accel = Eigen::Quaternions::FromTwoVectors(accel, z_world);
+  return Sophus::SO3s(quat_accel);
 }
 } // namespace
 
@@ -262,10 +263,10 @@ void LIO::initialize(const Nsec lidar_time) {
     return;
   }
 
-  const Eigen::Vector3d avg_accel = interval_stats.imu_acceleration_sum / interval_stats.imu_count;
-  const Eigen::Vector3d avg_gyro = interval_stats.angular_velocity_sum / interval_stats.imu_count;
+  const Eigen::Vector3s avg_accel = interval_stats.imu_acceleration_sum / interval_stats.imu_count;
+  const Eigen::Vector3s avg_gyro = interval_stats.angular_velocity_sum / interval_stats.imu_count;
 
-  const Sophus::SO3d initial_rotation = align_accel_to_z_world(avg_accel);
+  const Sophus::SO3s initial_rotation = align_accel_to_z_world(avg_accel);
   lidar_state.pose.so3() = initial_rotation;
   imu_state = lidar_state;
 
@@ -276,7 +277,7 @@ void LIO::initialize(const Nsec lidar_time) {
   lidar_state.time = lidar_time;
   imu_state.time = lidar_time;
 
-  const Eigen::Vector3d local_gravity = imu_state.pose.so3().inverse() * gravity();
+  const Eigen::Vector3s local_gravity = imu_state.pose.so3().inverse() * gravity();
   imu_bias.accelerometer = avg_accel + local_gravity;
   imu_bias.gyroscope = avg_gyro;
 
@@ -288,7 +289,7 @@ void LIO::initialize(const Nsec lidar_time) {
             << ", gyro bias: " << imu_bias.gyroscope.transpose() << "\n";
 }
 
-Vector3dVector LIO::bootstrap_first_scan(const Vector3dVector& scan, const Nsec current_lidar_time) {
+Vector3sVector LIO::bootstrap_first_scan(const Vector3sVector& scan, const Nsec current_lidar_time) {
   lidar_state.time = current_lidar_time;
   imu_state = lidar_state;
   auto preproc = preprocess_scan(scan, config);
@@ -300,18 +301,18 @@ Vector3dVector LIO::bootstrap_first_scan(const Vector3dVector& scan, const Nsec 
   return std::move(preproc.filtered_frame);
 }
 
-std::pair<Eigen::Vector3d, Eigen::Vector3d> LIO::motion_priors_from_imu(const Nsec current_lidar_time) {
+std::pair<Eigen::Vector3s, Eigen::Vector3s> LIO::motion_priors_from_imu(const Nsec current_lidar_time) {
   if (config.initialization_phase && !_initialized) {
     // assume static and
     initialize(current_lidar_time);
-    return {Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero()};
+    return {Eigen::Vector3s::Zero(), Eigen::Vector3s::Zero()};
   }
   if (interval_stats.imu_count == 0) {
     std::cerr << "[WARNING] No Imu measurements in interval to average. Assuming constant velocity motion.\n";
-    return {Eigen::Vector3d::Zero(), lidar_state.angular_velocity};
+    return {Eigen::Vector3s::Zero(), lidar_state.angular_velocity};
   }
-  const Eigen::Vector3d avg_body_accel = interval_stats.body_acceleration_sum / interval_stats.imu_count;
-  const Eigen::Vector3d avg_ang_vel = interval_stats.angular_velocity_sum / interval_stats.imu_count;
+  const Eigen::Vector3s avg_body_accel = interval_stats.body_acceleration_sum / interval_stats.imu_count;
+  const Eigen::Vector3s avg_ang_vel = interval_stats.angular_velocity_sum / interval_stats.imu_count;
   if (avg_body_accel.norm() > 50.0) {
     std::cerr << "[WARNING] Erratic body acceleration computed, norm > 50 m/s2. Either IMU data is corrupted, or you "
                  "should report an issue.";
@@ -341,7 +342,7 @@ void LIO::add_imu_measurement(const ImuControl& base_imu) {
     imu_state = lidar_state;
   }
 
-  const double dt = to_seconds(base_imu.time - imu_state.time);
+  const Scalar dt = to_seconds(base_imu.time - imu_state.time);
 
   if (dt < 0.0) {
     // messages are out of sync. thats a problem, since we integrate gyro from last lidar time onwards
@@ -349,17 +350,17 @@ void LIO::add_imu_measurement(const ImuControl& base_imu) {
     // maybe skip this imu reading?
   }
 
-  const Eigen::Vector3d unbiased_ang_vel = base_imu.angular_velocity - imu_bias.gyroscope;
-  const Eigen::Vector3d unbiased_accel = base_imu.acceleration - imu_bias.accelerometer;
+  const Eigen::Vector3s unbiased_ang_vel = base_imu.angular_velocity - imu_bias.gyroscope;
+  const Eigen::Vector3s unbiased_accel = base_imu.acceleration - imu_bias.accelerometer;
 
-  const Eigen::Vector3d local_gravity = imu_state.pose.so3().inverse() * gravity();
-  const Eigen::Vector3d compensated_accel = unbiased_accel + local_gravity;
+  const Eigen::Vector3s local_gravity = imu_state.pose.so3().inverse() * gravity();
+  const Eigen::Vector3s compensated_accel = unbiased_accel + local_gravity;
 
   // imu state update
-  Eigen::Vector6d tau;
+  Eigen::Vector6s tau;
   tau.head<3>() = imu_state.velocity * dt + compensated_accel * square(dt) / 2;
   tau.tail<3>() = unbiased_ang_vel * dt;
-  imu_state.pose = imu_state.pose * Sophus::SE3d::exp(tau);
+  imu_state.pose = imu_state.pose * Sophus::SE3s::exp(tau);
   imu_state.velocity += compensated_accel * dt;
   imu_state.angular_velocity = unbiased_ang_vel;
   imu_state.time = base_imu.time;
@@ -370,7 +371,7 @@ void LIO::add_imu_measurement(const ImuControl& base_imu) {
   _last_real_base_imu_ang_vel = base_imu.angular_velocity;
 }
 
-void LIO::add_imu_measurement(const Sophus::SE3d& extrinsic_imu2base, const ImuControl& raw_imu) {
+void LIO::add_imu_measurement(const Sophus::SE3s& extrinsic_imu2base, const ImuControl& raw_imu) {
   if (extrinsic_imu2base.log().norm() < EPSILON) {
     add_imu_measurement(raw_imu);
     return;
@@ -384,13 +385,13 @@ void LIO::add_imu_measurement(const Sophus::SE3d& extrinsic_imu2base, const ImuC
 
   // accounting for the transport-rate
   ImuControl base_imu = raw_imu;
-  const Sophus::SO3d& extrinsic_rotation = extrinsic_imu2base.so3();
+  const Sophus::SO3s& extrinsic_rotation = extrinsic_imu2base.so3();
   base_imu.angular_velocity = extrinsic_rotation * raw_imu.angular_velocity;
 
-  const Eigen::Vector3d& lever_arm = -1 * extrinsic_imu2base.translation();
+  const Eigen::Vector3s& lever_arm = -1 * extrinsic_imu2base.translation();
   const Nsec dt = raw_imu.time - _last_real_imu_time;
 
-  const Eigen::Vector3d angular_acceleration = std::invoke([&]() -> Eigen::Vector3d {
+  const Eigen::Vector3s angular_acceleration = std::invoke([&]() -> Eigen::Vector3s {
     if (std::chrono::abs(dt) < std::chrono::microseconds(200)) {
       // if dt is less than the equivalent of a 5000 Hz imu, assuming zero ang accel,
       // causes numerical issues otherwise
@@ -400,9 +401,9 @@ void LIO::add_imu_measurement(const Sophus::SE3d& extrinsic_imu2base, const ImuC
                      "all such messages.\n";
         warning_imu_too_close = true;
       }
-      return Eigen::Vector3d::Zero();
+      return Eigen::Vector3s::Zero();
     } else {
-      const Eigen::Vector3d angular_acceleration =
+      const Eigen::Vector3s angular_acceleration =
           (base_imu.angular_velocity - _last_real_base_imu_ang_vel) / to_seconds(dt);
       return angular_acceleration;
     }
@@ -416,7 +417,7 @@ void LIO::add_imu_measurement(const Sophus::SE3d& extrinsic_imu2base, const ImuC
 
 // ============================ lidar ===============================
 
-Vector3dVector LIO::register_scan(Vector3dVector scan, const TimestampVector& timestamps) {
+Vector3sVector LIO::register_scan(Vector3sVector scan, const TimestampVector& timestamps) {
   if (timestamps.empty()) {
     throw std::invalid_argument("LIO::register_scan: timestamps must not be empty.");
   }
@@ -437,15 +438,15 @@ Vector3dVector LIO::register_scan(Vector3dVector scan, const TimestampVector& ti
   const auto [avg_body_accel, avg_ang_vel] = motion_priors_from_imu(current_lidar_time);
 
   // compute relative motion using controls
-  auto relative_pose_at_time = [&](const Nsec time) -> Sophus::SE3d {
-    const double dt = to_seconds(time - lidar_state.time);
-    Eigen::Vector6d tau;
+  auto relative_pose_at_time = [&](const Nsec time) -> Sophus::SE3s {
+    const Scalar dt = to_seconds(time - lidar_state.time);
+    Eigen::Vector6s tau;
     tau.head<3>() = lidar_state.velocity * dt + (avg_body_accel * square(dt) / 2);
     tau.tail<3>() = avg_ang_vel * dt;
-    return Sophus::SE3d::exp(tau);
+    return Sophus::SE3s::exp(tau);
   };
 
-  const Sophus::SE3d initial_guess = lidar_state.pose * relative_pose_at_time(current_lidar_time);
+  const Sophus::SE3s initial_guess = lidar_state.pose * relative_pose_at_time(current_lidar_time);
 
   // body acceleration filter
   const auto kf_step =
@@ -469,17 +470,17 @@ Vector3dVector LIO::register_scan(Vector3dVector scan, const TimestampVector& ti
     throw std::invalid_argument(error_msg);
   }
 
-  const Vector3dVector& map_input = config.double_downsample ? preproc_result.map_frame : preproc_result.keypoints;
+  const Vector3sVector& map_input = config.double_downsample ? preproc_result.map_frame : preproc_result.keypoints;
 
   if (!map.empty()) {
     SCOPED_PROFILER("ICP");
-    const Sophus::SE3d optimized_pose = icp(preproc_result.keypoints, map, initial_guess, config, kf_step.info);
+    const Sophus::SE3s optimized_pose = icp(preproc_result.keypoints, map, initial_guess, config, kf_step.info);
 
     // estimate velocities and accelerations from the new pose
-    const double dt = to_seconds(current_lidar_time - lidar_state.time);
-    const Sophus::SE3d motion = lidar_state.pose.inverse() * optimized_pose;
-    const Eigen::Vector6d local_velocity = motion.log() / dt;
-    const Eigen::Vector3d local_linear_acceleration =
+    const Scalar dt = to_seconds(current_lidar_time - lidar_state.time);
+    const Sophus::SE3s motion = lidar_state.pose.inverse() * optimized_pose;
+    const Eigen::Vector6s local_velocity = motion.log() / dt;
+    const Eigen::Vector3s local_linear_acceleration =
         (local_velocity.head<3>() - motion.so3().inverse() * lidar_state.velocity) / dt;
 
     // update
@@ -502,13 +503,15 @@ Vector3dVector LIO::register_scan(Vector3dVector scan, const TimestampVector& ti
   return std::move(preproc_result.filtered_frame);
 }
 
-Vector3dVector
-LIO::register_scan(const Sophus::SE3d& extrinsic_lidar2base, Vector3dVector scan, const TimestampVector& timestamps) {
+Vector3sVector LIO::register_scan(const Sophus::SE3s& extrinsic_lidar2base,
+                                  Vector3sVector scan,
+                                  const TimestampVector& timestamps) {
   if (extrinsic_lidar2base.log().norm() < EPSILON) {
     return register_scan(std::move(scan), timestamps);
   }
+
   transform_points(extrinsic_lidar2base, scan);
-  Vector3dVector frame = register_scan(std::move(scan), timestamps);
+  Vector3sVector frame = register_scan(std::move(scan), timestamps);
   transform_points(extrinsic_lidar2base.inverse(), frame);
   return frame;
 }

--- a/rko_lio/core/lio.hpp
+++ b/rko_lio/core/lio.hpp
@@ -45,22 +45,22 @@ public:
     size_t max_iterations = 100;
 
     /** Size of voxel grid (m). */
-    double voxel_size = 1.0;
+    Scalar voxel_size = 1.0;
 
     /** Max points per voxel. */
     int max_points_per_voxel = 20;
 
     /** Maximum lidar range (m). */
-    double max_range = 100.0;
+    Scalar max_range = 100.0;
 
     /** Minimum lidar range (m). */
-    double min_range = 1.0;
+    Scalar min_range = 1.0;
 
     /** ICP convergence threshold. */
-    double convergence_criterion = 1e-5;
+    Scalar convergence_criterion = 1e-5;
 
     /** Max distance for correspondences (m). */
-    double max_correspondence_distance = 0.5;
+    Scalar max_correspondence_distance = 0.5;
 
     /** Thread count for data association (0 = automatic). */
     int max_num_threads = 0;
@@ -69,13 +69,13 @@ public:
     bool initialization_phase = false;
 
     /** Maximum expected jerk (m/s³). */
-    double max_expected_jerk = 3;
+    Scalar max_expected_jerk = 3;
 
     /** Enable double downsampling. */
     bool double_downsample = true;
 
     /** Minimum weight for orientation regularization. */
-    double min_beta = 200;
+    Scalar min_beta = 200;
   };
 
   /** Configuration parameters. */
@@ -91,10 +91,10 @@ public:
   ImuBias imu_bias;
 
   /** Mean body acceleration estimate. */
-  Eigen::Vector3d mean_body_acceleration = Eigen::Vector3d::Zero();
+  Eigen::Vector3s mean_body_acceleration = Eigen::Vector3s::Zero();
 
   /** Covariance of body acceleration estimate. */
-  Eigen::Matrix3d body_acceleration_covariance = Eigen::Matrix3d::Identity();
+  Eigen::Matrix3s body_acceleration_covariance = Eigen::Matrix3s::Identity();
 
   /** IMU measurement statistics since last LiDAR frame. */
   IntervalStats interval_stats;
@@ -110,7 +110,7 @@ public:
    * @param extrinsic_imu2base Extrinsic transform from IMU to base frame.
    * @param raw_imu Raw IMU measurement.
    */
-  void add_imu_measurement(const Sophus::SE3d& extrinsic_imu2base, const ImuControl& raw_imu);
+  void add_imu_measurement(const Sophus::SE3s& extrinsic_imu2base, const ImuControl& raw_imu);
 
   /**
    * Register a LiDAR scan, applying deskewing based on the initial motion guess
@@ -119,7 +119,7 @@ public:
    * @param timestamps Absolute timestamps corresponding to each scan point.
    * @return Deskewed and clipped point cloud.
    */
-  Vector3dVector register_scan(Vector3dVector scan, const TimestampVector& timestamps);
+  Vector3sVector register_scan(Vector3sVector scan, const TimestampVector& timestamps);
 
   /**
    * Register a LiDAR scan for which the extrinsic calibration from lidar to base
@@ -129,12 +129,12 @@ public:
    * @param timestamps Absolute timestamps corresponding to each scan point.
    * @return Deskewed and clipped scan in the original lidar frame.
    */
-  Vector3dVector register_scan(const Sophus::SE3d& extrinsic_lidar2base,
-                               Vector3dVector scan,
+  Vector3sVector register_scan(const Sophus::SE3s& extrinsic_lidar2base,
+                               Vector3sVector scan,
                                const TimestampVector& timestamps);
 
   /** Sequence of registered scan poses with corresponding timestamps. */
-  std::vector<std::pair<Nsec, Sophus::SE3d>> poses_with_timestamps;
+  std::vector<std::pair<Nsec, Sophus::SE3s>> poses_with_timestamps;
 
   /** Base-frame state propagated from IMU measurements. Runs ahead of `lidar_state` between scans; reset to the
    *  optimized lidar pose after each successful registration. Used for gravity compensation and for publishing
@@ -150,10 +150,10 @@ private:
   void initialize(const Nsec lidar_time);
 
   /** First-scan path: stamps state, optionally seeds the map, logs the pose. */
-  Vector3dVector bootstrap_first_scan(const Vector3dVector& scan, const Nsec current_lidar_time);
+  Vector3sVector bootstrap_first_scan(const Vector3sVector& scan, const Nsec current_lidar_time);
 
   /** Average body acceleration and angular velocity over the IMU interval, with init-phase and no-IMU fallbacks. */
-  std::pair<Eigen::Vector3d, Eigen::Vector3d> motion_priors_from_imu(const Nsec current_lidar_time);
+  std::pair<Eigen::Vector3s, Eigen::Vector3s> motion_priors_from_imu(const Nsec current_lidar_time);
 
   /** True if odometry initialization has been completed. */
   bool _initialized = false;
@@ -162,6 +162,6 @@ private:
   Nsec _last_real_imu_time{0};
 
   /** Angular velocity of last true IMU measurement expressed in base frame. */
-  Eigen::Vector3d _last_real_base_imu_ang_vel = Eigen::Vector3d::Zero();
+  Eigen::Vector3s _last_real_base_imu_ang_vel = Eigen::Vector3s::Zero();
 };
 } // namespace rko_lio::core

--- a/rko_lio/core/preprocess_scan.cpp
+++ b/rko_lio/core/preprocess_scan.cpp
@@ -3,21 +3,21 @@
 
 namespace rko_lio::core {
 
-PreprocessingResult preprocess_scan(Vector3dVector frame, const LIO::Config& config) {
+PreprocessingResult preprocess_scan(Vector3sVector frame, const LIO::Config& config) {
   std::erase_if(frame, [&](const auto& point) {
-    const double point_range = point.norm();
+    const Scalar point_range = point.norm();
     // negation handles nans as well
     return !(point_range > config.min_range && point_range < config.max_range);
   });
 
   if (config.double_downsample) {
-    Vector3dVector downsampled_frame = voxel_down_sample(frame, config.voxel_size * 0.5);
-    Vector3dVector keypoints = voxel_down_sample(downsampled_frame, config.voxel_size * 1.5);
+    Vector3sVector downsampled_frame = voxel_down_sample(frame, config.voxel_size * 0.5);
+    Vector3sVector keypoints = voxel_down_sample(downsampled_frame, config.voxel_size * 1.5);
     return {.filtered_frame = std::move(frame),
             .keypoints = std::move(keypoints),
             .map_frame = std::move(downsampled_frame)};
   }
-  Vector3dVector keypoints = voxel_down_sample(frame, config.voxel_size);
+  Vector3sVector keypoints = voxel_down_sample(frame, config.voxel_size);
   return {.filtered_frame = std::move(frame), .keypoints = std::move(keypoints), .map_frame = {}};
 }
 

--- a/rko_lio/core/preprocess_scan.hpp
+++ b/rko_lio/core/preprocess_scan.hpp
@@ -7,12 +7,12 @@
 namespace rko_lio::core {
 
 struct PreprocessingResult {
-  Vector3dVector filtered_frame;
-  Vector3dVector keypoints;
-  Vector3dVector map_frame; // populated only when config.double_downsample; empty otherwise
+  Vector3sVector filtered_frame;
+  Vector3sVector keypoints;
+  Vector3sVector map_frame; // populated only when config.double_downsample; empty otherwise
 };
 
 // clip and downsample the input cloud
-PreprocessingResult preprocess_scan(Vector3dVector frame, const LIO::Config& config);
+PreprocessingResult preprocess_scan(Vector3sVector frame, const LIO::Config& config);
 
 } // namespace rko_lio::core

--- a/rko_lio/core/scalar.hpp.in
+++ b/rko_lio/core/scalar.hpp.in
@@ -1,7 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 Ignacio Vizzo, Tiziano Guadagnino, Benedikt Mersch, Cyrill
-// Stachniss.
+// Copyright (c) 2025 Meher V.R. Malladi.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,14 +20,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// Generated from scalar.hpp.in - do not edit. The type is fixed when the library is
+// configured, via the RKO_LIO_SCALAR cmake option.
 #pragma once
-#include <rko_lio/core/util.hpp>
+#include <concepts>
 
-#include <Eigen/Core>
-#include <sensor_msgs/msg/point_cloud2.hpp>
-#include <vector>
+namespace rko_lio::core {
 
-namespace rko_lio::ros::utils {
-std::unique_ptr<sensor_msgs::msg::PointCloud2> eigen_to_point_cloud2(const core::Vector3sVector& points,
-                                                                     const std_msgs::msg::Header& header);
-}
+template <std::floating_point T>
+using FloatingPoint = T;
+
+using Scalar = FloatingPoint<@RKO_LIO_SCALAR@>;
+
+} // namespace rko_lio::core

--- a/rko_lio/core/util.hpp
+++ b/rko_lio/core/util.hpp
@@ -23,47 +23,59 @@
  */
 
 #pragma once
+#include "rko_lio/core/scalar.hpp"
 #include <Eigen/Core>
 #include <chrono>
 #include <sophus/se3.hpp>
 
+// Scalar is either float or double, as configured
 namespace Eigen {
-using Matrix3_6d = Matrix<double, 3, 6>;
-using Vector6d = Matrix<double, 6, 1>;
-using Matrix6d = Matrix<double, 6, 6>;
+using Vector3s = Vector3<rko_lio::core::Scalar>;
+using Vector4s = Vector4<rko_lio::core::Scalar>;
+using Matrix3s = Matrix3<rko_lio::core::Scalar>;
+using Matrix4s = Matrix4<rko_lio::core::Scalar>;
+using Matrix3_6s = Matrix<rko_lio::core::Scalar, 3, 6>;
+using Vector6s = Matrix<rko_lio::core::Scalar, 6, 1>;
+using Matrix6s = Matrix<rko_lio::core::Scalar, 6, 6>;
+using Quaternions = Quaternion<rko_lio::core::Scalar>;
 } // namespace Eigen
 
+namespace Sophus {
+using SE3s = SE3<rko_lio::core::Scalar>;
+using SO3s = SO3<rko_lio::core::Scalar>;
+} // namespace Sophus
+
 namespace rko_lio::core {
-// aliases
-using Vector3dVector = std::vector<Eigen::Vector3d>;
+using Vector3sVector = std::vector<Eigen::Vector3s>;
+
 using Nsec = std::chrono::nanoseconds;
 using TimestampVector = std::vector<Nsec>;
 
 // constants and util funcs
-constexpr double square(double x) { return x * x; }
-constexpr double GRAVITY_MAG = 9.8107;
-inline Eigen::Vector3d gravity() { return {0, 0, -GRAVITY_MAG}; }
+constexpr Scalar square(Scalar x) { return x * x; }
+constexpr Scalar GRAVITY_MAG = 9.8107;
+inline Eigen::Vector3s gravity() { return {0, 0, -GRAVITY_MAG}; }
 
 inline double to_seconds(const Nsec d) { return std::chrono::duration<double>(d).count(); }
 
 // data structs
 struct State {
   Nsec time{0};
-  Sophus::SE3d pose;
-  Eigen::Vector3d velocity = Eigen::Vector3d::Zero();
-  Eigen::Vector3d angular_velocity = Eigen::Vector3d::Zero();
-  Eigen::Vector3d linear_acceleration = Eigen::Vector3d::Zero();
+  Sophus::SE3s pose;
+  Eigen::Vector3s velocity = Eigen::Vector3s::Zero();
+  Eigen::Vector3s angular_velocity = Eigen::Vector3s::Zero();
+  Eigen::Vector3s linear_acceleration = Eigen::Vector3s::Zero();
 };
 
 struct ImuBias {
-  Eigen::Vector3d accelerometer = Eigen::Vector3d::Zero();
-  Eigen::Vector3d gyroscope = Eigen::Vector3d::Zero();
+  Eigen::Vector3s accelerometer = Eigen::Vector3s::Zero();
+  Eigen::Vector3s gyroscope = Eigen::Vector3s::Zero();
 };
 
 struct ImuControl {
   Nsec time{0};
-  Eigen::Vector3d acceleration = Eigen::Vector3d::Zero();
-  Eigen::Vector3d angular_velocity = Eigen::Vector3d::Zero();
+  Eigen::Vector3s acceleration = Eigen::Vector3s::Zero();
+  Eigen::Vector3s angular_velocity = Eigen::Vector3s::Zero();
 };
 
 /** Accumulated IMU statistics over the interval between consecutive LiDAR scans. */
@@ -72,19 +84,19 @@ struct IntervalStats {
   int imu_count = 0;
 
   /** Sum of unbiased angular velocity samples. */
-  Eigen::Vector3d angular_velocity_sum = Eigen::Vector3d::Zero();
+  Eigen::Vector3s angular_velocity_sum = Eigen::Vector3s::Zero();
 
   /** Sum of gravity-compensated body-frame accelerations. */
-  Eigen::Vector3d body_acceleration_sum = Eigen::Vector3d::Zero();
+  Eigen::Vector3s body_acceleration_sum = Eigen::Vector3s::Zero();
 
   /** Sum of unbiased raw IMU accelerations. */
-  Eigen::Vector3d imu_acceleration_sum = Eigen::Vector3d::Zero();
+  Eigen::Vector3s imu_acceleration_sum = Eigen::Vector3s::Zero();
 
   /** Mean magnitude of raw IMU acceleration over the interval. */
-  double imu_accel_mag_mean = 0;
+  Scalar imu_accel_mag_mean = 0;
 
   /** Variance accumulator for acceleration magnitude using Welford’s method. */
-  double welford_sum_of_squares = 0;
+  Scalar welford_sum_of_squares = 0;
 
   /**
    * Update accumulated statistics with a new IMU measurement.
@@ -92,15 +104,15 @@ struct IntervalStats {
    * @param uncompensated_unbiased_accel Uncompensated, unbiased acceleration.
    * @param compensated_accel Gravity-compensated acceleration.
    */
-  void update(const Eigen::Vector3d& unbiased_ang_vel,
-              const Eigen::Vector3d& uncompensated_unbiased_accel,
-              const Eigen::Vector3d& compensated_accel) {
+  void update(const Eigen::Vector3s& unbiased_ang_vel,
+              const Eigen::Vector3s& uncompensated_unbiased_accel,
+              const Eigen::Vector3s& compensated_accel) {
     ++imu_count;
     angular_velocity_sum += unbiased_ang_vel;
     imu_acceleration_sum += uncompensated_unbiased_accel;
 
-    const double previous_mean = imu_accel_mag_mean;
-    const double accel_norm = uncompensated_unbiased_accel.norm();
+    const Scalar previous_mean = imu_accel_mag_mean;
+    const Scalar accel_norm = uncompensated_unbiased_accel.norm();
 
     imu_accel_mag_mean += (accel_norm - previous_mean) / imu_count;
     welford_sum_of_squares += (accel_norm - previous_mean) * (accel_norm - imu_accel_mag_mean);

--- a/rko_lio/core/voxel_down_sample.cpp
+++ b/rko_lio/core/voxel_down_sample.cpp
@@ -33,13 +33,13 @@ namespace rko_lio::core {
 // https://github.com/PRBonn/kiss-icp/pull/347
 // although it does lead to worse odometry performance in certain situations
 
-std::vector<Eigen::Vector3d> voxel_down_sample(const std::vector<Eigen::Vector3d>& frame, const double voxel_size) {
-  const double inv_voxel_size = 1.0 / voxel_size;
-  std::unordered_map<Eigen::Vector3i, Eigen::Vector3d, VoxelHash> grid;
+std::vector<Eigen::Vector3s> voxel_down_sample(const std::vector<Eigen::Vector3s>& frame, const Scalar voxel_size) {
+  const Scalar inv_voxel_size = 1.0 / voxel_size;
+  std::unordered_map<Eigen::Vector3i, Eigen::Vector3s, VoxelHash> grid;
   grid.reserve(frame.size());
   std::for_each(frame.cbegin(), frame.cend(),
                 [&](const auto& point) { grid.try_emplace(point_to_voxel(point, inv_voxel_size), point); });
-  std::vector<Eigen::Vector3d> frame_downsampled;
+  std::vector<Eigen::Vector3s> frame_downsampled;
   frame_downsampled.reserve(grid.size());
   std::for_each(grid.cbegin(), grid.cend(),
                 [&](const auto& voxel_and_point) { frame_downsampled.emplace_back(voxel_and_point.second); });

--- a/rko_lio/core/voxel_down_sample.hpp
+++ b/rko_lio/core/voxel_down_sample.hpp
@@ -22,15 +22,17 @@
 // SOFTWARE.
 #pragma once
 
+#include "util.hpp"
+
 #include <Eigen/Core>
 #include <cmath>
 #include <sophus/se3.hpp>
 
 namespace rko_lio::core {
 /// Voxelize point cloud keeping the original coordinates
-std::vector<Eigen::Vector3d> voxel_down_sample(const std::vector<Eigen::Vector3d>& frame, const double voxel_size);
+std::vector<Eigen::Vector3s> voxel_down_sample(const std::vector<Eigen::Vector3s>& frame, const Scalar voxel_size);
 
-inline Eigen::Vector3i point_to_voxel(const Eigen::Vector3d& point, const double inv_voxel_size) {
+inline Eigen::Vector3i point_to_voxel(const Eigen::Vector3s& point, const Scalar inv_voxel_size) {
   return {static_cast<int>(std::floor(point.x() * inv_voxel_size)),
           static_cast<int>(std::floor(point.y() * inv_voxel_size)),
           static_cast<int>(std::floor(point.z() * inv_voxel_size))};

--- a/rko_lio/core/voxel_hash_map.cpp
+++ b/rko_lio/core/voxel_hash_map.cpp
@@ -59,32 +59,32 @@ static const std::array<Voxel, 27> shifts{
 
 namespace rko_lio::core {
 
-VoxelHashMap::VoxelHashMap(const double voxel_size,
-                           const double clipping_distance,
+VoxelHashMap::VoxelHashMap(const Scalar voxel_size,
+                           const Scalar clipping_distance,
                            const unsigned int max_points_per_voxel)
     : voxel_size_(voxel_size),
       inv_voxel_size_(1.0 / voxel_size),
       clipping_distance_(clipping_distance),
       max_points_per_voxel_(max_points_per_voxel) {}
 
-std::optional<VoxelBlock::const_iterator> VoxelHashMap::get_closest_neighbor(const Eigen::Vector3d& query,
-                                                                             const double max_distance) const {
-  double closest_distance_sq = max_distance * max_distance;
+std::optional<VoxelBlock::const_iterator> VoxelHashMap::get_closest_neighbor(const Eigen::Vector3s& query,
+                                                                             const Scalar max_distance) const {
+  Scalar closest_distance_sq = max_distance * max_distance;
   std::optional<VoxelBlock::const_iterator> closest;
   const Voxel voxel = point_to_voxel(query, inv_voxel_size_);
 
   // lower_bounds is squared distance from the query to the near face of a neighbouring voxel, per axis.
   // Columns are indexed by voxel shift + 1, rows are axes
-  const Eigen::Vector3d offset = query - voxel.cast<double>() * voxel_size_;
-  const Eigen::Vector3d to_far = Eigen::Vector3d::Constant(voxel_size_) - offset;
-  Eigen::Matrix3d lower_bounds;
+  const Eigen::Vector3s offset = query - voxel.cast<Scalar>() * voxel_size_;
+  const Eigen::Vector3s to_far = Eigen::Vector3s::Constant(voxel_size_) - offset;
+  Eigen::Matrix3s lower_bounds;
   lower_bounds.col(0) = offset.array().square();
   lower_bounds.col(1).setZero();
   lower_bounds.col(2) = to_far.array().square();
 
   for (const Voxel& shift : shifts) {
     // lower bound on the distance to query within this voxel + shift
-    const double lower_bound_sq =
+    const Scalar lower_bound_sq =
         lower_bounds(0, shift.x() + 1) + lower_bounds(1, shift.y() + 1) + lower_bounds(2, shift.z() + 1);
     if (lower_bound_sq >= closest_distance_sq) {
       continue;
@@ -96,7 +96,7 @@ std::optional<VoxelBlock::const_iterator> VoxelHashMap::get_closest_neighbor(con
     // returning an iterator rather than a copy reduces branching (with the usual compiler caveats)
     const VoxelBlock& voxel_points = search.value();
     for (auto neighbor = voxel_points.cbegin(); neighbor != voxel_points.cend(); ++neighbor) {
-      const double distance_sq = (*neighbor - query).squaredNorm();
+      const Scalar distance_sq = (*neighbor - query).squaredNorm();
       if (distance_sq < closest_distance_sq) {
         closest_distance_sq = distance_sq;
         closest = neighbor;
@@ -106,10 +106,10 @@ std::optional<VoxelBlock::const_iterator> VoxelHashMap::get_closest_neighbor(con
   return closest;
 }
 
-void VoxelHashMap::add_points(const std::vector<Eigen::Vector3d>& points, const Sophus::SE3d& pose) {
-  const double map_resolution_sq = voxel_size_ * voxel_size_ / max_points_per_voxel_;
-  std::for_each(points.cbegin(), points.cend(), [&](const Eigen::Vector3d& point) {
-    const Eigen::Vector3d p = pose * point;
+void VoxelHashMap::add_points(const std::vector<Eigen::Vector3s>& points, const Sophus::SE3s& pose) {
+  const Scalar map_resolution_sq = voxel_size_ * voxel_size_ / max_points_per_voxel_;
+  std::for_each(points.cbegin(), points.cend(), [&](const Eigen::Vector3s& point) {
+    const Eigen::Vector3s p = pose * point;
     const Voxel voxel = point_to_voxel(p, inv_voxel_size_);
     auto it = map_.try_emplace(voxel).first;
     VoxelBlock& voxel_points = it.value();
@@ -123,8 +123,8 @@ void VoxelHashMap::add_points(const std::vector<Eigen::Vector3d>& points, const 
   });
 }
 
-void VoxelHashMap::remove_points_far_from_location(const Eigen::Vector3d& origin) {
-  const double clipping_distance_sq = clipping_distance_ * clipping_distance_;
+void VoxelHashMap::remove_points_far_from_location(const Eigen::Vector3s& origin) {
+  const Scalar clipping_distance_sq = clipping_distance_ * clipping_distance_;
   for (auto it = map_.begin(); it != map_.end();) {
     const VoxelBlock& voxel_points = it->second;
     if ((voxel_points.front() - origin).squaredNorm() > clipping_distance_sq) {
@@ -135,13 +135,13 @@ void VoxelHashMap::remove_points_far_from_location(const Eigen::Vector3d& origin
   }
 }
 
-void VoxelHashMap::update(const std::vector<Eigen::Vector3d>& points, const Sophus::SE3d& pose) {
+void VoxelHashMap::update(const std::vector<Eigen::Vector3s>& points, const Sophus::SE3s& pose) {
   add_points(points, pose);
   remove_points_far_from_location(pose.translation());
 }
 
-std::vector<Eigen::Vector3d> VoxelHashMap::pointcloud() const {
-  std::vector<Eigen::Vector3d> point_cloud;
+std::vector<Eigen::Vector3s> VoxelHashMap::pointcloud() const {
+  std::vector<Eigen::Vector3s> point_cloud;
   point_cloud.reserve(map_.size() * max_points_per_voxel_);
   for (const auto& [_, block] : map_) {
     point_cloud.insert(point_cloud.end(), block.cbegin(), block.cend());

--- a/rko_lio/core/voxel_hash_map.hpp
+++ b/rko_lio/core/voxel_hash_map.hpp
@@ -41,27 +41,27 @@
 namespace rko_lio::core {
 
 using Voxel = Eigen::Vector3i;
-using VoxelBlock = std::vector<Eigen::Vector3d>;
+using VoxelBlock = std::vector<Eigen::Vector3s>;
 
 struct VoxelHashMap {
-  explicit VoxelHashMap(const double voxel_size,
-                        const double clipping_distance,
+  explicit VoxelHashMap(const Scalar voxel_size,
+                        const Scalar clipping_distance,
                         const unsigned int max_points_per_voxel);
 
   void clear() { map_.clear(); }
   bool empty() const { return map_.empty(); }
-  void update(const std::vector<Eigen::Vector3d>& points, const Sophus::SE3d& pose);
-  void add_points(const std::vector<Eigen::Vector3d>& points, const Sophus::SE3d& pose);
-  void remove_points_far_from_location(const Eigen::Vector3d& origin);
-  std::vector<Eigen::Vector3d> pointcloud() const;
+  void update(const std::vector<Eigen::Vector3s>& points, const Sophus::SE3s& pose);
+  void add_points(const std::vector<Eigen::Vector3s>& points, const Sophus::SE3s& pose);
+  void remove_points_far_from_location(const Eigen::Vector3s& origin);
+  std::vector<Eigen::Vector3s> pointcloud() const;
 
   /// Iterator to nearest point to `query` strictly within `max_distance`, or nullopt if there is none.
-  std::optional<VoxelBlock::const_iterator> get_closest_neighbor(const Eigen::Vector3d& query,
-                                                                 const double max_distance) const;
+  std::optional<VoxelBlock::const_iterator> get_closest_neighbor(const Eigen::Vector3s& query,
+                                                                 const Scalar max_distance) const;
 
-  double voxel_size_;
-  double inv_voxel_size_;
-  double clipping_distance_;
+  Scalar voxel_size_;
+  Scalar inv_voxel_size_;
+  Scalar clipping_distance_;
   unsigned int max_points_per_voxel_;
   tsl::robin_map<Voxel, VoxelBlock, VoxelHash> map_;
 };

--- a/rko_lio/python/pybind/rko_lio_pybind.cpp
+++ b/rko_lio/python/pybind/rko_lio_pybind.cpp
@@ -37,13 +37,13 @@ namespace py = pybind11;
 using namespace pybind11::literals;
 using namespace rko_lio::core;
 
-PYBIND11_MAKE_OPAQUE(std::vector<Eigen::Vector3d>);
+PYBIND11_MAKE_OPAQUE(std::vector<Eigen::Vector3s>);
 PYBIND11_MAKE_OPAQUE(std::vector<double>);
 PYBIND11_MAKE_OPAQUE(std::vector<int64_t>);
 
 PYBIND11_MODULE(rko_lio_pybind, m) {
-  auto vector3dvector = pybind_eigen_vector_of_vector<Eigen::Vector3d>(
-      m, "_Vector3dVector", "std::vector<Eigen::Vector3d>", py::py_array_to_vectors_double<Eigen::Vector3d>);
+  auto vector3svector = pybind_eigen_vector_of_vector<Eigen::Vector3s>(
+      m, "_Vector3sVector", "std::vector<Eigen::Vector3s>", py::py_array_to_vectors<Eigen::Vector3s>);
   py::bind_vector<std::vector<double>>(m, "_VectorDouble");
   py::bind_vector<std::vector<int64_t>>(m, "_VectorInt64");
 
@@ -77,7 +77,7 @@ PYBIND11_MODULE(rko_lio_pybind, m) {
       .def(py::init<const LIO::Config&>(), "config"_a)
       .def(
           "add_imu_measurement",
-          [](LIO& self, const Eigen::Vector3d& accel, const Eigen::Vector3d& gyro, const int64_t time_ns) {
+          [](LIO& self, const Eigen::Vector3s& accel, const Eigen::Vector3s& gyro, const int64_t time_ns) {
             self.add_imu_measurement(ImuControl{
                 .time = Nsec(time_ns),
                 .acceleration = accel,
@@ -87,9 +87,9 @@ PYBIND11_MODULE(rko_lio_pybind, m) {
           "acceleration"_a, "angular_velocity"_a, "time"_a)
       .def(
           "add_imu_measurement",
-          [](LIO& self, const Eigen::Matrix4d& extrinsic_imu2base, const Eigen::Vector3d& accel,
-             const Eigen::Vector3d& gyro, const int64_t time_ns) {
-            self.add_imu_measurement(Sophus::SE3d(extrinsic_imu2base), ImuControl{
+          [](LIO& self, const Eigen::Matrix4s& extrinsic_imu2base, const Eigen::Vector3s& accel,
+             const Eigen::Vector3s& gyro, const int64_t time_ns) {
+            self.add_imu_measurement(Sophus::SE3s(extrinsic_imu2base), ImuControl{
                                                                            .time = Nsec(time_ns),
                                                                            .acceleration = accel,
                                                                            .angular_velocity = gyro,
@@ -98,7 +98,7 @@ PYBIND11_MODULE(rko_lio_pybind, m) {
           "extrinsic_imu2base"_a, "acceleration"_a, "angular_velocity"_a, "time"_a)
       .def(
           "register_scan",
-          [](LIO& self, const std::vector<Eigen::Vector3d>& scan, const std::vector<int64_t>& timestamps_ns) {
+          [](LIO& self, const std::vector<Eigen::Vector3s>& scan, const std::vector<int64_t>& timestamps_ns) {
             TimestampVector timestamps(timestamps_ns.size());
             std::transform(timestamps_ns.cbegin(), timestamps_ns.cend(), timestamps.begin(),
                            [](const int64_t t) { return Nsec(t); });
@@ -107,12 +107,12 @@ PYBIND11_MODULE(rko_lio_pybind, m) {
           "scan"_a, "timestamps"_a)
       .def(
           "register_scan",
-          [](LIO& self, const Eigen::Matrix4d& extrinsic_lidar2base, const std::vector<Eigen::Vector3d>& scan,
+          [](LIO& self, const Eigen::Matrix4s& extrinsic_lidar2base, const std::vector<Eigen::Vector3s>& scan,
              const std::vector<int64_t>& timestamps_ns) {
             TimestampVector timestamps(timestamps_ns.size());
             std::transform(timestamps_ns.cbegin(), timestamps_ns.cend(), timestamps.begin(),
                            [](const int64_t t) { return Nsec(t); });
-            return self.register_scan(Sophus::SE3d(extrinsic_lidar2base), scan, timestamps);
+            return self.register_scan(Sophus::SE3s(extrinsic_lidar2base), scan, timestamps);
           },
           "extrinsic_lidar2base"_a, "scan"_a, "timestamps"_a)
       .def("map_point_cloud", [](LIO& self) { return self.map.pointcloud(); })
@@ -130,8 +130,8 @@ PYBIND11_MODULE(rko_lio_pybind, m) {
              for (size_t i = 0; i < n; ++i) {
                const auto& [time, pose] = self.poses_with_timestamps[i];
                times_ns[i] = time.count();
-               const Eigen::Vector3d& trans = pose.translation();
-               const Eigen::Quaterniond& q = pose.unit_quaternion();
+               const Eigen::Vector3s& trans = pose.translation();
+               const Eigen::Quaternions& q = pose.unit_quaternion();
                pose_buf(i, 0) = trans.x();
                pose_buf(i, 1) = trans.y();
                pose_buf(i, 2) = trans.z();

--- a/rko_lio/python/pybind/stl_vector_eigen.hpp
+++ b/rko_lio/python/pybind/stl_vector_eigen.hpp
@@ -56,21 +56,19 @@ py::class_<Vector, holder_type> bind_vector_without_repr(py::module& m, std::str
 // - This function is used by Pybind for std::vector<SomeEigenType> constructor.
 //   This optional constructor is added to avoid too many Python <-> C++ API
 //   calls when the vector size is large using the default biding method.
-//   Pybind matches np.float64 array to py::array_t<double> buffer.
-// - Directly using templates for the py::array_t<double> and py::array_t<int>
-//   and etc. doesn't work. The current solution is to explicitly implement
-//   bindings for each py array types.
+// - The numpy dtype follows the eigen vector's scalar, so a matching array is taken
+//   straight through and anything else is converted once by forcecast.
 template <typename EigenVector>
 std::vector<EigenVector>
-py_array_to_vectors_double(py::array_t<double, py::array::c_style | py::array::forcecast> array) {
+py_array_to_vectors(py::array_t<typename EigenVector::Scalar, py::array::c_style | py::array::forcecast> array) {
   int64_t eigen_vector_size = EigenVector::SizeAtCompileTime;
   if (array.ndim() != 2 || array.shape(1) != eigen_vector_size) {
     throw py::cast_error();
   }
   std::vector<EigenVector> eigen_vectors(array.shape(0));
-  auto array_unchecked = array.mutable_unchecked<2>();
+  auto array_unchecked = array.template unchecked<2>();
   for (auto i = 0; i < array_unchecked.shape(0); ++i) {
-    eigen_vectors[i] = Eigen::Map<EigenVector>(&array_unchecked(i, 0));
+    eigen_vectors[i] = Eigen::Map<const EigenVector>(&array_unchecked(i, 0));
   }
   return eigen_vectors;
 }

--- a/rko_lio/python/rko_lio/lio.py
+++ b/rko_lio/python/rko_lio/lio.py
@@ -30,7 +30,7 @@ from .config import LIOConfig
 from .rko_lio_pybind import (
     _LIO,
     _IntervalStats,
-    _Vector3dVector,
+    _Vector3sVector,
     _VectorInt64,
 )
 
@@ -162,7 +162,7 @@ class LIO:
             raise ValueError(
                 f"timestamps: expected ({scan_arr.shape[0]},), got {times_arr.shape}"
             )
-        scan_vec = _Vector3dVector(scan_arr)
+        scan_vec = _Vector3sVector(scan_arr)
         time_vec = _VectorInt64(times_arr)
         if extrinsic_lidar2base is None:
             ret_scan = self._impl.register_scan(scan_vec, time_vec)

--- a/rko_lio/ros/base_node.cpp
+++ b/rko_lio/ros/base_node.cpp
@@ -58,8 +58,8 @@ namespace rko_lio::ros {
 core::ImuControl imu_msg_to_imu_data(const sensor_msgs::msg::Imu& imu_msg) {
   core::ImuControl imu_data;
   imu_data.time = utils::to_ns(imu_msg.header.stamp);
-  imu_data.angular_velocity = utils::ros_xyz_to_eigen_vector3d(imu_msg.angular_velocity);
-  imu_data.acceleration = utils::ros_xyz_to_eigen_vector3d(imu_msg.linear_acceleration);
+  imu_data.angular_velocity = utils::ros_xyz_to_eigen_vector(imu_msg.angular_velocity);
+  imu_data.acceleration = utils::ros_xyz_to_eigen_vector(imu_msg.linear_acceleration);
   return imu_data;
 }
 
@@ -169,7 +169,7 @@ BaseNode::BaseNode(const std::string& node_name, const rclcpp::NodeOptions& opti
 }
 
 void BaseNode::parse_cli_extrinsics() {
-  auto parse_extrinsic = [this](const std::string& name, Sophus::SE3d& extrinsic) {
+  auto parse_extrinsic = [this](const std::string& name, Sophus::SE3s& extrinsic) {
     const std::string param_name = "extrinsic_" + name + "2base_quat_xyzw_xyz";
     const std::vector<double> vec = node->declare_parameter<std::vector<double>>(param_name, std::vector<double>{});
 
@@ -183,11 +183,11 @@ void BaseNode::parse_cli_extrinsics() {
       }
       return false;
     }
-    Eigen::Quaterniond q(vec[3], vec[0], vec[1], vec[2]); // qw, qx, qy, qz
+    Eigen::Quaternions q(vec[3], vec[0], vec[1], vec[2]); // qw, qx, qy, qz
     if (q.norm() < 1e-6) {
       throw std::runtime_error(name + " extrinsic quaternion has zero norm");
     }
-    extrinsic = Sophus::SE3d(q, Eigen::Vector3d(vec[4], vec[5], vec[6]));
+    extrinsic = Sophus::SE3s(q, Eigen::Vector3s(vec[4], vec[5], vec[6]));
     RCLCPP_INFO_STREAM(node->get_logger(), "Parsed " << name << " extrinsic as: " << extrinsic.log().transpose());
     return true;
   };
@@ -215,11 +215,11 @@ bool BaseNode::check_and_set_extrinsics() {
   if (extrinsics_set) {
     return true;
   }
-  const std::optional<Sophus::SE3d> imu_transform = utils::get_transform(tf_buffer, imu_frame, base_frame, 0s);
+  const std::optional<Sophus::SE3s> imu_transform = utils::get_transform(tf_buffer, imu_frame, base_frame, 0s);
   if (!imu_transform) {
     return false;
   }
-  const std::optional<Sophus::SE3d> lidar_transform = utils::get_transform(tf_buffer, lidar_frame, base_frame, 0s);
+  const std::optional<Sophus::SE3s> lidar_transform = utils::get_transform(tf_buffer, lidar_frame, base_frame, 0s);
   if (!lidar_transform) {
     return false;
   }
@@ -243,7 +243,7 @@ LidarFrame BaseNode::process_lidar_msg(const sensor_msgs::msg::PointCloud2::Cons
   return frame;
 }
 
-core::Vector3dVector BaseNode::register_scan_locked(core::Vector3dVector scan,
+core::Vector3sVector BaseNode::register_scan_locked(core::Vector3sVector scan,
                                                     const core::TimestampVector& time_vector) {
   std::unique_lock lock(local_map_mutex, std::defer_lock);
   if (publish_local_map) {
@@ -252,7 +252,7 @@ core::Vector3dVector BaseNode::register_scan_locked(core::Vector3dVector scan,
   return lio->register_scan(extrinsic_lidar2base, std::move(scan), time_vector);
 }
 
-void BaseNode::publish_lidar_outputs(const core::Vector3dVector& deskewed_frame) const {
+void BaseNode::publish_lidar_outputs(const core::Vector3sVector& deskewed_frame) const {
   if (publish_deskewed_scan) {
     std_msgs::msg::Header header;
     header.frame_id = lidar_frame;
@@ -272,8 +272,8 @@ void BaseNode::publish_odometry(const core::State& state,
   odom_msg.header.frame_id = odom_frame;
   odom_msg.child_frame_id = base_frame;
   odom_msg.pose.pose = utils::sophus_to_pose(state.pose);
-  utils::eigen_vector3d_to_ros_xyz(state.velocity, odom_msg.twist.twist.linear);
-  utils::eigen_vector3d_to_ros_xyz(state.angular_velocity, odom_msg.twist.twist.angular);
+  utils::eigen_vector_to_ros_xyz(state.velocity, odom_msg.twist.twist.linear);
+  utils::eigen_vector_to_ros_xyz(state.angular_velocity, odom_msg.twist.twist.angular);
   publisher->publish(odom_msg);
 }
 
@@ -296,7 +296,7 @@ void BaseNode::publish_lidar_accel(const core::State& state) const {
   auto accel_msg = geometry_msgs::msg::AccelStamped();
   accel_msg.header.stamp = utils::to_ros_time(state.time);
   accel_msg.header.frame_id = base_frame;
-  utils::eigen_vector3d_to_ros_xyz(state.linear_acceleration, accel_msg.accel.linear);
+  utils::eigen_vector_to_ros_xyz(state.linear_acceleration, accel_msg.accel.linear);
   lidar_accel_publisher->publish(accel_msg);
 }
 
@@ -308,7 +308,7 @@ void BaseNode::publish_map_loop() {
       RCLCPP_WARN_ONCE(node->get_logger(), "Local map publish thread: Local map is empty.");
       continue;
     }
-    const core::Vector3dVector map_points = lio->map.pointcloud();
+    const core::Vector3sVector map_points = lio->map.pointcloud();
     lock.unlock(); // we don't access the local map anymore
     std_msgs::msg::Header map_header;
     map_header.stamp = node->now();
@@ -333,8 +333,8 @@ void BaseNode::dump_results_to_disk(const std::filesystem::path& results_dir, co
     // dump poses
     if (std::ofstream file(output_file); file.is_open()) {
       for (const auto& [timestamp, pose] : lio->poses_with_timestamps) {
-        const Eigen::Vector3d& translation = pose.translation();
-        const Eigen::Quaterniond& quaternion = pose.so3().unit_quaternion();
+        const Eigen::Vector3s& translation = pose.translation();
+        const Eigen::Quaternions& quaternion = pose.so3().unit_quaternion();
         file << std::fixed << std::setprecision(6) << core::to_seconds(timestamp) << " " << translation.x() << " "
              << translation.y() << " " << translation.z() << " " << quaternion.x() << " " << quaternion.y() << " "
              << quaternion.z() << " " << quaternion.w() << "\n";

--- a/rko_lio/ros/base_node.hpp
+++ b/rko_lio/ros/base_node.hpp
@@ -49,7 +49,7 @@ namespace rko_lio::ros {
 
 struct LidarFrame {
   core::Timestamps timestamps;
-  core::Vector3dVector points;
+  core::Vector3sVector points;
 };
 // Shared helper used by both the threaded and sequential nodes.
 core::ImuControl imu_msg_to_imu_data(const sensor_msgs::msg::Imu& imu_msg);
@@ -79,8 +79,8 @@ public:
   bool publish_deskewed_scan = false;
   bool publish_local_map = false;
 
-  Sophus::SE3d extrinsic_imu2base;
-  Sophus::SE3d extrinsic_lidar2base;
+  Sophus::SE3s extrinsic_imu2base;
+  Sophus::SE3s extrinsic_lidar2base;
   bool extrinsics_set = false;
 
   std::shared_ptr<tf2_ros::TransformListener> tf_listener;
@@ -115,9 +115,9 @@ public:
 
   LidarFrame process_lidar_msg(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& lidar_msg) const;
 
-  core::Vector3dVector register_scan_locked(core::Vector3dVector scan, const core::TimestampVector& time_vector);
+  core::Vector3sVector register_scan_locked(core::Vector3sVector scan, const core::TimestampVector& time_vector);
 
-  void publish_lidar_outputs(const core::Vector3dVector& deskewed_frame) const;
+  void publish_lidar_outputs(const core::Vector3sVector& deskewed_frame) const;
 
   void publish_odometry(const core::State& state,
                         const rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr& publisher) const;

--- a/rko_lio/ros/online_imu_rate_node.cpp
+++ b/rko_lio/ros/online_imu_rate_node.cpp
@@ -109,7 +109,7 @@ public:
 
     try {
       LidarFrame frame = process_lidar_msg(lidar_msg);
-      const core::Vector3dVector deskewed_frame =
+      const core::Vector3sVector deskewed_frame =
           register_scan_locked(std::move(frame.points), frame.timestamps.per_point);
       if (deskewed_frame.empty()) {
         // first frame is skipped and an empty frame is returned. nothing to publish.

--- a/rko_lio/ros/threaded_node.cpp
+++ b/rko_lio/ros/threaded_node.cpp
@@ -35,10 +35,9 @@ using namespace std::literals;
 
 namespace rko_lio::ros {
 
-ThreadedNode::ThreadedNode(const std::string& node_name, const rclcpp::NodeOptions& options)
-    : BaseNode(node_name, options) {
-  max_lidar_buffer_size = static_cast<size_t>(
-      node->declare_parameter<int>("async.max_lidar_buffer_size", static_cast<int>(max_lidar_buffer_size)));
+ThreadedNode::ThreadedNode(const std::string& node_name, const rclcpp::NodeOptions& options) : BaseNode(node_name, options) {
+  max_lidar_buffer_size = static_cast<size_t>(node->declare_parameter<int>(
+      "async.max_lidar_buffer_size", static_cast<int>(max_lidar_buffer_size)));
   registration_thread = std::jthread([this]() { registration_loop(); });
 }
 
@@ -106,8 +105,7 @@ void ThreadedNode::registration_loop() {
     buffer_lock.unlock(); // we dont touch the buffers anymore
 
     try {
-      const core::Vector3dVector deskewed_frame =
-          register_scan_locked(std::move(frame.points), frame.timestamps.per_point);
+      const core::Vector3sVector deskewed_frame = register_scan_locked(std::move(frame.points), frame.timestamps.per_point);
       if (!deskewed_frame.empty()) {
         // TODO: first frame is skipped and an empty frame is returned. improve how we handle this
         publish_lidar_outputs(deskewed_frame);

--- a/rko_lio/ros/utils/CMakeLists.txt
+++ b/rko_lio/ros/utils/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(
          tf2_ros::static_transform_broadcaster_node
          tf2_ros::tf2_ros
          # ros deps end
+         rko_lio::core
          Sophus::Sophus
          Eigen3::Eigen)
 set_target_properties(rko_lio.ros.utils PROPERTIES POSITION_INDEPENDENT_CODE ON

--- a/rko_lio/ros/utils/point_cloud_read.cpp
+++ b/rko_lio/ros/utils/point_cloud_read.cpp
@@ -29,13 +29,12 @@
 #include <stdexcept>
 
 namespace rko_lio::ros::utils {
-using Vector3dVector = std::vector<Eigen::Vector3d>;
 using PointCloud2 = sensor_msgs::msg::PointCloud2;
 using PointField = sensor_msgs::msg::PointField;
 
-Vector3dVector point_cloud2_to_eigen(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& msg) {
+core::Vector3sVector point_cloud2_to_eigen(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& msg) {
   const size_t point_count = static_cast<size_t>(msg->height) * msg->width;
-  Vector3dVector points;
+  core::Vector3sVector points;
   points.reserve(point_count);
   sensor_msgs::PointCloud2ConstIterator<float> msg_x(*msg, "x");
   sensor_msgs::PointCloud2ConstIterator<float> msg_y(*msg, "y");

--- a/rko_lio/ros/utils/point_cloud_read.hpp
+++ b/rko_lio/ros/utils/point_cloud_read.hpp
@@ -23,6 +23,8 @@
  */
 
 #pragma once
+#include <rko_lio/core/util.hpp>
+
 #include <Eigen/Core>
 #include <sophus/se3.hpp>
 // ros
@@ -30,10 +32,10 @@
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 
 namespace rko_lio::ros::utils {
-std::vector<Eigen::Vector3d> point_cloud2_to_eigen(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& msg);
+core::Vector3sVector point_cloud2_to_eigen(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& msg);
 
 struct RawScan {
-  std::vector<Eigen::Vector3d> points;
+  core::Vector3sVector points;
   std::vector<double> timestamps;
 };
 

--- a/rko_lio/ros/utils/point_cloud_write.cpp
+++ b/rko_lio/ros/utils/point_cloud_write.cpp
@@ -60,12 +60,12 @@ PointCloud2::UniquePtr create_point_cloud2_msg(const size_t n_points, const Head
   return cloud_msg;
 }
 
-void fill_point_cloud2_xyz(const std::vector<Eigen::Vector3d>& points, PointCloud2& msg) {
+void fill_point_cloud2_xyz(const rko_lio::core::Vector3sVector& points, PointCloud2& msg) {
   sensor_msgs::PointCloud2Iterator<float> msg_x(msg, "x");
   sensor_msgs::PointCloud2Iterator<float> msg_y(msg, "y");
   sensor_msgs::PointCloud2Iterator<float> msg_z(msg, "z");
   for (size_t i = 0; i < points.size(); i++, ++msg_x, ++msg_y, ++msg_z) {
-    const Eigen::Vector3d& point = points[i];
+    const Eigen::Vector3s& point = points[i];
     *msg_x = static_cast<float>(point.x());
     *msg_y = static_cast<float>(point.y());
     *msg_z = static_cast<float>(point.z());
@@ -74,7 +74,7 @@ void fill_point_cloud2_xyz(const std::vector<Eigen::Vector3d>& points, PointClou
 } // namespace
 namespace rko_lio::ros::utils {
 
-PointCloud2::UniquePtr eigen_to_point_cloud2(const std::vector<Eigen::Vector3d>& points, const Header& header) {
+PointCloud2::UniquePtr eigen_to_point_cloud2(const rko_lio::core::Vector3sVector& points, const Header& header) {
   PointCloud2::UniquePtr msg = create_point_cloud2_msg(points.size(), header);
   fill_point_cloud2_xyz(points, *msg);
   return msg;

--- a/rko_lio/ros/utils/ros_vectors.hpp
+++ b/rko_lio/ros/utils/ros_vectors.hpp
@@ -27,7 +27,7 @@
 #include <Eigen/Core>
 
 namespace rko_lio::ros::utils {
-void eigen_vector3d_to_ros_xyz(const Eigen::Vector3d& vector, auto& ros_vector)
+void eigen_vector_to_ros_xyz(const Eigen::Vector3s& vector, auto& ros_vector)
   requires requires(decltype(ros_vector) v) {
     { v.x } -> std::convertible_to<double>;
     { v.y } -> std::convertible_to<double>;
@@ -40,7 +40,7 @@ void eigen_vector3d_to_ros_xyz(const Eigen::Vector3d& vector, auto& ros_vector)
 }
 
 template <typename T>
-Eigen::Vector3d ros_xyz_to_eigen_vector3d(const T& ros_vector) {
-  return Eigen::Vector3d{ros_vector.x, ros_vector.y, ros_vector.z};
+Eigen::Vector3s ros_xyz_to_eigen_vector(const T& ros_vector) {
+  return Eigen::Vector3s{ros_vector.x, ros_vector.y, ros_vector.z};
 }
 }; // namespace rko_lio::ros::utils

--- a/rko_lio/ros/utils/ros_vectors.hpp
+++ b/rko_lio/ros/utils/ros_vectors.hpp
@@ -41,6 +41,6 @@ void eigen_vector_to_ros_xyz(const Eigen::Vector3s& vector, auto& ros_vector)
 
 template <typename T>
 Eigen::Vector3s ros_xyz_to_eigen_vector(const T& ros_vector) {
-  return Eigen::Vector3s{ros_vector.x, ros_vector.y, ros_vector.z};
+  return Eigen::Vector3s(ros_vector.x, ros_vector.y, ros_vector.z);
 }
 }; // namespace rko_lio::ros::utils

--- a/rko_lio/ros/utils/transforms.hpp
+++ b/rko_lio/ros/utils/transforms.hpp
@@ -27,6 +27,8 @@
 #include <Eigen/Core>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
+#include <rko_lio/core/util.hpp>
+
 #include <optional>
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
@@ -36,14 +38,13 @@
 #include <tf2_ros/buffer.hpp>
 
 namespace rko_lio::ros::utils {
-template <typename Scalar = double>
-inline geometry_msgs::msg::Pose sophus_to_pose(const Sophus::SE3<Scalar>& T) {
+inline geometry_msgs::msg::Pose sophus_to_pose(const Sophus::SE3s& T) {
   geometry_msgs::msg::Pose t;
   t.position.x = T.translation().x();
   t.position.y = T.translation().y();
   t.position.z = T.translation().z();
 
-  Eigen::Quaternion<Scalar> q(T.so3().unit_quaternion());
+  Eigen::Quaternions q(T.so3().unit_quaternion());
   t.orientation.x = q.x();
   t.orientation.y = q.y();
   t.orientation.z = q.z();
@@ -52,14 +53,13 @@ inline geometry_msgs::msg::Pose sophus_to_pose(const Sophus::SE3<Scalar>& T) {
   return t;
 }
 
-template <typename Scalar = double>
-inline geometry_msgs::msg::Transform sophus_to_transform(const Sophus::SE3<Scalar>& T) {
+inline geometry_msgs::msg::Transform sophus_to_transform(const Sophus::SE3s& T) {
   geometry_msgs::msg::Transform t;
   t.translation.x = T.translation().x();
   t.translation.y = T.translation().y();
   t.translation.z = T.translation().z();
 
-  Eigen::Quaternion<Scalar> q(T.so3().unit_quaternion());
+  Eigen::Quaternions q(T.so3().unit_quaternion());
   t.rotation.x = q.x();
   t.rotation.y = q.y();
   t.rotation.z = q.z();
@@ -68,15 +68,13 @@ inline geometry_msgs::msg::Transform sophus_to_transform(const Sophus::SE3<Scala
   return t;
 }
 
-template <typename Scalar = double>
-inline Sophus::SE3<Scalar> transform_to_sophus(const geometry_msgs::msg::TransformStamped& transform) {
+inline Sophus::SE3s transform_to_sophus(const geometry_msgs::msg::TransformStamped& transform) {
   const auto& t = transform.transform;
-  return {typename Sophus::SE3<Scalar>::QuaternionType(t.rotation.w, t.rotation.x, t.rotation.y, t.rotation.z),
-          typename Sophus::SE3<Scalar>::Point(t.translation.x, t.translation.y, t.translation.z)};
+  return {Sophus::SE3s::QuaternionType(t.rotation.w, t.rotation.x, t.rotation.y, t.rotation.z),
+          Sophus::SE3s::Point(t.translation.x, t.translation.y, t.translation.z)};
 }
 
-template <typename Scalar = double>
-std::optional<Sophus::SE3<Scalar>>
+inline std::optional<Sophus::SE3s>
 get_transform(const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
               const std::string& from_frame,
               const std::string& to_frame,
@@ -96,7 +94,7 @@ get_transform(const std::shared_ptr<tf2_ros::Buffer>& tf_buffer,
       return std::nullopt;
     }
     from_to_transform = tf_buffer->lookupTransform(to_frame, from_frame, tf_time);
-    return transform_to_sophus<Scalar>(from_to_transform);
+    return transform_to_sophus(from_to_transform);
   } catch (const tf2::InvalidArgumentException& e) {
     RCLCPP_WARN_STREAM(rclcpp::get_logger("transform lookup"),
                        "TF lookup error (InvalidArgumentException): " << e.what());

--- a/tests/core/eigen_approx.hpp
+++ b/tests/core/eigen_approx.hpp
@@ -19,24 +19,33 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-
 #pragma once
+#include <rko_lio/core/util.hpp>
+
 #include <Eigen/Core>
 #include <sophus/se3.hpp>
 #include <sophus/so3.hpp>
+#include <type_traits>
 
 namespace rko_lio::tests {
 
-inline bool approx_equal(const Eigen::Vector3d& a, const Eigen::Vector3d& b, double tol = 1e-6) {
-  return (a - b).norm() < tol;
+constexpr bool IS_DOUBLE = std::is_same_v<core::Scalar, double>;
+
+// double has tighter tolerances when being used. float is looser
+constexpr double LOOSE_TOL = IS_DOUBLE ? 1e-6 : 1e-4;
+constexpr double TOL = IS_DOUBLE ? 1e-9 : 1e-4;
+constexpr double EXACT_TOL = IS_DOUBLE ? 1e-12 : 1e-4;
+
+inline bool approx_equal(const Eigen::Vector3s& a, const Eigen::Vector3s& b, double tolerance = LOOSE_TOL) {
+  return (a - b).norm() < tolerance;
 }
 
-inline bool approx_equal(const Sophus::SO3d& a, const Sophus::SO3d& b, double tol = 1e-6) {
-  return (a.inverse() * b).log().norm() < tol;
+inline bool approx_equal(const Sophus::SO3s& a, const Sophus::SO3s& b, double tolerance = LOOSE_TOL) {
+  return (a.inverse() * b).log().norm() < tolerance;
 }
 
-inline bool approx_equal(const Sophus::SE3d& a, const Sophus::SE3d& b, double tol = 1e-6) {
-  return (a.inverse() * b).log().norm() < tol;
+inline bool approx_equal(const Sophus::SE3s& a, const Sophus::SE3s& b, double tolerance = LOOSE_TOL) {
+  return (a.inverse() * b).log().norm() < tolerance;
 }
 
 } // namespace rko_lio::tests

--- a/tests/core/synthetic_clouds.hpp
+++ b/tests/core/synthetic_clouds.hpp
@@ -28,8 +28,8 @@ namespace rko_lio::tests {
 
 // Hollow cube of side 2*half_extent centered at the origin, six faces sampled at
 // `spacing`. 
-inline std::vector<Eigen::Vector3d> make_hollow_cube(double spacing = 0.5, double half_extent = 5.0) {
-  std::vector<Eigen::Vector3d> points;
+inline std::vector<Eigen::Vector3s> make_hollow_cube(double spacing = 0.5, double half_extent = 5.0) {
+  std::vector<Eigen::Vector3s> points;
   const int n = static_cast<int>(2 * half_extent / spacing) + 1;
   points.reserve(static_cast<size_t>(6 * n * n));
   for (int i = 0; i < n; ++i) {

--- a/tests/core/test_imu_integration.cpp
+++ b/tests/core/test_imu_integration.cpp
@@ -29,13 +29,16 @@
 #include <cmath>
 #include <cstdint>
 
+using rko_lio::tests::TOL;
+using rko_lio::tests::LOOSE_TOL;
+using rko_lio::tests::EXACT_TOL;
 using rko_lio::core::GRAVITY_MAG;
 using rko_lio::core::ImuControl;
 using rko_lio::core::LIO;
 using rko_lio::core::Nsec;
 using rko_lio::core::TimestampVector;
 using rko_lio::core::to_seconds;
-using rko_lio::core::Vector3dVector;
+using rko_lio::core::Vector3sVector;
 using rko_lio::tests::approx_equal;
 using rko_lio::tests::make_hollow_cube;
 using Catch::Matchers::WithinAbs;
@@ -60,7 +63,7 @@ TEST_CASE("IMU before first LiDAR is silently dropped", "[imu_integration]") {
     ImuControl m;
     m.time = ns_from_seconds(0.01 * (i + 1));
     m.acceleration = {0.0, 0.0, GRAVITY_MAG};
-    m.angular_velocity = Eigen::Vector3d::Zero();
+    m.angular_velocity = Eigen::Vector3s::Zero();
     lio.add_imu_measurement(m);
   }
   REQUIRE(lio.interval_stats.imu_count == 0);
@@ -76,20 +79,20 @@ TEST_CASE("Static IMU at rest: gravity is compensated", "[imu_integration]") {
     ImuControl m;
     m.time = ns_from_seconds(1.0 + 0.01 * (i + 1));
     m.acceleration = {0.0, 0.0, GRAVITY_MAG};
-    m.angular_velocity = Eigen::Vector3d::Zero();
+    m.angular_velocity = Eigen::Vector3s::Zero();
     lio.add_imu_measurement(m);
   }
 
   REQUIRE(lio.interval_stats.imu_count == N);
-  REQUIRE(lio.interval_stats.body_acceleration_sum.norm() < 1e-9);
-  REQUIRE_THAT(lio.interval_stats.imu_acceleration_sum.z(), WithinAbs(N * GRAVITY_MAG, 1e-6));
+  REQUIRE(lio.interval_stats.body_acceleration_sum.norm() < TOL);
+  REQUIRE_THAT(lio.interval_stats.imu_acceleration_sum.z(), WithinAbs(N * GRAVITY_MAG, LOOSE_TOL));
 }
 
 TEST_CASE("Pure rotation: gyro integration matches exp(omega*T)", "[imu_integration]") {
   LIO lio(default_config());
   lio.lidar_state.time = ns_from_seconds(1.0);
 
-  const Eigen::Vector3d omega(0.0, 0.0, 0.5);
+  const Eigen::Vector3s omega(0.0, 0.0, 0.5);
   constexpr int N = 100;
   constexpr double dt = 0.01;
   const double T = N * dt;
@@ -98,12 +101,12 @@ TEST_CASE("Pure rotation: gyro integration matches exp(omega*T)", "[imu_integrat
     ImuControl m;
     m.time = ns_from_seconds(1.0 + dt * (i + 1));
     m.angular_velocity = omega;
-    m.acceleration = Eigen::Vector3d::Zero();
+    m.acceleration = Eigen::Vector3s::Zero();
     lio.add_imu_measurement(m);
   }
 
-  const Sophus::SO3d expected = Sophus::SO3d::exp(omega * T);
-  REQUIRE(approx_equal(lio.imu_state.pose.so3(), expected, 1e-9));
+  const Sophus::SO3s expected = Sophus::SO3s::exp(omega * T);
+  REQUIRE(approx_equal(lio.imu_state.pose.so3(), expected, TOL));
   REQUIRE_THAT(to_seconds(lio.imu_state.time), WithinAbs(1.0 + T, 1e-12));
 }
 
@@ -112,27 +115,27 @@ TEST_CASE("Gyro bias is subtracted before integration", "[imu_integration]") {
   lio.lidar_state.time = ns_from_seconds(1.0);
   lio.imu_bias.gyroscope = {0.1, -0.2, 0.05};
 
-  const Eigen::Vector3d measured(0.5, 0.3, 0.1);
+  const Eigen::Vector3s measured(0.5, 0.3, 0.1);
   constexpr int N = 50;
   for (int i = 0; i < N; ++i) {
     ImuControl m;
     m.time = ns_from_seconds(1.0 + 0.01 * (i + 1));
     m.angular_velocity = measured;
-    m.acceleration = Eigen::Vector3d::Zero();
+    m.acceleration = Eigen::Vector3s::Zero();
     lio.add_imu_measurement(m);
   }
 
-  const Eigen::Vector3d expected = measured - lio.imu_bias.gyroscope;
-  const Eigen::Vector3d avg = lio.interval_stats.angular_velocity_sum / lio.interval_stats.imu_count;
-  REQUIRE(approx_equal(avg, expected, 1e-12));
+  const Eigen::Vector3s expected = measured - lio.imu_bias.gyroscope;
+  const Eigen::Vector3s avg = lio.interval_stats.angular_velocity_sum / lio.interval_stats.imu_count;
+  REQUIRE(approx_equal(avg, expected, EXACT_TOL));
 }
 
 TEST_CASE("Extrinsic overload: identity extrinsic delegates to base-frame", "[imu_integration]") {
   LIO lio(default_config());
   lio.lidar_state.time = ns_from_seconds(1.0);
 
-  const Sophus::SE3d identity_extrinsic;
-  const Eigen::Vector3d omega(0.1, 0.2, 0.3);
+  const Sophus::SE3s identity_extrinsic;
+  const Eigen::Vector3s omega(0.1, 0.2, 0.3);
 
   constexpr int N = 10;
   for (int i = 0; i < N; ++i) {
@@ -146,19 +149,19 @@ TEST_CASE("Extrinsic overload: identity extrinsic delegates to base-frame", "[im
   // Identity-extrinsic short-circuits straight into the base-frame overload,
   // bypassing the extrinsic-overload's first-sample skip.
   REQUIRE(lio.interval_stats.imu_count == N);
-  const Eigen::Vector3d avg_gyro = lio.interval_stats.angular_velocity_sum / lio.interval_stats.imu_count;
-  REQUIRE(approx_equal(avg_gyro, omega, 1e-12));
+  const Eigen::Vector3s avg_gyro = lio.interval_stats.angular_velocity_sum / lio.interval_stats.imu_count;
+  REQUIRE(approx_equal(avg_gyro, omega, EXACT_TOL));
 }
 
 TEST_CASE("Extrinsic overload: pure-rotation extrinsic transforms omega", "[imu_integration]") {
   LIO lio(default_config());
   lio.lidar_state.time = ns_from_seconds(1.0);
 
-  const Sophus::SO3d R = Sophus::SO3d::rotX(M_PI / 2.0);
-  const Sophus::SE3d extrinsic_imu2base(R, Eigen::Vector3d::Zero());
+  const Sophus::SO3s R = Sophus::SO3s::rotX(M_PI / 2.0);
+  const Sophus::SE3s extrinsic_imu2base(R, Eigen::Vector3s::Zero());
 
-  const Eigen::Vector3d omega_imu(0.0, 0.0, 1.0);
-  const Eigen::Vector3d expected_base = R * omega_imu;
+  const Eigen::Vector3s omega_imu(0.0, 0.0, 1.0);
+  const Eigen::Vector3s expected_base = R * omega_imu;
 
   // First extrinsic call is dropped (primes _last_real_imu_time); feed N+1 to get N integrated.
   constexpr int N = 20;
@@ -166,13 +169,13 @@ TEST_CASE("Extrinsic overload: pure-rotation extrinsic transforms omega", "[imu_
     ImuControl m;
     m.time = ns_from_seconds(1.0 + 0.01 * (i + 1));
     m.angular_velocity = omega_imu;
-    m.acceleration = Eigen::Vector3d::Zero();
+    m.acceleration = Eigen::Vector3s::Zero();
     lio.add_imu_measurement(extrinsic_imu2base, m);
   }
 
   REQUIRE(lio.interval_stats.imu_count == N);
-  const Eigen::Vector3d avg_gyro = lio.interval_stats.angular_velocity_sum / lio.interval_stats.imu_count;
-  REQUIRE(approx_equal(avg_gyro, expected_base, 1e-9));
+  const Eigen::Vector3s avg_gyro = lio.interval_stats.angular_velocity_sum / lio.interval_stats.imu_count;
+  REQUIRE(approx_equal(avg_gyro, expected_base, TOL));
 }
 
 // TODO: lever-arm centripetal correction (omega x (omega x r)) for translational extrinsic.
@@ -188,13 +191,13 @@ TEST_CASE("Static IMU at rest: imu_state translation stays zero", "[imu_integrat
     ImuControl m;
     m.time = ns_from_seconds(1.0 + 0.01 * (i + 1));
     m.acceleration = {0.0, 0.0, GRAVITY_MAG};
-    m.angular_velocity = Eigen::Vector3d::Zero();
+    m.angular_velocity = Eigen::Vector3s::Zero();
     lio.add_imu_measurement(m);
   }
 
   REQUIRE(lio.interval_stats.imu_count == N);
-  REQUIRE(lio.imu_state.pose.translation().norm() < 1e-9);
-  REQUIRE(lio.imu_state.velocity.norm() < 1e-9);
+  REQUIRE(lio.imu_state.pose.translation().norm() < TOL);
+  REQUIRE(lio.imu_state.velocity.norm() < TOL);
 }
 
 TEST_CASE("Constant body acceleration: position grows as 0.5 * a * t^2", "[imu_integration]") {
@@ -212,7 +215,7 @@ TEST_CASE("Constant body acceleration: position grows as 0.5 * a * t^2", "[imu_i
     m.time = ns_from_seconds(1.0 + dt * (i + 1));
     // Raw IMU acceleration: body accel + gravity (so compensated_accel comes out (a_x, 0, 0)).
     m.acceleration = {a_x, 0.0, GRAVITY_MAG};
-    m.angular_velocity = Eigen::Vector3d::Zero();
+    m.angular_velocity = Eigen::Vector3s::Zero();
     lio.add_imu_measurement(m);
   }
 
@@ -220,14 +223,14 @@ TEST_CASE("Constant body acceleration: position grows as 0.5 * a * t^2", "[imu_i
   // a_x * dt^2 / 2 and the integrator effectively uses pre-step velocity, so the
   // accumulated error after N steps is ~N * dt^2 * a_x / 2 = T * dt * a_x / 2.
   const double pos_tol = N * dt * dt * a_x;
-  const double vel_tol = 1e-9;
+  const double vel_tol = TOL;
   REQUIRE(lio.interval_stats.imu_count == N);
   REQUIRE_THAT(lio.imu_state.pose.translation().x(), WithinAbs(0.5 * a_x * T * T, pos_tol));
-  REQUIRE(std::abs(lio.imu_state.pose.translation().y()) < 1e-9);
-  REQUIRE(std::abs(lio.imu_state.pose.translation().z()) < 1e-9);
+  REQUIRE(std::abs(lio.imu_state.pose.translation().y()) < TOL);
+  REQUIRE(std::abs(lio.imu_state.pose.translation().z()) < TOL);
   REQUIRE_THAT(lio.imu_state.velocity.x(), WithinAbs(a_x * T, vel_tol));
-  REQUIRE(std::abs(lio.imu_state.velocity.y()) < 1e-9);
-  REQUIRE(std::abs(lio.imu_state.velocity.z()) < 1e-9);
+  REQUIRE(std::abs(lio.imu_state.velocity.y()) < TOL);
+  REQUIRE(std::abs(lio.imu_state.velocity.z()) < TOL);
 }
 
 TEST_CASE("register_scan resets imu_state to optimized pose", "[imu_integration]") {
@@ -260,7 +263,7 @@ TEST_CASE("register_scan resets imu_state to optimized pose", "[imu_integration]
     const double frac = static_cast<double>(i) / static_cast<double>(N - 1);
     m.time = ns_from_seconds(FIRST_SCAN_END + 0.05 + (DT - 0.1) * frac);
     m.acceleration = {0.0, 0.0, GRAVITY_MAG};
-    m.angular_velocity = Eigen::Vector3d::Zero();
+    m.angular_velocity = Eigen::Vector3s::Zero();
     lio.add_imu_measurement(m);
   }
 
@@ -269,9 +272,9 @@ TEST_CASE("register_scan resets imu_state to optimized pose", "[imu_integration]
   lio.register_scan(cloud, ts2);
 
   REQUIRE(lio.poses_with_timestamps.size() == 2);
-  REQUIRE(approx_equal(lio.imu_state.pose, lio.lidar_state.pose, 1e-12));
+  REQUIRE(approx_equal(lio.imu_state.pose, lio.lidar_state.pose, EXACT_TOL));
   REQUIRE_THAT(to_seconds(lio.imu_state.time), WithinAbs(to_seconds(lio.lidar_state.time), 1e-12));
-  REQUIRE(approx_equal(lio.imu_state.velocity, lio.lidar_state.velocity, 1e-12));
-  REQUIRE(approx_equal(lio.imu_state.angular_velocity, lio.lidar_state.angular_velocity, 1e-12));
-  REQUIRE(approx_equal(lio.imu_state.linear_acceleration, lio.lidar_state.linear_acceleration, 1e-12));
+  REQUIRE(approx_equal(lio.imu_state.velocity, lio.lidar_state.velocity, EXACT_TOL));
+  REQUIRE(approx_equal(lio.imu_state.angular_velocity, lio.lidar_state.angular_velocity, EXACT_TOL));
+  REQUIRE(approx_equal(lio.imu_state.linear_acceleration, lio.lidar_state.linear_acceleration, EXACT_TOL));
 }

--- a/tests/core/test_interval_stats.cpp
+++ b/tests/core/test_interval_stats.cpp
@@ -20,12 +20,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include "eigen_approx.hpp"
+
 #include "rko_lio/core/util.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <numeric>
 #include <vector>
 
+using rko_lio::tests::TOL;
+using rko_lio::tests::EXACT_TOL;
 using rko_lio::core::IntervalStats;
 using Catch::Matchers::WithinAbs;
 
@@ -41,24 +45,24 @@ TEST_CASE("IntervalStats: default-constructed state is zero", "[interval_stats]"
 
 TEST_CASE("IntervalStats: single update", "[interval_stats]") {
   IntervalStats stats;
-  const Eigen::Vector3d gyro(0.1, -0.2, 0.3);
-  const Eigen::Vector3d accel(1.0, 2.0, 2.0);
-  const Eigen::Vector3d compensated(0.0, 0.0, 0.0);
+  const Eigen::Vector3s gyro(0.1, -0.2, 0.3);
+  const Eigen::Vector3s accel(1.0, 2.0, 2.0);
+  const Eigen::Vector3s compensated(0.0, 0.0, 0.0);
   stats.update(gyro, accel, compensated);
 
   REQUIRE(stats.imu_count == 1);
   REQUIRE(stats.angular_velocity_sum == gyro);
   REQUIRE(stats.imu_acceleration_sum == accel);
   REQUIRE(stats.body_acceleration_sum == compensated);
-  REQUIRE_THAT(stats.imu_accel_mag_mean, WithinAbs(accel.norm(), 1e-12));
-  REQUIRE_THAT(stats.welford_sum_of_squares, WithinAbs(0.0, 1e-12));
+  REQUIRE_THAT(stats.imu_accel_mag_mean, WithinAbs(accel.norm(), EXACT_TOL));
+  REQUIRE_THAT(stats.welford_sum_of_squares, WithinAbs(0.0, EXACT_TOL));
 }
 
 TEST_CASE("IntervalStats: constant accel magnitude over N updates -> variance = 0", "[interval_stats]") {
   IntervalStats stats;
-  const Eigen::Vector3d gyro(0.0, 0.0, 0.0);
-  const Eigen::Vector3d accel(0.0, 0.0, 9.81);
-  const Eigen::Vector3d compensated(0.0, 0.0, 0.0);
+  const Eigen::Vector3s gyro(0.0, 0.0, 0.0);
+  const Eigen::Vector3s accel(0.0, 0.0, 9.81);
+  const Eigen::Vector3s compensated(0.0, 0.0, 0.0);
 
   constexpr int N = 50;
   for (int i = 0; i < N; ++i) {
@@ -66,8 +70,8 @@ TEST_CASE("IntervalStats: constant accel magnitude over N updates -> variance = 
   }
 
   REQUIRE(stats.imu_count == N);
-  REQUIRE_THAT(stats.imu_accel_mag_mean, WithinAbs(accel.norm(), 1e-9));
-  REQUIRE_THAT(stats.welford_sum_of_squares, WithinAbs(0.0, 1e-9));
+  REQUIRE_THAT(stats.imu_accel_mag_mean, WithinAbs(accel.norm(), TOL));
+  REQUIRE_THAT(stats.welford_sum_of_squares, WithinAbs(0.0, TOL));
 }
 
 TEST_CASE("IntervalStats: variance matches naive formula", "[interval_stats]") {
@@ -75,8 +79,8 @@ TEST_CASE("IntervalStats: variance matches naive formula", "[interval_stats]") {
   // Vary only the z-axis to control the resulting scalar magnitudes.
   const std::vector<double> magnitudes = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0};
   for (double m : magnitudes) {
-    const Eigen::Vector3d accel(0.0, 0.0, m);
-    stats.update(Eigen::Vector3d::Zero(), accel, Eigen::Vector3d::Zero());
+    const Eigen::Vector3s accel(0.0, 0.0, m);
+    stats.update(Eigen::Vector3s::Zero(), accel, Eigen::Vector3s::Zero());
   }
 
   const double mean = std::accumulate(magnitudes.begin(), magnitudes.end(), 0.0) / magnitudes.size();
@@ -86,19 +90,19 @@ TEST_CASE("IntervalStats: variance matches naive formula", "[interval_stats]") {
   }
 
   REQUIRE(stats.imu_count == static_cast<int>(magnitudes.size()));
-  REQUIRE_THAT(stats.imu_accel_mag_mean, WithinAbs(mean, 1e-9));
-  REQUIRE_THAT(stats.welford_sum_of_squares, WithinAbs(naive_sum_sq, 1e-9));
+  REQUIRE_THAT(stats.imu_accel_mag_mean, WithinAbs(mean, TOL));
+  REQUIRE_THAT(stats.welford_sum_of_squares, WithinAbs(naive_sum_sq, TOL));
 
   // sample variance = sum_of_squares / (N-1)
   const double sample_var = stats.welford_sum_of_squares / (stats.imu_count - 1);
   const double naive_var = naive_sum_sq / (magnitudes.size() - 1);
-  REQUIRE_THAT(sample_var, WithinAbs(naive_var, 1e-9));
+  REQUIRE_THAT(sample_var, WithinAbs(naive_var, TOL));
 }
 
 TEST_CASE("IntervalStats: reset zeros every field", "[interval_stats]") {
   IntervalStats stats;
-  stats.update(Eigen::Vector3d(1, 2, 3), Eigen::Vector3d(4, 5, 6), Eigen::Vector3d(7, 8, 9));
-  stats.update(Eigen::Vector3d(1, 1, 1), Eigen::Vector3d(2, 2, 2), Eigen::Vector3d(3, 3, 3));
+  stats.update(Eigen::Vector3s(1, 2, 3), Eigen::Vector3s(4, 5, 6), Eigen::Vector3s(7, 8, 9));
+  stats.update(Eigen::Vector3s(1, 1, 1), Eigen::Vector3s(2, 2, 2), Eigen::Vector3s(3, 3, 3));
   REQUIRE(stats.imu_count == 2);
 
   stats.reset();
@@ -112,18 +116,18 @@ TEST_CASE("IntervalStats: reset zeros every field", "[interval_stats]") {
 
 TEST_CASE("IntervalStats: sums accumulate across updates", "[interval_stats]") {
   IntervalStats stats;
-  const Eigen::Vector3d g1(0.1, 0.2, 0.3);
-  const Eigen::Vector3d g2(0.4, 0.5, 0.6);
-  const Eigen::Vector3d a1(1.0, 0.0, 0.0);
-  const Eigen::Vector3d a2(0.0, 1.0, 0.0);
-  const Eigen::Vector3d c1(0.5, 0.0, 0.0);
-  const Eigen::Vector3d c2(0.0, 0.5, 0.0);
+  const Eigen::Vector3s g1(0.1, 0.2, 0.3);
+  const Eigen::Vector3s g2(0.4, 0.5, 0.6);
+  const Eigen::Vector3s a1(1.0, 0.0, 0.0);
+  const Eigen::Vector3s a2(0.0, 1.0, 0.0);
+  const Eigen::Vector3s c1(0.5, 0.0, 0.0);
+  const Eigen::Vector3s c2(0.0, 0.5, 0.0);
 
   stats.update(g1, a1, c1);
   stats.update(g2, a2, c2);
 
   REQUIRE(stats.imu_count == 2);
-  REQUIRE((stats.angular_velocity_sum - (g1 + g2)).norm() < 1e-12);
-  REQUIRE((stats.imu_acceleration_sum - (a1 + a2)).norm() < 1e-12);
-  REQUIRE((stats.body_acceleration_sum - (c1 + c2)).norm() < 1e-12);
+  REQUIRE((stats.angular_velocity_sum - (g1 + g2)).norm() < EXACT_TOL);
+  REQUIRE((stats.imu_acceleration_sum - (a1 + a2)).norm() < EXACT_TOL);
+  REQUIRE((stats.body_acceleration_sum - (c1 + c2)).norm() < EXACT_TOL);
 }

--- a/tests/core/test_preprocess_scan.cpp
+++ b/tests/core/test_preprocess_scan.cpp
@@ -25,7 +25,7 @@
 
 using rko_lio::core::LIO;
 using rko_lio::core::preprocess_scan;
-using rko_lio::core::Vector3dVector;
+using rko_lio::core::Vector3sVector;
 
 namespace {
 LIO::Config default_config() {
@@ -44,7 +44,7 @@ TEST_CASE("preprocess_scan: clipping by min/max range", "[preprocess_scan]") {
   cfg.double_downsample = false;
   cfg.voxel_size = 0.05;
 
-  Vector3dVector frame = {
+  Vector3sVector frame = {
       {0.1, 0.0, 0.0},
       {0.4, 0.0, 0.0},
       {1.0, 0.0, 0.0},
@@ -68,7 +68,7 @@ TEST_CASE("preprocess_scan: double_downsample = false -> no map_frame", "[prepro
   LIO::Config cfg = default_config();
   cfg.double_downsample = false;
 
-  Vector3dVector frame;
+  Vector3sVector frame;
   for (int i = 0; i < 20; ++i) {
     for (int j = 0; j < 20; ++j) {
       frame.emplace_back(2.0 + 0.05 * i, 2.0 + 0.05 * j, 1.0);
@@ -85,7 +85,7 @@ TEST_CASE("preprocess_scan: double_downsample = true -> all three populated", "[
   LIO::Config cfg = default_config();
   cfg.double_downsample = true;
 
-  Vector3dVector frame;
+  Vector3sVector frame;
   for (int i = 0; i < 30; ++i) {
     for (int j = 0; j < 30; ++j) {
       frame.emplace_back(2.0 + 0.05 * i, 2.0 + 0.05 * j, 1.0);

--- a/tests/core/test_register_scan.cpp
+++ b/tests/core/test_register_scan.cpp
@@ -30,13 +30,14 @@
 #include <random>
 #include <stdexcept>
 
+using rko_lio::tests::EXACT_TOL;
 using rko_lio::core::GRAVITY_MAG;
 using rko_lio::core::ImuControl;
 using rko_lio::core::LIO;
 using rko_lio::core::Nsec;
 using rko_lio::core::TimestampVector;
 using rko_lio::core::to_seconds;
-using rko_lio::core::Vector3dVector;
+using rko_lio::core::Vector3sVector;
 using rko_lio::tests::approx_equal;
 using rko_lio::tests::make_hollow_cube;
 using Catch::Matchers::WithinAbs;
@@ -70,7 +71,7 @@ TimestampVector instant_timestamps(size_t n, double t) {
 }
 
 void feed_imu(LIO& lio, double t_start, double t_end, int n,
-              const Eigen::Vector3d& acceleration, const Eigen::Vector3d& angular_velocity) {
+              const Eigen::Vector3s& acceleration, const Eigen::Vector3s& angular_velocity) {
   for (int i = 0; i < n; ++i) {
     ImuControl m;
     const double frac = n == 1 ? 0.0 : static_cast<double>(i) / static_cast<double>(n - 1);
@@ -82,13 +83,13 @@ void feed_imu(LIO& lio, double t_start, double t_end, int n,
 }
 
 void feed_static_imu(LIO& lio, double t_start, double t_end, int n) {
-  feed_imu(lio, t_start, t_end, n, {0.0, 0.0, GRAVITY_MAG}, Eigen::Vector3d::Zero());
+  feed_imu(lio, t_start, t_end, n, {0.0, 0.0, GRAVITY_MAG}, Eigen::Vector3s::Zero());
 }
 
 // Same as feed_imu but with per-sample Gaussian noise added to accel and gyro.
 // Seed is fixed at the call site so the test is deterministic.
 void feed_imu_noisy(LIO& lio, double t_start, double t_end, int n,
-                    const Eigen::Vector3d& acceleration, const Eigen::Vector3d& angular_velocity,
+                    const Eigen::Vector3s& acceleration, const Eigen::Vector3s& angular_velocity,
                     double accel_stddev, double gyro_stddev, uint32_t seed) {
   std::mt19937 rng(seed);
   std::normal_distribution<double> a_noise(0.0, accel_stddev);
@@ -97,8 +98,8 @@ void feed_imu_noisy(LIO& lio, double t_start, double t_end, int n,
     ImuControl m;
     const double frac = n == 1 ? 0.0 : static_cast<double>(i) / static_cast<double>(n - 1);
     m.time = ns_from_seconds(t_start + (t_end - t_start) * frac);
-    m.acceleration = acceleration + Eigen::Vector3d{a_noise(rng), a_noise(rng), a_noise(rng)};
-    m.angular_velocity = angular_velocity + Eigen::Vector3d{g_noise(rng), g_noise(rng), g_noise(rng)};
+    m.acceleration = acceleration + Eigen::Vector3s{a_noise(rng), a_noise(rng), a_noise(rng)};
+    m.angular_velocity = angular_velocity + Eigen::Vector3s{g_noise(rng), g_noise(rng), g_noise(rng)};
     lio.add_imu_measurement(m);
   }
 }
@@ -123,7 +124,7 @@ TEST_CASE("First scan: empty map -> populated, single pose at lidar_state.time",
   REQUIRE_FALSE(lio.map.empty());
   REQUIRE(lio.poses_with_timestamps.size() == 1);
   REQUIRE_THAT(to_seconds(lio.lidar_state.time), WithinAbs(FIRST_SCAN_END, 1e-9));
-  REQUIRE(approx_equal(lio.lidar_state.pose, Sophus::SE3d{}, 1e-12));
+  REQUIRE(approx_equal(lio.lidar_state.pose, Sophus::SE3s{}, EXACT_TOL));
   REQUIRE_THAT(to_seconds(lio.poses_with_timestamps[0].first), WithinAbs(FIRST_SCAN_END, 1e-9));
 }
 
@@ -163,12 +164,12 @@ TEST_CASE("Pure translation: recover +1m in x", "[register_scan]") {
 
   // Body accel a such that a * DT^2 / 2 = 1m in x  =>  a = 2 m/s^2. Add gravity for
   // the raw IMU value so compensated body accel comes out to (a, 0, 0).
-  const Eigen::Vector3d t(1.0, 0.0, 0.0);
-  const Eigen::Vector3d a_body = 2.0 * t / (DT * DT);
-  const Eigen::Vector3d imu_accel = a_body + Eigen::Vector3d{0.0, 0.0, GRAVITY_MAG};
-  feed_imu(lio, FIRST_SCAN_END + 0.05, SECOND_SCAN_END - 0.05, 10, imu_accel, Eigen::Vector3d::Zero());
+  const Eigen::Vector3s t(1.0, 0.0, 0.0);
+  const Eigen::Vector3s a_body = 2.0 * t / (DT * DT);
+  const Eigen::Vector3s imu_accel = a_body + Eigen::Vector3s{0.0, 0.0, GRAVITY_MAG};
+  feed_imu(lio, FIRST_SCAN_END + 0.05, SECOND_SCAN_END - 0.05, 10, imu_accel, Eigen::Vector3s::Zero());
 
-  Vector3dVector cloud2;
+  Vector3sVector cloud2;
   cloud2.reserve(cloud.size());
   for (const auto& p : cloud) {
     cloud2.emplace_back(p - t);
@@ -188,7 +189,7 @@ TEST_CASE("Pure rotation: recover 5 deg yaw", "[register_scan]") {
 
   // omega * DT = yaw (5 deg) about z  =>  omega = yaw/DT rad/s.
   const double yaw = 5.0 * M_PI / 180.0;
-  const Eigen::Vector3d omega(0.0, 0.0, yaw / DT);
+  const Eigen::Vector3s omega(0.0, 0.0, yaw / DT);
   feed_imu(lio,
            FIRST_SCAN_END + 0.05,
            SECOND_SCAN_END - 0.05,
@@ -196,9 +197,9 @@ TEST_CASE("Pure rotation: recover 5 deg yaw", "[register_scan]") {
            {0.0, 0.0, GRAVITY_MAG},
            omega);
 
-  const Sophus::SO3d R = Sophus::SO3d::rotZ(yaw);
-  const Sophus::SO3d R_inv = R.inverse();
-  Vector3dVector cloud2;
+  const Sophus::SO3s R = Sophus::SO3s::rotZ(yaw);
+  const Sophus::SO3s R_inv = R.inverse();
+  Vector3sVector cloud2;
   cloud2.reserve(cloud.size());
   for (const auto& p : cloud) {
     cloud2.emplace_back(R_inv * p);
@@ -218,15 +219,15 @@ TEST_CASE("Full SE(3): translation + rotation combined", "[register_scan]") {
 
   // Combined yaw + acceleration
   const double yaw = 3.0 * M_PI / 180.0;
-  const Eigen::Vector3d t(0.5, 0.3, 0.0);
-  const Eigen::Vector3d a_body = 2.0 * t / (DT * DT);
-  const Eigen::Vector3d imu_accel = a_body + Eigen::Vector3d{0.0, 0.0, GRAVITY_MAG};
-  const Eigen::Vector3d omega(0.0, 0.0, yaw / DT);
+  const Eigen::Vector3s t(0.5, 0.3, 0.0);
+  const Eigen::Vector3s a_body = 2.0 * t / (DT * DT);
+  const Eigen::Vector3s imu_accel = a_body + Eigen::Vector3s{0.0, 0.0, GRAVITY_MAG};
+  const Eigen::Vector3s omega(0.0, 0.0, yaw / DT);
   feed_imu(lio, FIRST_SCAN_END + 0.05, SECOND_SCAN_END - 0.05, 10, imu_accel, omega);
 
-  const Sophus::SE3d T_expected(Sophus::SO3d::rotZ(yaw), t);
-  const Sophus::SE3d T_inv = T_expected.inverse();
-  Vector3dVector cloud2;
+  const Sophus::SE3s T_expected(Sophus::SO3s::rotZ(yaw), t);
+  const Sophus::SE3s T_inv = T_expected.inverse();
+  Vector3sVector cloud2;
   cloud2.reserve(cloud.size());
   for (const auto& p : cloud) {
     cloud2.emplace_back(T_inv * p);
@@ -248,13 +249,13 @@ TEST_CASE("Noisy: pure translation +1m in x", "[register_scan][!mayfail]") {
 
   lio.register_scan(cloud, linspace_timestamps(cloud.size(), 0.0, FIRST_SCAN_END));
 
-  const Eigen::Vector3d t(1.0, 0.0, 0.0);
-  const Eigen::Vector3d a_body = 2.0 * t / (DT * DT);
-  const Eigen::Vector3d imu_accel = a_body + Eigen::Vector3d{0.0, 0.0, GRAVITY_MAG};
+  const Eigen::Vector3s t(1.0, 0.0, 0.0);
+  const Eigen::Vector3s a_body = 2.0 * t / (DT * DT);
+  const Eigen::Vector3s imu_accel = a_body + Eigen::Vector3s{0.0, 0.0, GRAVITY_MAG};
   feed_imu_noisy(lio, FIRST_SCAN_END + 0.05, SECOND_SCAN_END - 0.05, 10, imu_accel,
-                 Eigen::Vector3d::Zero(), NOISY_ACCEL_STDDEV, NOISY_GYRO_STDDEV, /*seed=*/1u);
+                 Eigen::Vector3s::Zero(), NOISY_ACCEL_STDDEV, NOISY_GYRO_STDDEV, /*seed=*/1u);
 
-  Vector3dVector cloud2;
+  Vector3sVector cloud2;
   cloud2.reserve(cloud.size());
   for (const auto& p : cloud) {
     cloud2.emplace_back(p - t);
@@ -274,14 +275,14 @@ TEST_CASE("Noisy: pure rotation 5 deg yaw", "[register_scan][!mayfail]") {
   lio.register_scan(cloud, linspace_timestamps(cloud.size(), 0.0, FIRST_SCAN_END));
 
   const double yaw = 5.0 * M_PI / 180.0;
-  const Eigen::Vector3d omega(0.0, 0.0, yaw / DT);
+  const Eigen::Vector3s omega(0.0, 0.0, yaw / DT);
   feed_imu_noisy(lio, FIRST_SCAN_END + 0.05, SECOND_SCAN_END - 0.05, 10,
                  {0.0, 0.0, GRAVITY_MAG}, omega, NOISY_ACCEL_STDDEV, NOISY_GYRO_STDDEV,
                  /*seed=*/2u);
 
-  const Sophus::SO3d R = Sophus::SO3d::rotZ(yaw);
-  const Sophus::SO3d R_inv = R.inverse();
-  Vector3dVector cloud2;
+  const Sophus::SO3s R = Sophus::SO3s::rotZ(yaw);
+  const Sophus::SO3s R_inv = R.inverse();
+  Vector3sVector cloud2;
   cloud2.reserve(cloud.size());
   for (const auto& p : cloud) {
     cloud2.emplace_back(R_inv * p);
@@ -301,16 +302,16 @@ TEST_CASE("Noisy: full SE(3) translation + rotation", "[register_scan][!mayfail]
   lio.register_scan(cloud, linspace_timestamps(cloud.size(), 0.0, FIRST_SCAN_END));
 
   const double yaw = 3.0 * M_PI / 180.0;
-  const Eigen::Vector3d t(0.5, 0.3, 0.0);
-  const Eigen::Vector3d a_body = 2.0 * t / (DT * DT);
-  const Eigen::Vector3d imu_accel = a_body + Eigen::Vector3d{0.0, 0.0, GRAVITY_MAG};
-  const Eigen::Vector3d omega(0.0, 0.0, yaw / DT);
+  const Eigen::Vector3s t(0.5, 0.3, 0.0);
+  const Eigen::Vector3s a_body = 2.0 * t / (DT * DT);
+  const Eigen::Vector3s imu_accel = a_body + Eigen::Vector3s{0.0, 0.0, GRAVITY_MAG};
+  const Eigen::Vector3s omega(0.0, 0.0, yaw / DT);
   feed_imu_noisy(lio, FIRST_SCAN_END + 0.05, SECOND_SCAN_END - 0.05, 10, imu_accel, omega,
                  NOISY_ACCEL_STDDEV, NOISY_GYRO_STDDEV, /*seed=*/3u);
 
-  const Sophus::SE3d T_expected(Sophus::SO3d::rotZ(yaw), t);
-  const Sophus::SE3d T_inv = T_expected.inverse();
-  Vector3dVector cloud2;
+  const Sophus::SE3s T_expected(Sophus::SO3s::rotZ(yaw), t);
+  const Sophus::SE3s T_inv = T_expected.inverse();
+  Vector3sVector cloud2;
   cloud2.reserve(cloud.size());
   for (const auto& p : cloud) {
     cloud2.emplace_back(T_inv * p);

--- a/tests/core/test_register_scan.cpp
+++ b/tests/core/test_register_scan.cpp
@@ -98,8 +98,8 @@ void feed_imu_noisy(LIO& lio, double t_start, double t_end, int n,
     ImuControl m;
     const double frac = n == 1 ? 0.0 : static_cast<double>(i) / static_cast<double>(n - 1);
     m.time = ns_from_seconds(t_start + (t_end - t_start) * frac);
-    m.acceleration = acceleration + Eigen::Vector3s{a_noise(rng), a_noise(rng), a_noise(rng)};
-    m.angular_velocity = angular_velocity + Eigen::Vector3s{g_noise(rng), g_noise(rng), g_noise(rng)};
+    m.acceleration = acceleration + Eigen::Vector3s(a_noise(rng), a_noise(rng), a_noise(rng));
+    m.angular_velocity = angular_velocity + Eigen::Vector3s(g_noise(rng), g_noise(rng), g_noise(rng));
     lio.add_imu_measurement(m);
   }
 }

--- a/tests/core/test_voxel_down_sample.cpp
+++ b/tests/core/test_voxel_down_sample.cpp
@@ -30,7 +30,7 @@
 using rko_lio::core::voxel_down_sample;
 
 namespace {
-std::set<std::tuple<int, int, int>> as_voxel_set(const std::vector<Eigen::Vector3d>& points, double voxel_size) {
+std::set<std::tuple<int, int, int>> as_voxel_set(const std::vector<Eigen::Vector3s>& points, double voxel_size) {
   std::set<std::tuple<int, int, int>> out;
   for (const auto& p : points) {
     out.emplace(static_cast<int>(std::floor(p.x() / voxel_size)),
@@ -42,14 +42,14 @@ std::set<std::tuple<int, int, int>> as_voxel_set(const std::vector<Eigen::Vector
 } // namespace
 
 TEST_CASE("voxel_down_sample: empty input -> empty output", "[voxel_down_sample]") {
-  const std::vector<Eigen::Vector3d> empty;
+  const std::vector<Eigen::Vector3s> empty;
   const auto result = voxel_down_sample(empty, 0.5);
   REQUIRE(result.empty());
 }
 
 TEST_CASE("voxel_down_sample: all points within one voxel -> 1 output", "[voxel_down_sample]") {
   const double voxel_size = 1.0;
-  const std::vector<Eigen::Vector3d> points = {
+  const std::vector<Eigen::Vector3s> points = {
       {0.1, 0.1, 0.1}, {0.2, 0.3, 0.4}, {0.5, 0.5, 0.5}, {0.99, 0.99, 0.99}};
   const auto result = voxel_down_sample(points, voxel_size);
   REQUIRE(result.size() == 1);
@@ -57,7 +57,7 @@ TEST_CASE("voxel_down_sample: all points within one voxel -> 1 output", "[voxel_
 
 TEST_CASE("voxel_down_sample: N well-separated points -> N outputs", "[voxel_down_sample]") {
   const double voxel_size = 0.5;
-  const std::vector<Eigen::Vector3d> points = {
+  const std::vector<Eigen::Vector3s> points = {
       {0.0, 0.0, 0.0}, {10.0, 0.0, 0.0}, {0.0, 10.0, 0.0}, {0.0, 0.0, 10.0}, {10.0, 10.0, 10.0}};
   const auto result = voxel_down_sample(points, voxel_size);
   REQUIRE(result.size() == points.size());
@@ -65,8 +65,8 @@ TEST_CASE("voxel_down_sample: N well-separated points -> N outputs", "[voxel_dow
 
 TEST_CASE("voxel_down_sample: order independence", "[voxel_down_sample]") {
   const double voxel_size = 0.5;
-  std::vector<Eigen::Vector3d> a = {{0.1, 0.1, 0.1}, {3.2, 1.1, 0.7}, {7.5, 4.5, 2.3}, {0.4, 0.4, 0.4}};
-  std::vector<Eigen::Vector3d> b = a;
+  std::vector<Eigen::Vector3s> a = {{0.1, 0.1, 0.1}, {3.2, 1.1, 0.7}, {7.5, 4.5, 2.3}, {0.4, 0.4, 0.4}};
+  std::vector<Eigen::Vector3s> b = a;
   std::reverse(b.begin(), b.end());
 
   const auto ra = voxel_down_sample(a, voxel_size);
@@ -78,7 +78,7 @@ TEST_CASE("voxel_down_sample: order independence", "[voxel_down_sample]") {
 }
 
 TEST_CASE("voxel_down_sample: doubling voxel size collapses points", "[voxel_down_sample]") {
-  const std::vector<Eigen::Vector3d> points = {{0.1, 0.1, 0.1}, {0.7, 0.1, 0.1}};
+  const std::vector<Eigen::Vector3s> points = {{0.1, 0.1, 0.1}, {0.7, 0.1, 0.1}};
   const auto small = voxel_down_sample(points, 0.5);
   const auto large = voxel_down_sample(points, 1.0);
   REQUIRE(small.size() == 2);

--- a/tests/python/test_scalar_conversion.py
+++ b/tests/python/test_scalar_conversion.py
@@ -1,0 +1,96 @@
+"""Numpy <-> C++ conversion behaviour for the point vector binding.
+
+The copy semantics are a performance contract: reading a vector back into numpy must stay a
+view, and handing numpy in must leave the C++ side independent of the caller's buffer.
+"""
+
+import numpy as np
+import pytest
+
+from rko_lio import rko_lio_pybind as pybind
+
+INPUT_DTYPES = [np.float32, np.float64]
+
+
+def binding_dtype():
+    """The scalar this package was built with, as numpy sees it."""
+    return np.asarray(pybind._Vector3sVector(np.zeros((1, 3)))).dtype
+
+
+def make_points(dtype, n=8):
+    return (np.arange(n * 3, dtype=np.float64).reshape(n, 3) + 0.5).astype(dtype)
+
+
+def test_binding_scalar_is_a_float_type():
+    assert binding_dtype() in (np.dtype(np.float32), np.dtype(np.float64))
+
+
+@pytest.mark.parametrize("dtype", INPUT_DTYPES)
+def test_accepts_input_and_exposes_the_build_scalar(dtype):
+    points = make_points(dtype)
+    vector = pybind._Vector3sVector(points)
+
+    assert len(vector) == len(points)
+    assert np.asarray(vector).dtype == binding_dtype()
+    np.testing.assert_allclose(np.asarray(vector), points.astype(binding_dtype()))
+
+
+@pytest.mark.parametrize("dtype", INPUT_DTYPES)
+def test_conversion_is_exact_when_no_narrowing_is_required(dtype):
+    """Widening or an already matching dtype must be bit exact."""
+    points = make_points(dtype)
+    result = np.asarray(pybind._Vector3sVector(points))
+
+    if np.can_cast(dtype, binding_dtype()):
+        np.testing.assert_array_equal(result, points.astype(binding_dtype()))
+    else:
+        np.testing.assert_allclose(result, points, rtol=1e-6)
+
+
+@pytest.mark.parametrize("dtype", INPUT_DTYPES)
+def test_reading_back_is_a_view_not_a_copy(dtype):
+    """C++ -> python must stay zero copy via the buffer protocol."""
+    vector = pybind._Vector3sVector(make_points(dtype))
+    view = np.asarray(vector)
+
+    assert view.base is not None, "numpy copied instead of viewing the C++ storage"
+    view[0, 0] = 123.0
+    assert np.asarray(vector)[0, 0] == 123.0, "write through the view did not reach C++"
+
+
+@pytest.mark.parametrize("dtype", INPUT_DTYPES)
+def test_construction_copies_so_the_vector_owns_its_points(dtype):
+    """python -> C++ takes a copy; a std::vector cannot alias the numpy buffer."""
+    points = make_points(dtype)
+    vector = pybind._Vector3sVector(points)
+
+    points[0, 0] = -999.0
+    assert np.asarray(vector)[0, 0] != -999.0, "vector aliased the caller's numpy buffer"
+
+
+@pytest.mark.parametrize("dtype", INPUT_DTYPES)
+def test_non_contiguous_input_is_handled(dtype):
+    """Every other row of a bigger array is not c-contiguous; forcecast must fix it up."""
+    points = make_points(dtype, n=16)[::2]
+
+    assert not points.flags["C_CONTIGUOUS"]
+    np.testing.assert_allclose(np.asarray(pybind._Vector3sVector(points)), points)
+
+
+@pytest.mark.parametrize("dtype", INPUT_DTYPES)
+def test_read_only_input_is_accepted(dtype):
+    points = make_points(dtype)
+    points.flags.writeable = False
+
+    np.testing.assert_allclose(np.asarray(pybind._Vector3sVector(points)), points)
+
+
+@pytest.mark.parametrize("dtype", INPUT_DTYPES)
+def test_empty_input(dtype):
+    assert len(pybind._Vector3sVector(np.zeros((0, 3), dtype=dtype))) == 0
+
+
+@pytest.mark.parametrize("shape", [(4,), (4, 2), (4, 4), (2, 3, 3)])
+def test_wrong_shape_is_rejected(shape):
+    with pytest.raises(Exception):
+        pybind._Vector3sVector(np.zeros(shape, dtype=np.float64))


### PR DESCRIPTION
An absolutely massive PR that basically allows the floating point scalar used for the math throughout the project to be either double or float.
Earlier we just used double everywhere. Which is fine as thats the most precision we can get. But when performance is the target, float's are enough to get by. At least that's what this PR will test (i'll do some regression testing on my usual set of trajectories for trajectory accuracy). 
Basically, one cmake flag, `RKO_LIO_SCALAR` controls the choice of float or double. The project default will be float henceforth (assuming the accuracy trade off is worth it, tbd). Python bindings default will still be `double` to maintain benchmarking accuracy which is what that is meant to be used for. Although it's possible to switch that to float too if someone needs a speedup, it's opt-in. Accuracy in the ROS side is opt-in by contrast.

That's basically the story of this massive LoC PR. core gets an alias Scalar, constrained to `std::floating_point` and then every relevant single instance of `double` or `d` is replaced with `Scalar` or `s`. Time remains long int nanoseconds, converted to double only where needed, never to float.

there's some pybind specific changes for the numpy buffer to c++ scalar vector handling (py_array_to_vectors is now templated on EigenVector::Scalar instead of being fixed at array_t<double>). its another in the line of improving copy behaviour. Further python specific performance improvements may land later, for now all i care about is no performance regressions on the python side. 

the scalar type is configured through cmake config files, to better handle package installations and downstream use (i.e. no unexpected floating point config breaks).

Testing also gets some changes to handle this, with float builds using looser tolerances than double builds. 

CI tests both scalar configs. 

With a switch to float instead of double, we're roughly 10% faster with 30% less memory usage, single thread OS0 at current default config.

The double branch outputs have been verified to be byte-identical after these changes. obviously the float branch is different. and I'll be running the regression tests to verify no significant accuracy loss, which is what this entire pr is hinged upon.
