### PR TITLE
core: better icp convergence criterion, function tolerance

### DIFF
--- a/docs/pages/config.rst
+++ b/docs/pages/config.rst
@@ -82,7 +82,8 @@ These show up under the top level of a Python config and as ROS launch arguments
 
 - **convergence_criterion** (`float`, default ``1e-5``)
 
-  Termination criterion for optimization.
+  Termination criterion for optimization. ICP stops once the cost changes by less than this
+  fraction of itself between two iterations.
   Lower (stricter) values will requires more ICP iterations.
 
 - **max_num_threads** (`int`, default ``0``)

--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -174,7 +174,7 @@ LinearSystem build_icp_linear_system(const Sophus::SE3s& current_pose,
     throw std::runtime_error("Number of correspondences are 0.");
   }
 
-  return {H_icp / correspondences_counter, b_icp / correspondences_counter, 0.5 * chi_icp};
+  return {H_icp / correspondences_counter, b_icp / correspondences_counter, 0.5 * chi_icp / correspondences_counter};
 }
 
 LinearSystem build_orientation_linear_system(const Sophus::SE3s& current_pose,
@@ -201,6 +201,7 @@ Sophus::SE3s icp(const Vector3sVector& frame,
                           : -1;
 
   Sophus::SE3s current_pose = initial_guess;
+  Scalar previous_chi = -1;
 
   for (size_t i = 0; i < config.max_iterations; ++i) {
     const auto& [H, b, chi] = std::invoke([&]() -> LinearSystem {
@@ -209,7 +210,9 @@ Sophus::SE3s icp(const Vector3sVector& frame,
       if (beta >= 0) {
         const auto& [H_ori, b_ori, chi_ori] =
             build_orientation_linear_system(current_pose, optional_accel_info->local_gravity_estimate);
-        return {H_icp + H_ori / beta, b_icp + b_ori / beta, chi_icp + chi_ori / beta};
+        // only chi_icp is used for convergence checks. chi_ori is typically small, fine to ignore, and problematically
+        // noisy near convergence
+        return {H_icp + H_ori / beta, b_icp + b_ori / beta, chi_icp};
       }
       return {H_icp, b_icp, chi_icp};
     });
@@ -217,7 +220,11 @@ Sophus::SE3s icp(const Vector3sVector& frame,
     const Eigen::Vector6s dx = H.ldlt().solve(-b);
     current_pose = Sophus::SE3s::exp(dx) * current_pose;
 
-    if (dx.norm() < config.convergence_criterion || i == (config.max_iterations - 1)) {
+    // Ceres function_tolerance style convergence check
+    const Scalar cost_change = std::abs(previous_chi - chi);
+    const bool converged = previous_chi > 0 && cost_change <= config.convergence_criterion * previous_chi;
+    previous_chi = chi;
+    if (converged || i == (config.max_iterations - 1)) {
       // TODO: proper debug logging
       // std::cout << "iter " << i << ", beta: " << beta << ", chi: " << chi << ", num_assoc: " <<
       // correspondences.size() << "\n";
@@ -503,9 +510,8 @@ Vector3sVector LIO::register_scan(Vector3sVector scan, const TimestampVector& ti
   return std::move(preproc_result.filtered_frame);
 }
 
-Vector3sVector LIO::register_scan(const Sophus::SE3s& extrinsic_lidar2base,
-                                  Vector3sVector scan,
-                                  const TimestampVector& timestamps) {
+Vector3sVector
+LIO::register_scan(const Sophus::SE3s& extrinsic_lidar2base, Vector3sVector scan, const TimestampVector& timestamps) {
   if (extrinsic_lidar2base.log().norm() < EPSILON) {
     return register_scan(std::move(scan), timestamps);
   }

--- a/rko_lio/python/rko_lio/config.py
+++ b/rko_lio/python/rko_lio/config.py
@@ -116,7 +116,7 @@ class LIOConfig:
     min_range : float, default 1.0
         Minimum usable range of lidar (meters).
     convergence_criterion : float, default 1e-5
-        Convergence threshold for optimization.
+        Convergence threshold for optimization, on the relative change in cost per iteration.
     max_correspondence_distance : float, default 0.5
         Max distance for associating points (meters).
     max_num_threads : int, default 0


### PR DESCRIPTION
continuing the perf series from #157. this one goes after the iteration count rather than the cost per iteration.

the convergence check was earlier ||dx|| < convergence_criterion, a norm over a 6 vector mixing radians and metres. scale dependent. in practice this should end up running iterations well past the point where the pose has stopped moving in any way that matters.

replaced with a terminate when the cost changes by less than some fraction of itself (ceres function_tolerance style). dimensionless, so the same 1e-5 default carries over and no config changes are needed anywhere.

two supporting changes that sidecar'd. first, chi was returned unnormalised while H and b were divided by the correspondence count, so the thing we terminated on before wasn't the cost we were minimising. the correspondence count also grows as alignment improves, so an unnormalised sum can rise while the fit gets better. now normalised like the rest. second, the gravity term is excluded from the convergence check. it's only ~2% of the cost but it's noisy, and near convergence the icp term's improvement gets small while the gravity noise doesn't. excluding it showed better behavior on some limited sequences i was using for testing.

numbers on the os0 bag from #157, single thread, default config: iterations go 19.05 to 12.95, m + 2 sigma drops about 22%. accuracy on leg_kilo corridor against ground truth is 229.68mm -> 230.37mm ATE rmse, so basically unchanged.

things that didn't work while i was trying to figure out better convergence behaviour, as it might be interesting for someone reading this. armijo backtracking line search costs 3.7x the correspondence searches and didn't really help either on time or accuracy. ceres' gradient_tolerance never fires in either absolute or relative form, so i didn't add a second criterion and config to keep things simple.

the parameter keeps its name and default, but the semantics changed, so anyone who set convergence_criterion explicitly gets different behaviour.

regression testing on my usual set of trajectories pending (actually now expanded with more than before), this pr hinges on that as usual.