### PR TITLE
core: quantise the voxel map to int8 offsets with fixed-size inline blocks

### DIFF
--- a/config/ros_default.yaml
+++ b/config/ros_default.yaml
@@ -24,7 +24,6 @@ odom_at_imu_rate: false
 # lio config
 deskew: true
 voxel_size: 1.0
-max_points_per_voxel: 20
 max_range: 100.0
 min_range: 1.0
 max_correspondence_distance: 0.5

--- a/docs/pages/config.rst
+++ b/docs/pages/config.rst
@@ -60,10 +60,6 @@ These show up under the top level of a Python config and as ROS launch arguments
   Points closer than this are discarded.
   Useful if your platform shows up in the scan due to occlusions.
 
-- **max_points_per_voxel** (`int`, default ``20``)
-
-  Maximum number of points stored per voxel in the VDB map.
-
   Affects both memory and ICP data association.
 
   In case you need more runtime performance, you can reduce this.
@@ -91,7 +87,7 @@ These show up under the top level of a Python config and as ROS launch arguments
   Only used to parallelize data association for ICP.
   ``0`` means autodetect based on hardware.
 
-  In case compute resources are a constraint, limit this to a few threads and, in order, ``max_points_per_voxel``, ``voxel_size``, ``max_range``, ``max_iterations`` are the parameters you probably care about.
+  In case compute resources are a constraint, limit this to a few threads and, in order, ``voxel_size``, ``max_range``, ``max_iterations`` are the parameters you probably care about.
 
 - **initialization_phase** (`bool`, default ``False``)
 

--- a/launch/odometry.launch.py
+++ b/launch/odometry.launch.py
@@ -146,12 +146,6 @@ configurable_parameters = [
         "description": "Voxel size for the local map (meters) used for odometry",
     },
     {
-        "name": "max_points_per_voxel",
-        "default": "20",
-        "type": "int",
-        "description": "Max points per voxel",
-    },
-    {
         "name": "max_range",
         "default": "100.0",
         "type": "float",

--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -152,7 +152,7 @@ LinearSystem build_icp_linear_system(const Sophus::SE3s& current_pose,
           if (!closest_neighbor.has_value()) {
             continue;
           }
-          const Eigen::Vector3s residual = rotation_transpose * (transformed_point - **closest_neighbor);
+          const Eigen::Vector3s residual = rotation_transpose * (transformed_point - *closest_neighbor);
           const auto& [point_H, point_b, point_chi, point_n] = linear_system_for_one_point(point, residual);
           H += point_H;
           b += point_b;
@@ -252,7 +252,7 @@ namespace rko_lio::core {
 
 LIO::LIO(const Config& config_)
     : config(config_),
-      map(config_.voxel_size, config_.max_range, config_.max_points_per_voxel),
+      map(config_.voxel_size, config_.max_range),
       arena(config_.max_num_threads > 0 ? config_.max_num_threads : tbb::task_arena::automatic) {}
 
 // ==========================

--- a/rko_lio/core/lio.hpp
+++ b/rko_lio/core/lio.hpp
@@ -50,7 +50,6 @@ public:
     Scalar voxel_size = 1.0;
 
     /** Max points per voxel. */
-    int max_points_per_voxel = 20;
 
     /** Maximum lidar range (m). */
     Scalar max_range = 100.0;

--- a/rko_lio/core/util.hpp
+++ b/rko_lio/core/util.hpp
@@ -38,6 +38,7 @@ using Matrix3_6s = Matrix<rko_lio::core::Scalar, 3, 6>;
 using Vector6s = Matrix<rko_lio::core::Scalar, 6, 1>;
 using Matrix6s = Matrix<rko_lio::core::Scalar, 6, 6>;
 using Quaternions = Quaternion<rko_lio::core::Scalar>;
+using Vector3i8 = Vector3<std::int8_t>;
 } // namespace Eigen
 
 namespace Sophus {

--- a/rko_lio/core/voxel_hash_map.cpp
+++ b/rko_lio/core/voxel_hash_map.cpp
@@ -21,11 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-// NOTE: This implementation is heavily inspired in the original CT-ICP VoxelHashMap implementation,
-// although it was heavily modified and drastically simplified, but if you are using this module you
-// should at least acknoowledge the work from CT-ICP by giving a star on GitHub.
-//
-// Modified from kiss-icp (kiss_icp/cpp/kiss_icp/core/VoxelHashMap.{hpp,cpp}).
+// Modified heavily from kiss-icp (kiss_icp/cpp/kiss_icp/core/VoxelHashMap.{hpp,cpp}).
 
 #include "voxel_hash_map.hpp"
 
@@ -34,11 +30,15 @@
 #include <array>
 #include <cmath>
 #include <limits>
+#include <numbers>
 #include <sophus/se3.hpp>
+#include <stdexcept>
+#include <string>
 #include <tuple>
 #include <vector>
 
 namespace {
+using rko_lio::core::Scalar;
 using rko_lio::core::Voxel;
 
 // the order of the shifts is deliberate
@@ -55,83 +55,153 @@ const std::array<Voxel, 27> shifts{
     Voxel{-1, -1, -1}, Voxel{-1, -1, 1}, Voxel{-1, 1, -1}, // corners
     Voxel{-1, 1, 1},   Voxel{1, -1, -1}, Voxel{1, -1, 1},  Voxel{1, 1, -1}, Voxel{1, 1, 1}};
 
+// Fixed point layout. A voxel is cut into QUANTA_PER_VOXEL steps per axis and a point is stored as its offset
+// from the centre in those steps, spanning [-127, 127], i.e. int8_t. One step is voxel_size / QUANTA_PER_VOXEL m.
+constexpr Scalar MAX_OFFSET = std::numeric_limits<std::int8_t>::max();
+constexpr Scalar QUANTA_PER_VOXEL = 2 * MAX_OFFSET;
+// past this a quantum is coarser than ~2 cm, which is the order of lidar range noise
+constexpr Scalar MAX_VOXEL_SIZE = 5.0;
+
+/// metres -> quanta
+inline Eigen::Vector3s to_quanta(const Eigen::Vector3s& metres, const Scalar inv_quantum) {
+  return metres * inv_quantum;
+}
+
+/// corner of `voxel`, in metres
+inline Eigen::Vector3s voxel_corner(const Voxel& voxel, const Scalar voxel_size) {
+  return voxel.cast<Scalar>() * voxel_size;
+}
+
+/// centre of `voxel`, in metres
+inline Eigen::Vector3s voxel_centre(const Voxel& voxel, const Scalar voxel_size) {
+  return (voxel.cast<Scalar>() + Eigen::Vector3s::Constant(Scalar(0.5))) * voxel_size;
+}
+
+/// `point` from the voxel corner, in quanta. Runs 0 to QUANTA_PER_VOXEL
+inline Eigen::Vector3s quanta_from_corner(const Eigen::Vector3s& point,
+                                          const Voxel& voxel,
+                                          const Scalar voxel_size,
+                                          const Scalar inv_quantum) {
+  return to_quanta(point - voxel_corner(voxel, voxel_size), inv_quantum);
+}
+
+/// `point` from the voxel centre, in quanta. Stored offsets live in this frame
+inline Eigen::Vector3s quanta_from_centre(const Eigen::Vector3s& point,
+                                          const Voxel& voxel,
+                                          const Scalar voxel_size,
+                                          const Scalar inv_quantum) {
+  return to_quanta(point - voxel_centre(voxel, voxel_size), inv_quantum);
+}
+
+/// re-origin quanta from the corner to the centre. Half a voxel is MAX_OFFSET quanta
+inline Eigen::Vector3s corner_to_centre(const Eigen::Vector3s& quanta) {
+  return quanta - Eigen::Vector3s::Constant(MAX_OFFSET);
+}
+
+/// against the centre of the voxel one `shift` away. A shift is a whole voxel, so QUANTA_PER_VOXEL per axis
+inline Eigen::Vector3s quanta_from_neighbour_centre(const Eigen::Vector3s& quanta, const Voxel& shift) {
+  return quanta - (shift.cast<Scalar>() * QUANTA_PER_VOXEL);
+}
+
+/// squared distance from the query to the near face of a neighbouring voxel, per axis.
+/// Columns are indexed by voxel shift + 1, rows are axes.
+inline Eigen::Matrix3s face_bounds(const Eigen::Vector3s& from_corner) {
+  const Eigen::Vector3s from_high = Eigen::Vector3s::Constant(QUANTA_PER_VOXEL) - from_corner;
+  Eigen::Matrix3s bounds;
+  bounds.col(0) = from_corner.array().square();
+  bounds.col(1).setZero();
+  bounds.col(2) = from_high.array().square();
+  return bounds;
+}
+
+/// round Scalar into int8 for storage. clamp prevents wrapping on type casts
+inline Eigen::Vector3i8 to_stored_offset(const Eigen::Vector3s& quanta) {
+  return quanta.array().round().min(MAX_OFFSET).max(-MAX_OFFSET).matrix().cast<std::int8_t>();
+}
 } // namespace
 
 namespace rko_lio::core {
 
-VoxelHashMap::VoxelHashMap(const Scalar voxel_size,
-                           const Scalar clipping_distance,
-                           const unsigned int max_points_per_voxel)
+VoxelHashMap::VoxelHashMap(const Scalar voxel_size, const Scalar clipping_distance)
     : voxel_size_(voxel_size),
       inv_voxel_size_(static_cast<Scalar>(1.0 / voxel_size)),
-      clipping_distance_(clipping_distance),
-      max_points_per_voxel_(max_points_per_voxel) {}
+      quantum_(voxel_size / QUANTA_PER_VOXEL),
+      inv_quantum_(QUANTA_PER_VOXEL / voxel_size),
+      clipping_distance_(clipping_distance) {
+  if (voxel_size <= 0 || voxel_size > MAX_VOXEL_SIZE) {
+    throw std::invalid_argument("voxel_size must be in (0, " + std::to_string(MAX_VOXEL_SIZE) + "] metres");
+  }
+}
 
-std::optional<VoxelBlock::const_iterator> VoxelHashMap::get_closest_neighbor(const Eigen::Vector3s& query,
-                                                                             const Scalar max_distance) const {
-  Scalar closest_distance_sq = max_distance * max_distance;
-  std::optional<VoxelBlock::const_iterator> closest;
+std::optional<Eigen::Vector3s> VoxelHashMap::get_closest_neighbor(const Eigen::Vector3s& query,
+                                                                  const Scalar max_distance) const {
   const Voxel voxel = point_to_voxel(query, inv_voxel_size_);
+  const Eigen::Vector3s query_quanta_from_corner = quanta_from_corner(query, voxel, voxel_size_, inv_quantum_);
+  const Eigen::Vector3s query_quanta_from_centre = corner_to_centre(query_quanta_from_corner);
+  const Eigen::Matrix3s lower_bounds = face_bounds(query_quanta_from_corner);
 
-  // lower_bounds is squared distance from the query to the near face of a neighbouring voxel, per axis.
-  // Columns are indexed by voxel shift + 1, rows are axes
-  const Eigen::Vector3s offset = query - voxel.cast<Scalar>() * voxel_size_;
-  const Eigen::Vector3s to_far = Eigen::Vector3s::Constant(voxel_size_) - offset;
-  Eigen::Matrix3s lower_bounds;
-  lower_bounds.col(0) = offset.array().square();
-  lower_bounds.col(1).setZero();
-  lower_bounds.col(2) = to_far.array().square();
+  Scalar closest_distance_sq = square(max_distance * inv_quantum_);
+  const Eigen::Vector3i8* closest_offset = nullptr;
+  const Voxel* closest_shift = shifts.begin();
 
-  for (const Voxel& shift : shifts) {
+  for (const Voxel* shift = shifts.begin(); shift != shifts.end(); ++shift) {
     // lower bound on the distance to query within this voxel + shift
     const Scalar lower_bound_sq =
-        lower_bounds(0, shift.x() + 1) + lower_bounds(1, shift.y() + 1) + lower_bounds(2, shift.z() + 1);
+        lower_bounds(0, shift->x() + 1) + lower_bounds(1, shift->y() + 1) + lower_bounds(2, shift->z() + 1);
     if (lower_bound_sq >= closest_distance_sq) {
       continue;
     }
-    const auto search = map_.find(voxel + shift);
+    const auto search = map_.find(voxel + *shift);
     if (search == map_.end()) {
       continue;
     }
-    // returning an iterator rather than a copy reduces branching (with the usual compiler caveats)
-    const VoxelBlock& voxel_points = search.value();
-    for (auto neighbor = voxel_points.cbegin(); neighbor != voxel_points.cend(); ++neighbor) {
-      const Scalar distance_sq = (*neighbor - query).squaredNorm();
+    const Eigen::Vector3s query_quanta_from_neighbour = quanta_from_neighbour_centre(query_quanta_from_centre, *shift);
+    const VoxelBlock& block = search.value();
+    for (const Eigen::Vector3i8* neighbor = block.begin(); neighbor != block.end(); ++neighbor) {
+      const Scalar distance_sq = (neighbor->cast<Scalar>() - query_quanta_from_neighbour).squaredNorm();
       if (distance_sq < closest_distance_sq) {
         closest_distance_sq = distance_sq;
-        closest = neighbor;
+        closest_offset = neighbor;
+        closest_shift = shift;
       }
     }
   }
-  return closest;
+
+  if (closest_offset == nullptr) {
+    return std::nullopt;
+  }
+  const Eigen::Vector3s query_quanta_from_neighbour =
+      quanta_from_neighbour_centre(query_quanta_from_centre, *closest_shift);
+  return query + (closest_offset->cast<Scalar>() - query_quanta_from_neighbour) * quantum_;
 }
 
 void VoxelHashMap::add_points(const std::vector<Eigen::Vector3s>& points, const Sophus::SE3s& pose) {
-  const Scalar map_resolution_sq = voxel_size_ * voxel_size_ / static_cast<Scalar>(max_points_per_voxel_);
+  // same radius as voxel_size^2 / max_points, but in quanta
+  const Scalar map_resolution_sq = square(QUANTA_PER_VOXEL) / static_cast<Scalar>(VoxelBlock::max_points);
   std::for_each(points.cbegin(), points.cend(), [&](const Eigen::Vector3s& point) {
     const Eigen::Vector3s p = pose * point;
     const Voxel voxel = point_to_voxel(p, inv_voxel_size_);
+    // quantise before the spacing test, so the test sees the offset that would actually be stored
+    const Eigen::Vector3i8 offset = to_stored_offset(quanta_from_centre(p, voxel, voxel_size_, inv_quantum_));
     auto it = map_.try_emplace(voxel).first;
     VoxelBlock& voxel_points = it.value();
-    if (voxel_points.size() == max_points_per_voxel_ ||
-        std::any_of(voxel_points.cbegin(), voxel_points.cend(),
-                    [&](const auto& voxel_point) { return (voxel_point - p).squaredNorm() < map_resolution_sq; })) {
+    if (voxel_points.full() ||
+        std::any_of(voxel_points.begin(), voxel_points.end(), [&](const Eigen::Vector3i8& voxel_point) {
+          return (voxel_point.cast<Scalar>() - offset.cast<Scalar>()).squaredNorm() < map_resolution_sq;
+        })) {
       return;
     }
-    voxel_points.reserve(max_points_per_voxel_);
-    voxel_points.emplace_back(p);
+    voxel_points.push_back(offset);
   });
 }
 
 void VoxelHashMap::remove_points_far_from_location(const Eigen::Vector3s& origin) {
-  const Scalar clipping_distance_sq = clipping_distance_ * clipping_distance_;
+  // a centre is within half a diagonal of every point it holds, so widening by that keeps a superset
+  const Scalar half_diagonal = Scalar(0.5) * std::numbers::sqrt3_v<Scalar> * voxel_size_;
+  const Scalar max_distance_sq = square(clipping_distance_ + half_diagonal);
   for (auto it = map_.begin(); it != map_.end();) {
-    const VoxelBlock& voxel_points = it->second;
-    if ((voxel_points.front() - origin).squaredNorm() > clipping_distance_sq) {
-      it = map_.erase(it);
-    } else {
-      ++it;
-    }
+    it = (voxel_centre(it->first, voxel_size_) - origin).squaredNorm() > max_distance_sq ? map_.erase(it)
+                                                                                         : std::next(it);
   }
 }
 
@@ -142,9 +212,12 @@ void VoxelHashMap::update(const std::vector<Eigen::Vector3s>& points, const Soph
 
 std::vector<Eigen::Vector3s> VoxelHashMap::pointcloud() const {
   std::vector<Eigen::Vector3s> point_cloud;
-  point_cloud.reserve(map_.size() * max_points_per_voxel_);
-  for (const auto& [_, block] : map_) {
-    point_cloud.insert(point_cloud.end(), block.cbegin(), block.cend());
+  point_cloud.reserve(map_.size() * VoxelBlock::max_points);
+  for (const auto& [voxel, block] : map_) {
+    const Eigen::Vector3s centre = voxel_centre(voxel, voxel_size_);
+    for (const Eigen::Vector3i8& offset : block) {
+      point_cloud.emplace_back(centre + offset.cast<Scalar>() * quantum_);
+    }
   }
   return point_cloud;
 }

--- a/rko_lio/core/voxel_hash_map.cpp
+++ b/rko_lio/core/voxel_hash_map.cpp
@@ -141,38 +141,40 @@ std::optional<Eigen::Vector3s> VoxelHashMap::get_closest_neighbor(const Eigen::V
   const Eigen::Matrix3s lower_bounds = face_bounds(query_quanta_from_corner);
 
   Scalar closest_distance_sq = square(max_distance * inv_quantum_);
-  const Eigen::Vector3i8* closest_offset = nullptr;
-  const Voxel* closest_shift = shifts.begin();
+  Eigen::Vector3i8 closest_offset = Eigen::Vector3i8::Zero();
+  Voxel closest_shift = Voxel::Zero();
+  bool found = false;
 
-  for (const Voxel* shift = shifts.begin(); shift != shifts.end(); ++shift) {
+  for (const Voxel& shift : shifts) {
     // lower bound on the distance to query within this voxel + shift
     const Scalar lower_bound_sq =
-        lower_bounds(0, shift->x() + 1) + lower_bounds(1, shift->y() + 1) + lower_bounds(2, shift->z() + 1);
+        lower_bounds(0, shift.x() + 1) + lower_bounds(1, shift.y() + 1) + lower_bounds(2, shift.z() + 1);
     if (lower_bound_sq >= closest_distance_sq) {
       continue;
     }
-    const auto search = map_.find(voxel + *shift);
+    const auto search = map_.find(voxel + shift);
     if (search == map_.end()) {
       continue;
     }
-    const Eigen::Vector3s query_quanta_from_neighbour = quanta_from_neighbour_centre(query_quanta_from_centre, *shift);
+    const Eigen::Vector3s query_quanta_from_neighbour = quanta_from_neighbour_centre(query_quanta_from_centre, shift);
     const VoxelBlock& block = search.value();
-    for (const Eigen::Vector3i8* neighbor = block.begin(); neighbor != block.end(); ++neighbor) {
-      const Scalar distance_sq = (neighbor->cast<Scalar>() - query_quanta_from_neighbour).squaredNorm();
+    for (const Eigen::Vector3i8& neighbor : block) {
+      const Scalar distance_sq = (neighbor.cast<Scalar>() - query_quanta_from_neighbour).squaredNorm();
       if (distance_sq < closest_distance_sq) {
         closest_distance_sq = distance_sq;
         closest_offset = neighbor;
         closest_shift = shift;
+        found = true;
       }
     }
   }
 
-  if (closest_offset == nullptr) {
+  if (!found) {
     return std::nullopt;
   }
   const Eigen::Vector3s query_quanta_from_neighbour =
-      quanta_from_neighbour_centre(query_quanta_from_centre, *closest_shift);
-  return query + (closest_offset->cast<Scalar>() - query_quanta_from_neighbour) * quantum_;
+      quanta_from_neighbour_centre(query_quanta_from_centre, closest_shift);
+  return query + (closest_offset.cast<Scalar>() - query_quanta_from_neighbour) * quantum_;
 }
 
 void VoxelHashMap::add_points(const std::vector<Eigen::Vector3s>& points, const Sophus::SE3s& pose) {

--- a/rko_lio/core/voxel_hash_map.hpp
+++ b/rko_lio/core/voxel_hash_map.hpp
@@ -21,19 +21,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-// NOTE: This implementation is heavily inspired in the original CT-ICP VoxelHashMap implementation,
-// although it was heavily modified and drastically simplified, but if you are using this module you
-// should at least acknoowledge the work from CT-ICP by giving a star on GitHub.
-//
-// modified from kiss-icp (kiss_icp/cpp/kiss_icp/core/VoxelHashMap.{hpp,cpp}).
+// modified heavily from kiss-icp (kiss_icp/cpp/kiss_icp/core/VoxelHashMap.{hpp,cpp}).
 #pragma once
 
 // brings VoxelHash and point_to_voxel
 #include "voxel_down_sample.hpp"
 
 #include <Eigen/Core>
+#include <array>
+#include <cstdint>
+#include <iterator>
+#include <limits>
 #include <optional>
 #include <sophus/se3.hpp>
+#include <stdexcept>
 #include <tsl/robin_map.h>
 #include <tuple>
 #include <vector>
@@ -41,12 +42,31 @@
 namespace rko_lio::core {
 
 using Voxel = Eigen::Vector3i;
-using VoxelBlock = std::vector<Eigen::Vector3s>;
+
+/// A map point is a signed offset from the centre of its voxel, quantized to int8
+struct VoxelBlock {
+  static constexpr unsigned int max_points = 8;
+  using PointArray = std::array<Eigen::Vector3i8, max_points>;
+
+  PointArray points;
+  std::uint8_t size = 0;
+
+  bool full() const { return size == max_points; }
+
+  void push_back(const Eigen::Vector3i8& offset) {
+    if (full()) {
+      throw std::out_of_range("VoxelBlock is full, check full() before pushing");
+    }
+    *std::next(points.begin(), size) = offset;
+    ++size;
+  }
+
+  PointArray::const_iterator begin() const { return points.begin(); }
+  PointArray::const_iterator end() const { return points.begin() + size; } // capacity is 8, size is what's filled
+};
 
 struct VoxelHashMap {
-  explicit VoxelHashMap(const Scalar voxel_size,
-                        const Scalar clipping_distance,
-                        const unsigned int max_points_per_voxel);
+  explicit VoxelHashMap(const Scalar voxel_size, const Scalar clipping_distance);
 
   void clear() { map_.clear(); }
   bool empty() const { return map_.empty(); }
@@ -55,14 +75,14 @@ struct VoxelHashMap {
   void remove_points_far_from_location(const Eigen::Vector3s& origin);
   std::vector<Eigen::Vector3s> pointcloud() const;
 
-  /// Iterator to nearest point to `query` strictly within `max_distance`, or nullopt if there is none.
-  std::optional<VoxelBlock::const_iterator> get_closest_neighbor(const Eigen::Vector3s& query,
-                                                                 const Scalar max_distance) const;
+  /// Nearest point to `query` strictly within `max_distance`, or nullopt if there is none.
+  std::optional<Eigen::Vector3s> get_closest_neighbor(const Eigen::Vector3s& query, const Scalar max_distance) const;
 
   Scalar voxel_size_;
   Scalar inv_voxel_size_;
+  Scalar quantum_;
+  Scalar inv_quantum_;
   Scalar clipping_distance_;
-  unsigned int max_points_per_voxel_;
   tsl::robin_map<Voxel, VoxelBlock, VoxelHash> map_;
 };
 

--- a/rko_lio/core/voxel_hash_map.hpp
+++ b/rko_lio/core/voxel_hash_map.hpp
@@ -48,7 +48,7 @@ struct VoxelBlock {
   static constexpr unsigned int max_points = 8;
   using PointArray = std::array<Eigen::Vector3i8, max_points>;
 
-  PointArray points;
+  PointArray points{};
   std::uint8_t size = 0;
 
   bool full() const { return size == max_points; }

--- a/rko_lio/python/pybind/rko_lio_pybind.cpp
+++ b/rko_lio/python/pybind/rko_lio_pybind.cpp
@@ -62,7 +62,6 @@ PYBIND11_MODULE(rko_lio_pybind, m) {
       .def_readwrite("deskew", &LIO::Config::deskew)
       .def_readwrite("max_iterations", &LIO::Config::max_iterations)
       .def_readwrite("voxel_size", &LIO::Config::voxel_size)
-      .def_readwrite("max_points_per_voxel", &LIO::Config::max_points_per_voxel)
       .def_readwrite("max_range", &LIO::Config::max_range)
       .def_readwrite("min_range", &LIO::Config::min_range)
       .def_readwrite("convergence_criterion", &LIO::Config::convergence_criterion)

--- a/rko_lio/python/rko_lio/config.py
+++ b/rko_lio/python/rko_lio/config.py
@@ -109,8 +109,6 @@ class LIOConfig:
         Maximum optimization iterations for scan matching.
     voxel_size : float, default 1.0
         Size of map voxels (meters).
-    max_points_per_voxel : int, default 20
-        Maximum points stored per voxel.
     max_range : float, default 100.0
         Max usable range of lidar (meters).
     min_range : float, default 1.0
@@ -134,7 +132,6 @@ class LIOConfig:
     deskew: bool = True
     max_iterations: int = 100
     voxel_size: float = 1.0
-    max_points_per_voxel: int = 20
     max_range: float = 100.0
     min_range: float = 1.0
     convergence_criterion: float = 1e-5
@@ -207,6 +204,13 @@ class PipelineConfig:
                 continue
             if fname in args:
                 pipeline_args[fname] = args.pop(fname)
+
+        if "max_points_per_voxel" in args or "max_points_per_voxel" in lio_args:
+            error_and_exit(
+                "Config argument",
+                "max_points_per_voxel",
+                "was removed, it is now fixed at compile time so the map can store points inline. Use voxel_size to control map density instead: smaller keeps more points overall, larger keeps fewer.",
+            )
 
         lio_valid_names = [f.name for f in fields(LIOConfig)]
         for arg in args:

--- a/rko_lio/ros/base_node.cpp
+++ b/rko_lio/ros/base_node.cpp
@@ -41,7 +41,6 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LIO::Config,
                                    deskew,
                                    max_iterations,
                                    voxel_size,
-                                   max_points_per_voxel,
                                    max_range,
                                    min_range,
                                    convergence_criterion,
@@ -113,8 +112,11 @@ BaseNode::BaseNode(const std::string& node_name, const rclcpp::NodeOptions& opti
       static_cast<size_t>(node->declare_parameter<int>("max_iterations", static_cast<int>(lio_config.max_iterations)));
   lio_config.voxel_size =
       static_cast<core::Scalar>(node->declare_parameter<double>("voxel_size", lio_config.voxel_size));
-  lio_config.max_points_per_voxel =
-      static_cast<int>(node->declare_parameter<int>("max_points_per_voxel", lio_config.max_points_per_voxel));
+  if (node->declare_parameter<int>("max_points_per_voxel", -1) != -1) {
+    throw std::runtime_error(
+        "max_points_per_voxel was removed, it is now fixed at compile time so the map can store points inline. "
+        "Use voxel_size to control map density instead: smaller keeps more points overall, larger keeps fewer.");
+  }
   lio_config.max_range = static_cast<core::Scalar>(node->declare_parameter<double>("max_range", lio_config.max_range));
   lio_config.min_range = static_cast<core::Scalar>(node->declare_parameter<double>("min_range", lio_config.min_range));
   lio_config.convergence_criterion = static_cast<core::Scalar>(


### PR DESCRIPTION
The last of my performance line of PRs started in #157 

Map points are now signed int8 offsets from the voxel centre, stored in fixed-size arrays instead of behind a vector's heap pointer. the centre follows from the hash key so it costs nothing.

int8 + inline (array) block is key. at 3 bytes per point an 8 point block is 24 bytes and the bucket stays at 40, same as before, with the heap block gone entirely. at float32 it would be 96 bytes and be beyond a cache line. 

os0, single thread, N is points per voxel, ICP profiling:

```
              wall              cycles            DRAM
N=20    15.36 -> 12.68 ms   180.3 -> 164.3 G   72.3 -> 29.4 M
N=8     11.80 ->  9.77 ms   158.1 -> 144.5 G   46.9 -> 16.6 M
```

-17% on the ICP loop, -60% DRAM traffic, map memory 5.28 -> 2.88 MB. run to run std. dev. tightens ~6x at N=8 (0.30 -> 0.05 ms).

A quantum (for the fixed point representation in the map) is voxel_size/254, so 3.9 mm at voxel_size 1.0m.

**Breaking Change**: max_points_per_voxel is now removed, and VoxelBlock::max_points is fixed at 8. the block has to be a fixed size array. I earlier tested the difference between N=8 and N=20 (the current default) on my regression set, and there was not a notable difference, compared to the speedup. Regardless, with how the points are added to the voxel map (with a check on map resolution), voxel size and max points per voxel were slightly redundant as the effective resolution due to the map resolution check was voxel_size/sqrt(max_points_per_voxel). with the latter now fixed to 8, the effective resolution can still be controlled via voxel size to obtain the same effect as before if someone needs that.

Trying to set the parameter leads to ros throwing, python errors out, both pointing at voxel_size instead. 

also a voxel_size guard is introduced with a max of 5m, past which a quantum starts to become coarser than typical lidar range noise.

PR merge pending on my typical regression testing as usual.