### PR TITLE
core, ros: consistent naming, and make the voxel map's state private

### DIFF
--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -104,12 +104,12 @@ template <typename Functor>
   requires requires(Functor f, Nsec stamp) {
     { f(stamp) } -> std::same_as<Sophus::SE3s>;
   }
-void deskew_scan(Vector3sVector& frame,
+void deskew_scan(Vector3sVector& scan,
                  const TimestampVector& timestamps,
                  const Nsec end_time,
                  const Functor& relative_pose_at_time) {
   const Sophus::SE3s scan_to_scan_motion_inverse = relative_pose_at_time(end_time).inverse();
-  std::transform(frame.cbegin(), frame.cend(), timestamps.cbegin(), frame.begin(),
+  std::transform(scan.cbegin(), scan.cend(), timestamps.cbegin(), scan.begin(),
                  [&](const Eigen::Vector3s& point, const Nsec timestamp) {
                    return (scan_to_scan_motion_inverse * relative_pose_at_time(timestamp)) * point;
                  });
@@ -117,7 +117,7 @@ void deskew_scan(Vector3sVector& frame,
 
 using LinearSystem = std::tuple<Eigen::Matrix6s, Eigen::Vector6s, Scalar>;
 LinearSystem build_icp_linear_system(const Sophus::SE3s& current_pose,
-                                     const rko_lio::core::Vector3sVector& frame,
+                                     const rko_lio::core::Vector3sVector& keypoints,
                                      const rko_lio::core::VoxelHashMap& voxel_map,
                                      const Scalar& max_correspondence_distance) {
   using IcpAccum = std::tuple<Eigen::Matrix6s, Eigen::Vector6s, Scalar, int>;
@@ -140,7 +140,7 @@ LinearSystem build_icp_linear_system(const Sophus::SE3s& current_pose,
   using points_iterator = std::vector<Eigen::Vector3s>::const_iterator;
   const auto& [H_icp, b_icp, chi_icp, correspondences_counter] = tbb::parallel_reduce(
       // Range
-      tbb::blocked_range<points_iterator>{frame.cbegin(), frame.cend()},
+      tbb::blocked_range<points_iterator>{keypoints.cbegin(), keypoints.cend()},
       // Identity
       IcpAccum(Eigen::Matrix6s::Zero(), Eigen::Vector6s::Zero(), 0.0, 0),
       // 1st Lambda: Parallel computation
@@ -192,7 +192,7 @@ LinearSystem build_orientation_linear_system(const Sophus::SE3s& current_pose,
   return LinearSystem{J_ori.transpose() * J_ori, J_ori.transpose() * residual, 0.5 * residual.squaredNorm()};
 }
 
-Sophus::SE3s icp(const Vector3sVector& frame,
+Sophus::SE3s icp(const Vector3sVector& keypoints,
                  const VoxelHashMap& voxel_map,
                  const Sophus::SE3s& initial_guess,
                  const LIO::Config& config,
@@ -208,7 +208,7 @@ Sophus::SE3s icp(const Vector3sVector& frame,
   for (size_t i = 0; i < config.max_iterations; ++i) {
     const auto& [H, b, chi] = std::invoke([&]() -> LinearSystem {
       const auto& [H_icp, b_icp, chi_icp] =
-          build_icp_linear_system(current_pose, frame, voxel_map, config.max_correspondence_distance);
+          build_icp_linear_system(current_pose, keypoints, voxel_map, config.max_correspondence_distance);
       if (beta >= 0) {
         const auto& [H_ori, b_ori, chi_ori] =
             build_orientation_linear_system(current_pose, optional_accel_info->local_gravity_estimate);
@@ -264,7 +264,7 @@ void LIO::initialize(const Nsec lidar_time) {
     std::cerr << "[WARNING] Cannot initialize. No imu measurements received.\n";
     // lidar_state.time has the time from the previous lidar, which we didn't log if init_phase was on
     poses_with_timestamps.emplace_back(lidar_state.time, lidar_state.pose);
-    _initialized = true;
+    initialized_ = true;
     return;
   }
 
@@ -286,7 +286,7 @@ void LIO::initialize(const Nsec lidar_time) {
   imu_bias.accelerometer = avg_accel + local_gravity;
   imu_bias.gyroscope = avg_gyro;
 
-  _initialized = true;
+  initialized_ = true;
   std::cout << "[INFO] Odometry map frame initialized using " << interval_stats.imu_count
             << " IMU measurements. Estimated initial rotation [se(3)] is " << imu_state.pose.so3().log().transpose()
             << "\n";
@@ -299,15 +299,15 @@ Vector3sVector LIO::bootstrap_first_scan(const Vector3sVector& scan, const Nsec 
   imu_state = lidar_state;
   auto preproc = preprocess_scan(scan, config);
   if (!config.initialization_phase) {
-    map.update(config.double_downsample ? preproc.map_frame : preproc.keypoints, lidar_state.pose);
+    map.update(config.double_downsample ? preproc.map_points : preproc.keypoints, lidar_state.pose);
     poses_with_timestamps.emplace_back(lidar_state.time, lidar_state.pose);
     std::cout << "[INFO] Odometry map frame initialized with first lidar scan.\n";
   }
-  return std::move(preproc.filtered_frame);
+  return std::move(preproc.filtered_scan);
 }
 
 std::pair<Eigen::Vector3s, Eigen::Vector3s> LIO::motion_priors_from_imu(const Nsec current_lidar_time) {
-  if (config.initialization_phase && !_initialized) {
+  if (config.initialization_phase && !initialized_) {
     // assume static and
     initialize(current_lidar_time);
     return {Eigen::Vector3s::Zero(), Eigen::Vector3s::Zero()};
@@ -338,8 +338,8 @@ void LIO::add_imu_measurement(const ImuControl& base_imu) {
       std::cerr << "[WARNING - ONCE] Skipping IMU, waiting for first LiDAR message.\n";
       warning_skip_till_first_lidar = true;
     }
-    _last_real_imu_time = base_imu.time;
-    _last_real_base_imu_ang_vel = base_imu.angular_velocity;
+    last_real_imu_time_ = base_imu.time;
+    last_real_base_imu_ang_vel_ = base_imu.angular_velocity;
     return;
   }
 
@@ -372,8 +372,8 @@ void LIO::add_imu_measurement(const ImuControl& base_imu) {
 
   interval_stats.update(unbiased_ang_vel, unbiased_accel, compensated_accel);
 
-  _last_real_imu_time = base_imu.time;
-  _last_real_base_imu_ang_vel = base_imu.angular_velocity;
+  last_real_imu_time_ = base_imu.time;
+  last_real_base_imu_ang_vel_ = base_imu.angular_velocity;
 }
 
 void LIO::add_imu_measurement(const Sophus::SE3s& extrinsic_imu2base, const ImuControl& raw_imu) {
@@ -382,9 +382,9 @@ void LIO::add_imu_measurement(const Sophus::SE3s& extrinsic_imu2base, const ImuC
     return;
   }
 
-  if (_last_real_imu_time < EPSILON_TIME) {
+  if (last_real_imu_time_ < EPSILON_TIME) {
     // skip IMU message as we need a previous imu time for extrinsic compensation
-    _last_real_imu_time = raw_imu.time;
+    last_real_imu_time_ = raw_imu.time;
     return;
   }
 
@@ -394,7 +394,7 @@ void LIO::add_imu_measurement(const Sophus::SE3s& extrinsic_imu2base, const ImuC
   base_imu.angular_velocity = extrinsic_rotation * raw_imu.angular_velocity;
 
   const Eigen::Vector3s& lever_arm = -1 * extrinsic_imu2base.translation();
-  const Nsec dt = raw_imu.time - _last_real_imu_time;
+  const Nsec dt = raw_imu.time - last_real_imu_time_;
 
   const Eigen::Vector3s angular_acceleration = std::invoke([&]() -> Eigen::Vector3s {
     if (std::chrono::abs(dt) < std::chrono::microseconds(200)) {
@@ -409,7 +409,7 @@ void LIO::add_imu_measurement(const Sophus::SE3s& extrinsic_imu2base, const ImuC
       return Eigen::Vector3s::Zero();
     } else {
       const Eigen::Vector3s angular_acceleration =
-          (base_imu.angular_velocity - _last_real_base_imu_ang_vel) / to_seconds(dt);
+          (base_imu.angular_velocity - last_real_base_imu_ang_vel_) / to_seconds(dt);
       return angular_acceleration;
     }
   });
@@ -475,7 +475,7 @@ Vector3sVector LIO::register_scan(Vector3sVector scan, const TimestampVector& ti
     throw std::invalid_argument(error_msg);
   }
 
-  const Vector3sVector& map_input = config.double_downsample ? preproc_result.map_frame : preproc_result.keypoints;
+  const Vector3sVector& map_input = config.double_downsample ? preproc_result.map_points : preproc_result.keypoints;
 
   if (!map.empty()) {
     SCOPED_PROFILER("ICP");
@@ -506,7 +506,7 @@ Vector3sVector LIO::register_scan(Vector3sVector scan, const TimestampVector& ti
 
   poses_with_timestamps.emplace_back(lidar_state.time, lidar_state.pose);
 
-  return std::move(preproc_result.filtered_frame);
+  return std::move(preproc_result.filtered_scan);
 }
 
 Vector3sVector
@@ -516,8 +516,8 @@ LIO::register_scan(const Sophus::SE3s& extrinsic_lidar2base, Vector3sVector scan
   }
 
   transform_points(extrinsic_lidar2base, scan);
-  Vector3sVector frame = register_scan(std::move(scan), timestamps);
-  transform_points(extrinsic_lidar2base.inverse(), frame);
-  return frame;
+  Vector3sVector filtered_scan = register_scan(std::move(scan), timestamps);
+  transform_points(extrinsic_lidar2base.inverse(), filtered_scan);
+  return filtered_scan;
 }
 } // namespace rko_lio::core

--- a/rko_lio/core/lio.hpp
+++ b/rko_lio/core/lio.hpp
@@ -159,12 +159,12 @@ private:
   std::pair<Eigen::Vector3s, Eigen::Vector3s> motion_priors_from_imu(const Nsec current_lidar_time);
 
   /** True if odometry initialization has been completed. */
-  bool _initialized = false;
+  bool initialized_ = false;
 
   /** Timestamp of the most recent real IMU measurement. */
-  Nsec _last_real_imu_time{0};
+  Nsec last_real_imu_time_{0};
 
   /** Angular velocity of last true IMU measurement expressed in base frame. */
-  Eigen::Vector3s _last_real_base_imu_ang_vel = Eigen::Vector3s::Zero();
+  Eigen::Vector3s last_real_base_imu_ang_vel_ = Eigen::Vector3s::Zero();
 };
 } // namespace rko_lio::core

--- a/rko_lio/core/preprocess_scan.cpp
+++ b/rko_lio/core/preprocess_scan.cpp
@@ -5,21 +5,19 @@
 
 namespace rko_lio::core {
 
-PreprocessingResult preprocess_scan(Vector3sVector frame, const LIO::Config& config) {
-  std::erase_if(frame, [&](const auto& point) {
+PreprocessingResult preprocess_scan(Vector3sVector scan, const LIO::Config& config) {
+  std::erase_if(scan, [&](const auto& point) {
     const Scalar point_range = point.norm();
     return !std::isfinite(point_range) || point_range <= config.min_range || point_range >= config.max_range;
   });
 
   if (config.double_downsample) {
-    Vector3sVector downsampled_frame = voxel_down_sample(frame, config.voxel_size * Scalar(0.5));
-    Vector3sVector keypoints = voxel_down_sample(downsampled_frame, config.voxel_size * Scalar(1.5));
-    return {.filtered_frame = std::move(frame),
-            .keypoints = std::move(keypoints),
-            .map_frame = std::move(downsampled_frame)};
+    Vector3sVector downsampled = voxel_down_sample(scan, config.voxel_size * Scalar(0.5));
+    Vector3sVector keypoints = voxel_down_sample(downsampled, config.voxel_size * Scalar(1.5));
+    return {.filtered_scan = std::move(scan), .keypoints = std::move(keypoints), .map_points = std::move(downsampled)};
   }
-  Vector3sVector keypoints = voxel_down_sample(frame, config.voxel_size);
-  return {.filtered_frame = std::move(frame), .keypoints = std::move(keypoints), .map_frame = {}};
+  Vector3sVector keypoints = voxel_down_sample(scan, config.voxel_size);
+  return {.filtered_scan = std::move(scan), .keypoints = std::move(keypoints), .map_points = {}};
 }
 
 } // namespace rko_lio::core

--- a/rko_lio/core/preprocess_scan.hpp
+++ b/rko_lio/core/preprocess_scan.hpp
@@ -7,12 +7,12 @@
 namespace rko_lio::core {
 
 struct PreprocessingResult {
-  Vector3sVector filtered_frame;
+  Vector3sVector filtered_scan;
   Vector3sVector keypoints;
-  Vector3sVector map_frame; // populated only when config.double_downsample; empty otherwise
+  Vector3sVector map_points; // populated only when config.double_downsample; empty otherwise
 };
 
 // clip and downsample the input cloud
-PreprocessingResult preprocess_scan(Vector3sVector frame, const LIO::Config& config);
+PreprocessingResult preprocess_scan(Vector3sVector scan, const LIO::Config& config);
 
 } // namespace rko_lio::core

--- a/rko_lio/core/voxel_down_sample.cpp
+++ b/rko_lio/core/voxel_down_sample.cpp
@@ -34,19 +34,19 @@ namespace rko_lio::core {
 // https://github.com/PRBonn/kiss-icp/pull/347
 // although it does lead to worse odometry performance in certain situations
 
-std::vector<Eigen::Vector3s> voxel_down_sample(const std::vector<Eigen::Vector3s>& frame, const Scalar voxel_size) {
+std::vector<Eigen::Vector3s> voxel_down_sample(const std::vector<Eigen::Vector3s>& points, const Scalar voxel_size) {
   const auto inv_voxel_size = static_cast<Scalar>(1.0 / voxel_size);
   // the default allocator mallocs once per voxel, pmr cuts that to a handful of arena chunks
   std::pmr::monotonic_buffer_resource arena;
   std::pmr::unordered_map<Eigen::Vector3i, Eigen::Vector3s, VoxelHash> grid{&arena};
-  grid.reserve(frame.size());
-  std::for_each(frame.cbegin(), frame.cend(),
+  grid.reserve(points.size());
+  std::for_each(points.cbegin(), points.cend(),
                 [&](const auto& point) { grid.try_emplace(point_to_voxel(point, inv_voxel_size), point); });
-  std::vector<Eigen::Vector3s> frame_downsampled;
-  frame_downsampled.reserve(grid.size());
+  std::vector<Eigen::Vector3s> downsampled;
+  downsampled.reserve(grid.size());
   std::for_each(grid.cbegin(), grid.cend(),
-                [&](const auto& voxel_and_point) { frame_downsampled.emplace_back(voxel_and_point.second); });
-  return frame_downsampled;
+                [&](const auto& voxel_and_point) { downsampled.emplace_back(voxel_and_point.second); });
+  return downsampled;
 }
 
 } // namespace rko_lio::core

--- a/rko_lio/core/voxel_down_sample.hpp
+++ b/rko_lio/core/voxel_down_sample.hpp
@@ -30,7 +30,7 @@
 
 namespace rko_lio::core {
 /// Voxelize point cloud keeping the original coordinates
-std::vector<Eigen::Vector3s> voxel_down_sample(const std::vector<Eigen::Vector3s>& frame, const Scalar voxel_size);
+std::vector<Eigen::Vector3s> voxel_down_sample(const std::vector<Eigen::Vector3s>& points, const Scalar voxel_size);
 
 inline Eigen::Vector3i point_to_voxel(const Eigen::Vector3s& point, const Scalar inv_voxel_size) {
   return (point * inv_voxel_size).array().floor().cast<int>();

--- a/rko_lio/core/voxel_hash_map.cpp
+++ b/rko_lio/core/voxel_hash_map.cpp
@@ -152,8 +152,8 @@ std::optional<Eigen::Vector3s> VoxelHashMap::get_closest_neighbor(const Eigen::V
     if (lower_bound_sq >= closest_distance_sq) {
       continue;
     }
-    const auto search = map_.find(voxel + shift);
-    if (search == map_.end()) {
+    const auto search = voxels_.find(voxel + shift);
+    if (search == voxels_.end()) {
       continue;
     }
     const Eigen::Vector3s query_quanta_from_neighbour = quanta_from_neighbour_centre(query_quanta_from_centre, shift);
@@ -185,7 +185,7 @@ void VoxelHashMap::add_points(const std::vector<Eigen::Vector3s>& points, const 
     const Voxel voxel = point_to_voxel(p, inv_voxel_size_);
     // quantise before the spacing test, so the test sees the offset that would actually be stored
     const Eigen::Vector3i8 offset = to_stored_offset(quanta_from_centre(p, voxel, voxel_size_, inv_quantum_));
-    auto it = map_.try_emplace(voxel).first;
+    auto it = voxels_.try_emplace(voxel).first;
     VoxelBlock& voxel_points = it.value();
     if (voxel_points.full() ||
         std::any_of(voxel_points.begin(), voxel_points.end(), [&](const Eigen::Vector3i8& voxel_point) {
@@ -197,13 +197,13 @@ void VoxelHashMap::add_points(const std::vector<Eigen::Vector3s>& points, const 
   });
 }
 
-void VoxelHashMap::remove_points_far_from_location(const Eigen::Vector3s& origin) {
+void VoxelHashMap::remove_points_far_from_location(const Eigen::Vector3s& location) {
   // a centre is within half a diagonal of every point it holds, so widening by that keeps a superset
   const Scalar half_diagonal = Scalar(0.5) * std::numbers::sqrt3_v<Scalar> * voxel_size_;
   const Scalar max_distance_sq = square(clipping_distance_ + half_diagonal);
-  for (auto it = map_.begin(); it != map_.end();) {
-    it = (voxel_centre(it->first, voxel_size_) - origin).squaredNorm() > max_distance_sq ? map_.erase(it)
-                                                                                         : std::next(it);
+  for (auto it = voxels_.begin(); it != voxels_.end();) {
+    it = (voxel_centre(it->first, voxel_size_) - location).squaredNorm() > max_distance_sq ? voxels_.erase(it)
+                                                                                           : std::next(it);
   }
 }
 
@@ -212,16 +212,16 @@ void VoxelHashMap::update(const std::vector<Eigen::Vector3s>& points, const Soph
   remove_points_far_from_location(pose.translation());
 }
 
-std::vector<Eigen::Vector3s> VoxelHashMap::pointcloud() const {
-  std::vector<Eigen::Vector3s> point_cloud;
-  point_cloud.reserve(map_.size() * VoxelBlock::max_points);
-  for (const auto& [voxel, block] : map_) {
+std::vector<Eigen::Vector3s> VoxelHashMap::points() const {
+  std::vector<Eigen::Vector3s> map_points;
+  map_points.reserve(voxels_.size() * VoxelBlock::max_points);
+  for (const auto& [voxel, block] : voxels_) {
     const Eigen::Vector3s centre = voxel_centre(voxel, voxel_size_);
     for (const Eigen::Vector3i8& offset : block) {
-      point_cloud.emplace_back(centre + offset.cast<Scalar>() * quantum_);
+      map_points.emplace_back(centre + offset.cast<Scalar>() * quantum_);
     }
   }
-  return point_cloud;
+  return map_points;
 }
 
 } // namespace rko_lio::core

--- a/rko_lio/core/voxel_hash_map.hpp
+++ b/rko_lio/core/voxel_hash_map.hpp
@@ -65,25 +65,27 @@ struct VoxelBlock {
   PointArray::const_iterator end() const { return points.begin() + size; } // capacity is 8, size is what's filled
 };
 
-struct VoxelHashMap {
+class VoxelHashMap {
+public:
   explicit VoxelHashMap(const Scalar voxel_size, const Scalar clipping_distance);
 
-  void clear() { map_.clear(); }
-  bool empty() const { return map_.empty(); }
+  void clear() { voxels_.clear(); }
+  bool empty() const { return voxels_.empty(); }
   void update(const std::vector<Eigen::Vector3s>& points, const Sophus::SE3s& pose);
   void add_points(const std::vector<Eigen::Vector3s>& points, const Sophus::SE3s& pose);
-  void remove_points_far_from_location(const Eigen::Vector3s& origin);
-  std::vector<Eigen::Vector3s> pointcloud() const;
+  void remove_points_far_from_location(const Eigen::Vector3s& location);
+  std::vector<Eigen::Vector3s> points() const;
 
   /// Nearest point to `query` strictly within `max_distance`, or nullopt if there is none.
   std::optional<Eigen::Vector3s> get_closest_neighbor(const Eigen::Vector3s& query, const Scalar max_distance) const;
 
+private:
   Scalar voxel_size_;
   Scalar inv_voxel_size_;
   Scalar quantum_;
   Scalar inv_quantum_;
   Scalar clipping_distance_;
-  tsl::robin_map<Voxel, VoxelBlock, VoxelHash> map_;
+  tsl::robin_map<Voxel, VoxelBlock, VoxelHash> voxels_;
 };
 
 } // namespace rko_lio::core

--- a/rko_lio/python/pybind/rko_lio_pybind.cpp
+++ b/rko_lio/python/pybind/rko_lio_pybind.cpp
@@ -114,7 +114,7 @@ PYBIND11_MODULE(rko_lio_pybind, m) {
             return self.register_scan(Sophus::SE3s(extrinsic_lidar2base), scan, timestamps);
           },
           "extrinsic_lidar2base"_a, "scan"_a, "timestamps"_a)
-      .def("map_point_cloud", [](LIO& self) { return self.map.pointcloud(); })
+      .def("map_point_cloud", [](LIO& self) { return self.map.points(); })
       .def("pose", [](LIO& self) { return self.lidar_state.pose.matrix(); })
       .def("imu_pose", [](LIO& self) { return self.imu_state.pose.matrix(); })
       .def("imu_velocity", [](LIO& self) { return self.imu_state.velocity; })

--- a/rko_lio/ros/base_node.cpp
+++ b/rko_lio/ros/base_node.cpp
@@ -102,7 +102,7 @@ BaseNode::BaseNode(const std::string& node_name, const rclcpp::NodeOptions& opti
     publish_map_after =
         std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(publish_map_after_seconds));
     map_publisher = node->create_publisher<sensor_msgs::msg::PointCloud2>(map_topic, publisher_qos);
-    map_publish_thead = std::jthread([this]() { publish_map_loop(); });
+    map_publish_thread = std::jthread([this]() { publish_map_loop(); });
   }
 
   // lio params
@@ -231,7 +231,7 @@ bool BaseNode::check_and_set_extrinsics() {
   return true;
 }
 
-LidarFrame BaseNode::process_lidar_msg(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& lidar_msg) const {
+LidarScan BaseNode::process_lidar_msg(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& lidar_msg) const {
   const core::Nsec header_stamp = utils::to_ns(lidar_msg->header.stamp);
   if (lio->config.deskew) {
     utils::RawScan scan = utils::point_cloud2_to_eigen_with_timestamps(lidar_msg);
@@ -239,10 +239,10 @@ LidarFrame BaseNode::process_lidar_msg(const sensor_msgs::msg::PointCloud2::Cons
             .points = std::move(scan.points)};
   }
   RCLCPP_WARN_STREAM_ONCE(node->get_logger(), "Deskewing is disabled. Populating timestamps with static header time.");
-  LidarFrame frame{.timestamps = {.min = header_stamp, .max = header_stamp},
-                   .points = utils::point_cloud2_to_eigen(lidar_msg)};
-  frame.timestamps.per_point.assign(frame.points.size(), header_stamp);
-  return frame;
+  LidarScan scan{.timestamps = {.min = header_stamp, .max = header_stamp},
+                 .points = utils::point_cloud2_to_eigen(lidar_msg)};
+  scan.timestamps.per_point.assign(scan.points.size(), header_stamp);
+  return scan;
 }
 
 core::Vector3sVector BaseNode::register_scan_locked(core::Vector3sVector scan,
@@ -254,12 +254,12 @@ core::Vector3sVector BaseNode::register_scan_locked(core::Vector3sVector scan,
   return lio->register_scan(extrinsic_lidar2base, std::move(scan), time_vector);
 }
 
-void BaseNode::publish_lidar_outputs(const core::Vector3sVector& deskewed_frame) const {
+void BaseNode::publish_lidar_outputs(const core::Vector3sVector& deskewed_scan) const {
   if (publish_deskewed_scan) {
     std_msgs::msg::Header header;
     header.frame_id = lidar_frame;
     header.stamp = utils::to_ros_time(lio->lidar_state.time);
-    frame_publisher->publish(utils::eigen_to_point_cloud2(deskewed_frame, header));
+    frame_publisher->publish(utils::eigen_to_point_cloud2(deskewed_scan, header));
   }
   publish_odometry(lio->lidar_state, odom_publisher);
   if (publish_lidar_acceleration) {
@@ -310,7 +310,7 @@ void BaseNode::publish_map_loop() {
       RCLCPP_WARN_ONCE(node->get_logger(), "Local map publish thread: Local map is empty.");
       continue;
     }
-    const core::Vector3sVector map_points = lio->map.pointcloud();
+    const core::Vector3sVector map_points = lio->map.points();
     lock.unlock(); // we don't access the local map anymore
     std_msgs::msg::Header map_header;
     map_header.stamp = node->now();

--- a/rko_lio/ros/base_node.hpp
+++ b/rko_lio/ros/base_node.hpp
@@ -47,7 +47,7 @@
 
 namespace rko_lio::ros {
 
-struct LidarFrame {
+struct LidarScan {
   core::Timestamps timestamps;
   core::Vector3sVector points;
 };
@@ -74,7 +74,7 @@ public:
   rclcpp::Publisher<geometry_msgs::msg::AccelStamped>::SharedPtr lidar_accel_publisher;
 
   // map publish thread
-  std::jthread map_publish_thead;
+  std::jthread map_publish_thread;
 
   std::string imu_topic;
   std::string imu_frame; // default: get from the first imu message
@@ -111,11 +111,11 @@ public:
   // to querying TF inline per-message.
   bool ensure_frame_and_extrinsics(std::string& target_frame, const std::string& msg_frame, std::string_view kind);
 
-  LidarFrame process_lidar_msg(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& lidar_msg) const;
+  LidarScan process_lidar_msg(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& lidar_msg) const;
 
   core::Vector3sVector register_scan_locked(core::Vector3sVector scan, const core::TimestampVector& time_vector);
 
-  void publish_lidar_outputs(const core::Vector3sVector& deskewed_frame) const;
+  void publish_lidar_outputs(const core::Vector3sVector& deskewed_scan) const;
 
   void publish_odometry(const core::State& state,
                         const rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr& publisher) const;

--- a/rko_lio/ros/online_imu_rate_node.cpp
+++ b/rko_lio/ros/online_imu_rate_node.cpp
@@ -108,17 +108,17 @@ public:
     }
 
     try {
-      LidarFrame frame = process_lidar_msg(lidar_msg);
-      const core::Vector3sVector deskewed_frame =
-          register_scan_locked(std::move(frame.points), frame.timestamps.per_point);
-      if (deskewed_frame.empty()) {
-        // first frame is skipped and an empty frame is returned. nothing to publish.
+      LidarScan scan = process_lidar_msg(lidar_msg);
+      const core::Vector3sVector deskewed_scan =
+          register_scan_locked(std::move(scan.points), scan.timestamps.per_point);
+      if (deskewed_scan.empty()) {
+        // first scan is skipped and an empty scan is returned. nothing to publish.
         return;
       }
-      publish_lidar_outputs(deskewed_frame);
+      publish_lidar_outputs(deskewed_scan);
       publish_tf(lio->lidar_state);
     } catch (const std::invalid_argument& ex) {
-      RCLCPP_ERROR_STREAM(node->get_logger(), "Encountered error, dropping frame. Error: " << ex.what());
+      RCLCPP_ERROR_STREAM(node->get_logger(), "Encountered error, dropping scan. Error: " << ex.what());
     }
   }
 };

--- a/rko_lio/ros/threaded_node.cpp
+++ b/rko_lio/ros/threaded_node.cpp
@@ -63,23 +63,23 @@ void ThreadedNode::lidar_callback(const sensor_msgs::msg::PointCloud2::ConstShar
   {
     const std::scoped_lock lock(buffer_mutex);
     if (lidar_buffer.size() >= max_lidar_buffer_size) {
-      RCLCPP_WARN_STREAM(node->get_logger(), "Registration lidar buffer limit reached. Dropping frame.");
+      RCLCPP_WARN_STREAM(node->get_logger(), "Registration lidar buffer limit reached. Dropping scan.");
       sync_condition_variable.notify_one();
       return;
     }
   }
   try {
-    LidarFrame frame = process_lidar_msg(lidar_msg);
+    LidarScan scan = process_lidar_msg(lidar_msg);
     {
       const std::scoped_lock lock(buffer_mutex);
-      lidar_buffer.push(std::move(frame));
+      lidar_buffer.push(std::move(scan));
       atomic_can_process = !imu_buffer.empty() && imu_buffer.back().time > lidar_buffer.front().timestamps.max;
     }
     if (atomic_can_process) {
       sync_condition_variable.notify_one();
     }
   } catch (const std::invalid_argument& ex) {
-    RCLCPP_ERROR_STREAM(node->get_logger(), "Encountered error, dropping frame: Error. " << ex.what());
+    RCLCPP_ERROR_STREAM(node->get_logger(), "Encountered error, dropping scan: Error. " << ex.what());
   }
 }
 
@@ -92,10 +92,10 @@ void ThreadedNode::registration_loop() {
       // node could have been killed after waiting on the cv
       break;
     }
-    LidarFrame frame = std::move(lidar_buffer.front());
+    LidarScan scan = std::move(lidar_buffer.front());
     lidar_buffer.pop();
     registration_busy = true;
-    const core::Nsec end_stamp = frame.timestamps.max;
+    const core::Nsec end_stamp = scan.timestamps.max;
     for (; !imu_buffer.empty() && imu_buffer.front().time < end_stamp; imu_buffer.pop()) {
       const core::ImuControl& imu_data = imu_buffer.front();
       lio->add_imu_measurement(extrinsic_imu2base, imu_data);
@@ -106,15 +106,15 @@ void ThreadedNode::registration_loop() {
     buffer_lock.unlock(); // we dont touch the buffers anymore
 
     try {
-      const core::Vector3sVector deskewed_frame =
-          register_scan_locked(std::move(frame.points), frame.timestamps.per_point);
-      if (!deskewed_frame.empty()) {
-        // TODO: first frame is skipped and an empty frame is returned. improve how we handle this
-        publish_lidar_outputs(deskewed_frame);
+      const core::Vector3sVector deskewed_scan =
+          register_scan_locked(std::move(scan.points), scan.timestamps.per_point);
+      if (!deskewed_scan.empty()) {
+        // TODO: first scan is skipped and an empty scan is returned. improve how we handle this
+        publish_lidar_outputs(deskewed_scan);
         publish_tf(lio->lidar_state);
       }
     } catch (const std::invalid_argument& ex) {
-      RCLCPP_ERROR_STREAM(node->get_logger(), "Encountered error, dropping frame. Error: " << ex.what());
+      RCLCPP_ERROR_STREAM(node->get_logger(), "Encountered error, dropping scan. Error: " << ex.what());
     }
     registration_busy = false;
   }

--- a/rko_lio/ros/threaded_node.hpp
+++ b/rko_lio/ros/threaded_node.hpp
@@ -44,7 +44,7 @@ public:
   std::atomic<bool> atomic_can_process = false;
   std::atomic<bool> registration_busy{false};
   std::queue<core::ImuControl> imu_buffer;
-  std::queue<LidarFrame> lidar_buffer;
+  std::queue<LidarScan> lidar_buffer;
   size_t max_lidar_buffer_size = 10;
 
   ThreadedNode() = delete;

--- a/tests/core/test_preprocess_scan.cpp
+++ b/tests/core/test_preprocess_scan.cpp
@@ -29,15 +29,15 @@ TEST_CASE("preprocess_scan: clipping by min/max range", "[preprocess_scan]") {
 
   const auto result = preprocess_scan(frame, cfg);
 
-  REQUIRE(result.filtered_frame.size() == 3);
-  for (const auto& p : result.filtered_frame) {
+  REQUIRE(result.filtered_scan.size() == 3);
+  for (const auto& p : result.filtered_scan) {
     const double r = p.norm();
     REQUIRE(r > cfg.min_range);
     REQUIRE(r < cfg.max_range);
   }
 }
 
-TEST_CASE("preprocess_scan: double_downsample = false -> no map_frame", "[preprocess_scan]") {
+TEST_CASE("preprocess_scan: double_downsample = false -> no map_points", "[preprocess_scan]") {
   LIO::Config cfg = default_config();
   cfg.double_downsample = false;
 
@@ -49,9 +49,9 @@ TEST_CASE("preprocess_scan: double_downsample = false -> no map_frame", "[prepro
   }
 
   const auto result = preprocess_scan(frame, cfg);
-  REQUIRE(result.map_frame.empty());
+  REQUIRE(result.map_points.empty());
   REQUIRE(result.keypoints.size() > 0);
-  REQUIRE(result.filtered_frame.size() == frame.size());
+  REQUIRE(result.filtered_scan.size() == frame.size());
 }
 
 TEST_CASE("preprocess_scan: double_downsample = true -> all three populated", "[preprocess_scan]") {
@@ -66,7 +66,7 @@ TEST_CASE("preprocess_scan: double_downsample = true -> all three populated", "[
   }
 
   const auto result = preprocess_scan(frame, cfg);
-  REQUIRE_FALSE(result.map_frame.empty());
-  REQUIRE(result.map_frame.size() >= result.keypoints.size());
-  REQUIRE(result.filtered_frame.size() == frame.size());
+  REQUIRE_FALSE(result.map_points.empty());
+  REQUIRE(result.map_points.size() >= result.keypoints.size());
+  REQUIRE(result.filtered_scan.size() == frame.size());
 }


### PR DESCRIPTION
cleaning up the naming across the project as its drifted a bit. batching this in with all the other api changes i anyways did in the last stretch of PRs. most of it does not affect public api except the following, which also hopefully has not much usage. anyways this PR and the rest are leading up to a new version release. better to get this in now.

before -> after

| before | after |
| --- | --- |
| `VoxelHashMap::pointcloud()` | `VoxelHashMap::points()` |
| `VoxelHashMap` struct with public members | class, members private, `map_` -> `voxels_` |
| `ros::LidarFrame` | `ros::LidarScan` |
| `PreprocessingResult::filtered_frame` | `filtered_scan` |
| `PreprocessingResult::map_frame` | `map_points` |
| `BaseNode::map_publish_thead` | `map_publish_thread` |

of those potentially voxel hash map pointcloud and maybe the ros::LidarScan
changes may hurt.

pure rename, no behaviour change.