### PR TITLE
core: deskew without a per-point SE3 exp

### DIFF
--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -100,18 +100,43 @@ AccelFilterStep step_body_accel_filter(const BodyAccelKF& prev,
           .updated = BodyAccelKF{.mean = new_mean, .covariance = new_cov}};
 }
 
-template <typename Functor>
-  requires requires(Functor f, Nsec stamp) {
-    { f(stamp) } -> std::same_as<Sophus::SE3s>;
-  }
+// Refers every point to reference_time
 void deskew_scan(Vector3sVector& scan,
                  const TimestampVector& timestamps,
-                 const Nsec end_time,
-                 const Functor& relative_pose_at_time) {
-  const Sophus::SE3s scan_to_scan_motion_inverse = relative_pose_at_time(end_time).inverse();
+                 const Nsec reference_time,
+                 const MotionPrior& motion) {
+  const Sophus::SE3s start2reference = relative_pose_at_time(motion, reference_time).inverse();
+  const Eigen::Matrix3s& start2reference_rotation = start2reference.so3().matrix();
+  const Eigen::Vector3s& start2reference_translation = start2reference.translation();
+
+  // to avoid numerical issues
+  const Scalar angular_speed = std::max(motion.angular_velocity.norm(), Scalar(1e-6));
+  const Scalar inverse_angular_speed = 1 / angular_speed;
+  const Eigen::Vector3s axis = motion.angular_velocity * inverse_angular_speed;
+
   std::transform(scan.cbegin(), scan.cend(), timestamps.cbegin(), scan.begin(),
                  [&](const Eigen::Vector3s& point, const Nsec timestamp) {
-                   return (scan_to_scan_motion_inverse * relative_pose_at_time(timestamp)) * point;
+                   const auto dt = to_seconds<Scalar>(timestamp - motion.start_time);
+                   const Scalar theta = angular_speed * dt;
+                   const Scalar sin_theta = std::sin(theta);
+                   const Scalar one_minus_cos_theta = 1 - std::cos(theta);
+                   const Eigen::Vector3s mean_linear_velocity = motion.linear_velocity + motion.acceleration * dt / 2;
+                   const Eigen::Vector3s K_times_p = axis.cross(point);
+                   const Eigen::Vector3s K_times_linear_velocity = axis.cross(mean_linear_velocity);
+                   // SE(3) exp about a fixed axis, applied to the point: R * p + V * rho
+                   // Rodrigues -> K = hat(axis), R = I + sin(theta) K + (1 - cos theta) K^2
+                   // left Jacobian -> V = I + ((1 - cos theta) / theta) K + ((theta - sin theta) / theta) K^2
+                   // rho = dt * mean_linear_velocity and theta = angular_speed * dt
+                   // dt cancels in V * rho
+                   const Eigen::Vector3s R_times_p =
+                       point + sin_theta * K_times_p + one_minus_cos_theta * axis.cross(K_times_p);
+                   const Eigen::Vector3s V_times_rho =
+                       dt * mean_linear_velocity +
+                       (one_minus_cos_theta * inverse_angular_speed) * K_times_linear_velocity +
+                       ((theta - sin_theta) * inverse_angular_speed) * axis.cross(K_times_linear_velocity);
+                   const Eigen::Vector3s point_at_start = R_times_p + V_times_rho;
+                   // and finally move to reference time
+                   return Eigen::Vector3s(start2reference_rotation * point_at_start + start2reference_translation);
                  });
 }
 
@@ -306,15 +331,17 @@ Vector3sVector LIO::bootstrap_first_scan(const Vector3sVector& scan, const Nsec 
   return std::move(preproc.filtered_scan);
 }
 
-std::pair<Eigen::Vector3s, Eigen::Vector3s> LIO::motion_priors_from_imu(const Nsec current_lidar_time) {
+MotionPrior LIO::motion_prior_from_imu(const Nsec current_lidar_time) {
+  const Nsec start = lidar_state.time;
+  const Eigen::Vector3s& linear_velocity = lidar_state.linear_velocity;
   if (config.initialization_phase && !initialized_) {
     // assume static and
     initialize(current_lidar_time);
-    return {Eigen::Vector3s::Zero(), Eigen::Vector3s::Zero()};
+    return {.start_time = start, .linear_velocity = linear_velocity};
   }
   if (interval_stats.imu_count == 0) {
     std::cerr << "[WARNING] No Imu measurements in interval to average. Assuming constant velocity motion.\n";
-    return {Eigen::Vector3s::Zero(), lidar_state.angular_velocity};
+    return {.start_time = start, .linear_velocity = linear_velocity, .angular_velocity = lidar_state.angular_velocity};
   }
   const Eigen::Vector3s avg_body_accel = interval_stats.body_acceleration_sum / interval_stats.imu_count;
   const Eigen::Vector3s avg_ang_vel = interval_stats.angular_velocity_sum / interval_stats.imu_count;
@@ -322,7 +349,10 @@ std::pair<Eigen::Vector3s, Eigen::Vector3s> LIO::motion_priors_from_imu(const Ns
     std::cerr << "[WARNING] Erratic body acceleration computed, norm > 50 m/s2. Either IMU data is corrupted, or you "
                  "should report an issue.";
   }
-  return {avg_body_accel, avg_ang_vel};
+  return {.start_time = start,
+          .linear_velocity = linear_velocity,
+          .acceleration = avg_body_accel,
+          .angular_velocity = avg_ang_vel};
 }
 
 // ==========================
@@ -363,10 +393,10 @@ void LIO::add_imu_measurement(const ImuControl& base_imu) {
 
   // imu state update
   Eigen::Vector6s tau;
-  tau.head<3>() = imu_state.velocity * dt + compensated_accel * square(dt) / 2;
+  tau.head<3>() = imu_state.linear_velocity * dt + compensated_accel * square(dt) / 2;
   tau.tail<3>() = unbiased_ang_vel * dt;
   imu_state.pose = imu_state.pose * Sophus::SE3s::exp(tau);
-  imu_state.velocity += compensated_accel * dt;
+  imu_state.linear_velocity += compensated_accel * dt;
   imu_state.angular_velocity = unbiased_ang_vel;
   imu_state.time = base_imu.time;
 
@@ -440,18 +470,9 @@ Vector3sVector LIO::register_scan(Vector3sVector scan, const TimestampVector& ti
                                 " seconds delta to previous scan.");
   }
 
-  const auto [avg_body_accel, avg_ang_vel] = motion_priors_from_imu(current_lidar_time);
+  const MotionPrior motion = motion_prior_from_imu(current_lidar_time);
 
-  // compute relative motion using controls
-  auto relative_pose_at_time = [&](const Nsec time) -> Sophus::SE3s {
-    const auto dt = to_seconds<Scalar>(time - lidar_state.time);
-    Eigen::Vector6s tau;
-    tau.head<3>() = lidar_state.velocity * dt + (avg_body_accel * square(dt) / 2);
-    tau.tail<3>() = avg_ang_vel * dt;
-    return Sophus::SE3s::exp(tau);
-  };
-
-  const Sophus::SE3s initial_guess = lidar_state.pose * relative_pose_at_time(current_lidar_time);
+  const Sophus::SE3s initial_guess = lidar_state.pose * relative_pose_at_time(motion, current_lidar_time);
 
   // body acceleration filter
   const auto kf_step = step_body_accel_filter(
@@ -461,7 +482,8 @@ Vector3sVector LIO::register_scan(Vector3sVector scan, const TimestampVector& ti
   body_acceleration_covariance = kf_step.updated.covariance;
 
   if (config.deskew) {
-    deskew_scan(scan, timestamps, current_lidar_time, relative_pose_at_time);
+    SCOPED_PROFILER("Deskew");
+    deskew_scan(scan, timestamps, current_lidar_time, motion);
   }
   const std::size_t input_scan_size = scan.size();
   auto preproc_result = preprocess_scan(std::move(scan), config);
@@ -484,14 +506,14 @@ Vector3sVector LIO::register_scan(Vector3sVector scan, const TimestampVector& ti
 
     // estimate velocities and accelerations from the new pose
     const auto dt = to_seconds<Scalar>(current_lidar_time - lidar_state.time);
-    const Sophus::SE3s motion = lidar_state.pose.inverse() * optimized_pose;
-    const Eigen::Vector6s local_velocity = motion.log() / dt;
+    const Sophus::SE3s pose_delta = lidar_state.pose.inverse() * optimized_pose;
+    const Eigen::Vector6s local_velocity = pose_delta.log() / dt;
     const Eigen::Vector3s local_linear_acceleration =
-        (local_velocity.head<3>() - motion.so3().inverse() * lidar_state.velocity) / dt;
+        (local_velocity.head<3>() - pose_delta.so3().inverse() * lidar_state.linear_velocity) / dt;
 
     // update
     lidar_state.pose = optimized_pose;
-    lidar_state.velocity = local_velocity.head<3>();
+    lidar_state.linear_velocity = local_velocity.head<3>();
     lidar_state.angular_velocity = local_velocity.tail<3>();
     lidar_state.linear_acceleration = local_linear_acceleration;
   }

--- a/rko_lio/core/lio.hpp
+++ b/rko_lio/core/lio.hpp
@@ -155,8 +155,8 @@ private:
   /** First-scan path: stamps state, optionally seeds the map, logs the pose. */
   Vector3sVector bootstrap_first_scan(const Vector3sVector& scan, const Nsec current_lidar_time);
 
-  /** Average body acceleration and angular velocity over the IMU interval, with init-phase and no-IMU fallbacks. */
-  std::pair<Eigen::Vector3s, Eigen::Vector3s> motion_priors_from_imu(const Nsec current_lidar_time);
+  /** Motion prior for the coming scan, from the IMU interval average */
+  MotionPrior motion_prior_from_imu(const Nsec current_lidar_time);
 
   /** True if odometry initialization has been completed. */
   bool initialized_ = false;

--- a/rko_lio/core/util.hpp
+++ b/rko_lio/core/util.hpp
@@ -67,10 +67,27 @@ constexpr T to_seconds(const Nsec d) {
 struct State {
   Nsec time{0};
   Sophus::SE3s pose;
-  Eigen::Vector3s velocity = Eigen::Vector3s::Zero();
+  Eigen::Vector3s linear_velocity = Eigen::Vector3s::Zero();
   Eigen::Vector3s angular_velocity = Eigen::Vector3s::Zero();
   Eigen::Vector3s linear_acceleration = Eigen::Vector3s::Zero();
 };
+
+/** Constant-motion model anchored at the last registered state */
+struct MotionPrior {
+  Nsec start_time{0};
+  Eigen::Vector3s linear_velocity = Eigen::Vector3s::Zero();
+  Eigen::Vector3s acceleration = Eigen::Vector3s::Zero();
+  Eigen::Vector3s angular_velocity = Eigen::Vector3s::Zero();
+};
+
+/** Pose change from start_time to time */
+inline Sophus::SE3s relative_pose_at_time(const MotionPrior& prior, const Nsec time) {
+  const auto dt = to_seconds<Scalar>(time - prior.start_time);
+  Eigen::Vector6s tau;
+  tau.head<3>() = prior.linear_velocity * dt + (prior.acceleration * square(dt) / 2);
+  tau.tail<3>() = prior.angular_velocity * dt;
+  return Sophus::SE3s::exp(tau);
+}
 
 struct ImuBias {
   Eigen::Vector3s accelerometer = Eigen::Vector3s::Zero();

--- a/rko_lio/python/pybind/rko_lio_pybind.cpp
+++ b/rko_lio/python/pybind/rko_lio_pybind.cpp
@@ -117,7 +117,7 @@ PYBIND11_MODULE(rko_lio_pybind, m) {
       .def("map_point_cloud", [](LIO& self) { return self.map.points(); })
       .def("pose", [](LIO& self) { return self.lidar_state.pose.matrix(); })
       .def("imu_pose", [](LIO& self) { return self.imu_state.pose.matrix(); })
-      .def("imu_velocity", [](LIO& self) { return self.imu_state.velocity; })
+      .def("imu_velocity", [](LIO& self) { return self.imu_state.linear_velocity; })
       .def("imu_time", [](LIO& self) { return self.imu_state.time.count(); })
       .def("poses_with_timestamps",
            [](LIO& self) {

--- a/rko_lio/ros/base_node.cpp
+++ b/rko_lio/ros/base_node.cpp
@@ -274,7 +274,7 @@ void BaseNode::publish_odometry(const core::State& state,
   odom_msg.header.frame_id = odom_frame;
   odom_msg.child_frame_id = base_frame;
   odom_msg.pose.pose = utils::sophus_to_pose(state.pose);
-  utils::eigen_vector_to_ros_xyz(state.velocity, odom_msg.twist.twist.linear);
+  utils::eigen_vector_to_ros_xyz(state.linear_velocity, odom_msg.twist.twist.linear);
   utils::eigen_vector_to_ros_xyz(state.angular_velocity, odom_msg.twist.twist.angular);
   publisher->publish(odom_msg);
 }

--- a/tests/core/test_imu_integration.cpp
+++ b/tests/core/test_imu_integration.cpp
@@ -175,7 +175,7 @@ TEST_CASE("Static IMU at rest: imu_state translation stays zero", "[imu_integrat
 
   REQUIRE(lio.interval_stats.imu_count == N);
   REQUIRE(lio.imu_state.pose.translation().norm() < TOL);
-  REQUIRE(lio.imu_state.velocity.norm() < TOL);
+  REQUIRE(lio.imu_state.linear_velocity.norm() < TOL);
 }
 
 TEST_CASE("Constant body acceleration: position grows as 0.5 * a * t^2", "[imu_integration]") {
@@ -206,9 +206,9 @@ TEST_CASE("Constant body acceleration: position grows as 0.5 * a * t^2", "[imu_i
   REQUIRE_THAT(lio.imu_state.pose.translation().x(), WithinAbs(0.5 * a_x * T * T, pos_tol));
   REQUIRE(std::abs(lio.imu_state.pose.translation().y()) < TOL);
   REQUIRE(std::abs(lio.imu_state.pose.translation().z()) < TOL);
-  REQUIRE_THAT(lio.imu_state.velocity.x(), WithinAbs(a_x * T, vel_tol));
-  REQUIRE(std::abs(lio.imu_state.velocity.y()) < TOL);
-  REQUIRE(std::abs(lio.imu_state.velocity.z()) < TOL);
+  REQUIRE_THAT(lio.imu_state.linear_velocity.x(), WithinAbs(a_x * T, vel_tol));
+  REQUIRE(std::abs(lio.imu_state.linear_velocity.y()) < TOL);
+  REQUIRE(std::abs(lio.imu_state.linear_velocity.z()) < TOL);
 }
 
 TEST_CASE("register_scan resets imu_state to optimized pose", "[imu_integration]") {
@@ -250,7 +250,7 @@ TEST_CASE("register_scan resets imu_state to optimized pose", "[imu_integration]
   REQUIRE(lio.poses_with_timestamps.size() == 2);
   REQUIRE(approx_equal(lio.imu_state.pose, lio.lidar_state.pose, EXACT_TOL));
   REQUIRE_THAT(to_seconds(lio.imu_state.time), WithinAbs(to_seconds(lio.lidar_state.time), 1e-12));
-  REQUIRE(approx_equal(lio.imu_state.velocity, lio.lidar_state.velocity, EXACT_TOL));
+  REQUIRE(approx_equal(lio.imu_state.linear_velocity, lio.lidar_state.linear_velocity, EXACT_TOL));
   REQUIRE(approx_equal(lio.imu_state.angular_velocity, lio.lidar_state.angular_velocity, EXACT_TOL));
   REQUIRE(approx_equal(lio.imu_state.linear_acceleration, lio.lidar_state.linear_acceleration, EXACT_TOL));
 }


### PR DESCRIPTION
last of my performance PRs from #157. for real this time, I have no more ideas left.

deskewing earlier called `Sophus::SE3::exp` once per point, which turns out wasn't the brightest idea, nor probably what sophus' intended use case is. By hoisting the transforms out of the loop, and not doing quaternion multiplications, keeping everything mathematically same, the compute can be reduced by a bit (per point that's two sincos calls down to one, and a sqrt plus three divides inside exp gone). 

The ideas:
- reassociate pose multiplication to `T_end^-1 * (T(t) * p)`, instead of the earlier SE3 - SE3 compose then SE3 - point compose.
- the angular velocity is constant over a scan, so only the angle varies per
  point. Using rodrigues formula and the left jacobian of SO3 explicitly in the function body, allows to simplify quite a bit of the math with the fixed angular axis.
- with a fixed axis, `R p` and `V rho` are cross products, no 3x3 to build

Tested this on a few dev bags, and there is an improvement. And i'll take that. Doing the same transformation hoist for other batch transforms in the code doesn't have a similar or any improvement. So those weren't changed to keep readability (and those parts are likely memory-bound unlike the deskew which seems to be compute-bound). 

another small api break, as i cleaned up more of the naming as in #171: `core::State::velocity` -> `linear_velocity`.

There is another idea which can exploit the sampling structure of a lidar scan (a column firing all at the same time means those can be batched with the same transform computed once). But that bakes in more knowledge of the sensor here, which I'd avoid with this project. Maybe i'll have an independent package that just deskews scans, if i ever end up needing it...