### PR TITLE
ros: catch std::exception on recoverable LIO errors

### DIFF
--- a/rko_lio/ros/online_imu_rate_node.cpp
+++ b/rko_lio/ros/online_imu_rate_node.cpp
@@ -117,7 +117,7 @@ public:
       }
       publish_lidar_outputs(deskewed_scan);
       publish_tf(lio->lidar_state);
-    } catch (const std::invalid_argument& ex) {
+    } catch (const std::exception& ex) {
       RCLCPP_ERROR_STREAM(node->get_logger(), "Encountered error, dropping scan. Error: " << ex.what());
     }
   }

--- a/rko_lio/ros/threaded_node.cpp
+++ b/rko_lio/ros/threaded_node.cpp
@@ -78,7 +78,7 @@ void ThreadedNode::lidar_callback(const sensor_msgs::msg::PointCloud2::ConstShar
     if (atomic_can_process) {
       sync_condition_variable.notify_one();
     }
-  } catch (const std::invalid_argument& ex) {
+  } catch (const std::exception& ex) {
     RCLCPP_ERROR_STREAM(node->get_logger(), "Encountered error, dropping scan: Error. " << ex.what());
   }
 }
@@ -113,7 +113,7 @@ void ThreadedNode::registration_loop() {
         publish_lidar_outputs(deskewed_scan);
         publish_tf(lio->lidar_state);
       }
-    } catch (const std::invalid_argument& ex) {
+    } catch (const std::exception& ex) {
       RCLCPP_ERROR_STREAM(node->get_logger(), "Encountered error, dropping scan. Error: " << ex.what());
     }
     registration_busy = false;


### PR DESCRIPTION
## Summary

Recoverable LIO failures currently abort the whole ROS node.

`LIO` / ICP throws `std::runtime_error` when registration finds **zero correspondences** (`"Number of correspondences are 0."`). Timestamp processing can also throw `std::runtime_error`. The online ROS paths only catch `std::invalid_argument`, so those exceptions leave the worker thread, call `std::terminate()`, and the process dies with **SIGABRT**.

This PR widens the existing drop-and-log handlers to `catch (const std::exception&)` in:

- `ThreadedNode::lidar_callback`
- `ThreadedNode::registration_loop`
- `OnlineImuRateNode::lidar_callback`

Behavior on failure is unchanged: log the error and drop the scan. No odometry / ICP logic changes.

## Motivation / repro

Seen with Velodyne + IMU on ROS 2 Jazzy (`ros-jazzy-rko-lio` 0.2.0; same catch pattern on current `master`):

1. Run `online_node` with deskew enabled.
2. Hit a frame where ICP gets 0 correspondences (lost track, bad motion prior, sparse scene, etc.).
3. Node aborts:

#8  std::terminate()
#9  __cxa_throw
#10 …
#11 rko_lio::core::LIO::register_scan(…)
#12 rko_lio::ros::ThreadedNode::registration_loop()

Apport title: `online_node crashed with SIGABRT in std::terminate()`.

## Why not change the throw type?

Other recoverable paths already throw `std::runtime_error` (e.g. timestamp config). Catching `std::exception` at the ROS boundary matches “drop this scan, keep the node alive” without chasing every throw site. Fatal setup errors (missing frame id / bad extrinsic at init) still happen outside these handlers.

## Test plan

- [x] Existing core/ROS tests pass
- [x] Manual: feed a bag that previously SIGABRT’d on 0 correspondences → node logs `Encountered error, dropping scan` and keeps running
- [x] Manual: normal outdoor sequence still produces odom + map

## Related

Also aligns the online workers with `offline_node`, which already catches `std::exception` in at least one path.