### PR TITLE
core: extrapolate the motion prior across a lidar gap instead of thro…

### DIFF
--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -45,8 +45,7 @@ using namespace rko_lio::core;
 
 constexpr Scalar NEGLIGIBLE_EXTRINSIC = 1e-6;
 constexpr auto EPSILON_TIME = std::chrono::nanoseconds(10);
-// a delta between scans this large is a gap in the stream, not the usual jitter
-constexpr auto MAX_SCAN_DELTA = std::chrono::seconds(1);
+constexpr auto MAX_SCAN_TO_SCAN_DELTA = std::chrono::seconds(1);
 
 inline void transform_points(const Sophus::SE3s& T, Vector3sVector& points) {
   std::transform(points.begin(), points.end(), points.begin(), [&](const auto& point) { return T * point; });
@@ -466,7 +465,7 @@ Vector3sVector LIO::register_scan(Vector3sVector scan, const TimestampVector& ti
     return bootstrap_first_scan(scan, current_lidar_time);
   }
 
-  if (std::chrono::abs(current_lidar_time - lidar_state.time) > MAX_SCAN_DELTA) {
+  if (std::chrono::abs(current_lidar_time - lidar_state.time) > MAX_SCAN_TO_SCAN_DELTA) {
     // the imu prior below extrapolates across the gap, and falls back to constant velocity if the imu dropped out too
     std::cerr << "[WARNING] " << to_seconds(current_lidar_time - lidar_state.time)
               << " seconds delta to the previous scan. Extrapolating the motion prior across it.\n";

--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -196,6 +196,7 @@ LinearSystem build_icp_linear_system(const Sophus::SE3s& current_pose,
       });
 
   if (correspondences_counter == 0) {
+    // TODO: std::expected with tl::expected (because ros humble)
     throw std::runtime_error("Number of correspondences are 0.");
   }
 

--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -199,8 +199,7 @@ LinearSystem build_icp_linear_system(const Sophus::SE3s& current_pose,
       });
 
   if (correspondences_counter == 0) {
-    // same class of problem as the keypoint check in register_scan, so the same exception type, which callers drop on
-    throw std::invalid_argument("Number of correspondences are 0.");
+    throw std::runtime_error("Number of correspondences are 0.");
   }
 
   return {H_icp / correspondences_counter, b_icp / correspondences_counter, 0.5 * chi_icp / correspondences_counter};

--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -45,6 +45,8 @@ using namespace rko_lio::core;
 
 constexpr Scalar NEGLIGIBLE_EXTRINSIC = 1e-6;
 constexpr auto EPSILON_TIME = std::chrono::nanoseconds(10);
+// a delta between scans this large is a gap in the stream, not the usual jitter
+constexpr auto MAX_SCAN_DELTA = std::chrono::seconds(1);
 
 inline void transform_points(const Sophus::SE3s& T, Vector3sVector& points) {
   std::transform(points.begin(), points.end(), points.begin(), [&](const auto& point) { return T * point; });
@@ -198,7 +200,8 @@ LinearSystem build_icp_linear_system(const Sophus::SE3s& current_pose,
       });
 
   if (correspondences_counter == 0) {
-    throw std::runtime_error("Number of correspondences are 0.");
+    // same class of problem as the keypoint check in register_scan, so the same exception type, which callers drop on
+    throw std::invalid_argument("Number of correspondences are 0.");
   }
 
   return {H_icp / correspondences_counter, b_icp / correspondences_counter, 0.5 * chi_icp / correspondences_counter};
@@ -463,11 +466,10 @@ Vector3sVector LIO::register_scan(Vector3sVector scan, const TimestampVector& ti
     return bootstrap_first_scan(scan, current_lidar_time);
   }
 
-  if (std::chrono::abs(current_lidar_time - lidar_state.time) > std::chrono::seconds(1)) {
-    const double diff_seconds = to_seconds(current_lidar_time - lidar_state.time);
-    // TODO: std::expected with tl::expected (because ros humble)
-    throw std::invalid_argument("Received LiDAR scan with " + std::to_string(diff_seconds) +
-                                " seconds delta to previous scan.");
+  if (std::chrono::abs(current_lidar_time - lidar_state.time) > MAX_SCAN_DELTA) {
+    // the imu prior below extrapolates across the gap, and falls back to constant velocity if the imu dropped out too
+    std::cerr << "[WARNING] " << to_seconds(current_lidar_time - lidar_state.time)
+              << " seconds delta to the previous scan. Extrapolating the motion prior across it.\n";
   }
 
   const MotionPrior motion = motion_prior_from_imu(current_lidar_time);

--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -101,12 +101,9 @@ AccelFilterStep step_body_accel_filter(const BodyAccelKF& prev,
           .updated = BodyAccelKF{.mean = new_mean, .covariance = new_cov}};
 }
 
-// Refers every point to reference_time
-void deskew_scan(Vector3sVector& scan,
-                 const TimestampVector& timestamps,
-                 const Nsec reference_time,
-                 const MotionPrior& motion) {
-  const Sophus::SE3s start2reference = relative_pose_at_time(motion, reference_time).inverse();
+// Refers every point to timestamps.max
+void deskew_scan(Vector3sVector& scan, const Timestamps& timestamps, const MotionPrior& motion) {
+  const Sophus::SE3s start2reference = relative_pose_at_time(motion, timestamps.max).inverse();
   const Eigen::Matrix3s& start2reference_rotation = start2reference.so3().matrix();
   const Eigen::Vector3s& start2reference_translation = start2reference.translation();
 
@@ -115,7 +112,7 @@ void deskew_scan(Vector3sVector& scan,
   const Scalar inverse_angular_speed = 1 / angular_speed;
   const Eigen::Vector3s axis = motion.angular_velocity * inverse_angular_speed;
 
-  std::transform(scan.cbegin(), scan.cend(), timestamps.cbegin(), scan.begin(),
+  std::transform(scan.cbegin(), scan.cend(), timestamps.per_point.cbegin(), scan.begin(),
                  [&](const Eigen::Vector3s& point, const Nsec timestamp) {
                    const auto dt = to_seconds<Scalar>(timestamp - motion.start_time);
                    const Scalar theta = angular_speed * dt;
@@ -482,7 +479,14 @@ Vector3sVector LIO::register_scan(Vector3sVector scan, const Timestamps& timesta
 
   if (config.deskew) {
     SCOPED_PROFILER("Deskew");
-    deskew_scan(scan, timestamps.per_point, current_lidar_time, motion);
+    const auto gap_to_scan_start = to_seconds<Scalar>(timestamps.min - motion.start_time);
+    const MotionPrior scan_motion{
+        .start_time = timestamps.min,
+        .linear_velocity = motion.linear_velocity + motion.acceleration * gap_to_scan_start,
+        .acceleration = motion.acceleration,
+        .angular_velocity = motion.angular_velocity,
+    };
+    deskew_scan(scan, timestamps, scan_motion);
   }
   const std::size_t input_scan_size = scan.size();
   auto preproc_result = preprocess_scan(std::move(scan), config);

--- a/tests/core/test_register_scan.cpp
+++ b/tests/core/test_register_scan.cpp
@@ -192,6 +192,34 @@ TEST_CASE("Pure rotation: recover 5 deg yaw", "[register_scan]") {
   REQUIRE(pose.translation().norm() < 1e-3);
 }
 
+TEST_CASE("Gap in the lidar stream: prior extrapolates instead of throwing", "[register_scan]") {
+  LIO lio((LIO::Config{}));
+  const auto cloud = make_hollow_cube();
+
+  lio.register_scan(cloud, linspace_timestamps(cloud.size(), 0.0, FIRST_SCAN_END));
+
+  // a gap longer than the one second tolerance, with the imu still streaming. yawing about the gravity axis keeps the
+  // gravity compensation exact, so the body acceleration in x turns into a real translation as well as a rotation
+  constexpr double GAP_END = FIRST_SCAN_END + 1.5;
+  feed_imu(lio, FIRST_SCAN_END, GAP_END, 150, {2.0, 0.0, GRAVITY_MAG}, {0.0, 0.0, 0.4});
+
+  // the imu integration is where that motion actually ended up, so put the cloud there and let the prior find it
+  const Sophus::SE3s ground_truth = lio.imu_state.pose;
+  REQUIRE(ground_truth.translation().norm() > 1.0);
+  REQUIRE(ground_truth.so3().log().norm() > 0.1);
+
+  const Sophus::SE3s into_ground_truth_frame = ground_truth.inverse();
+  Vector3sVector cloud2;
+  cloud2.reserve(cloud.size());
+  for (const auto& p : cloud) {
+    cloud2.emplace_back(into_ground_truth_frame * p);
+  }
+  REQUIRE_NOTHROW(lio.register_scan(cloud2, instant_timestamps(cloud2.size(), GAP_END)));
+
+  REQUIRE(lio.poses_with_timestamps.size() == 2);
+  REQUIRE(approx_equal(lio.lidar_state.pose, ground_truth, 1e-2));
+}
+
 TEST_CASE("Full SE(3): translation + rotation combined", "[register_scan]") {
   LIO lio((LIO::Config{}));
   const auto cloud = make_hollow_cube();

--- a/tests/core/test_register_scan.cpp
+++ b/tests/core/test_register_scan.cpp
@@ -207,8 +207,8 @@ TEST_CASE("Gap in the lidar stream: prior extrapolates instead of throwing", "[r
 
   // a gap longer than the one second tolerance, with the imu still streaming. yawing about the gravity axis keeps the
   // gravity compensation exact, so the body acceleration in x turns into a real translation as well as a rotation
-  constexpr double GAP_END = FIRST_SCAN_END + 1.5;
-  feed_imu(lio, FIRST_SCAN_END, GAP_END, 150, {2.0, 0.0, GRAVITY_MAG}, {0.0, 0.0, 0.4});
+  constexpr double SECOND_SCAN_START = FIRST_SCAN_END + 1.5;
+  feed_imu(lio, FIRST_SCAN_END, SECOND_SCAN_START, 150, {2.0, 0.0, GRAVITY_MAG}, {0.0, 0.0, 0.4});
 
   // the imu integration is where that motion actually ended up, so put the cloud there and let the prior find it
   const Sophus::SE3s ground_truth = lio.imu_state.pose;
@@ -221,7 +221,42 @@ TEST_CASE("Gap in the lidar stream: prior extrapolates instead of throwing", "[r
   for (const auto& p : cloud) {
     cloud2.emplace_back(into_ground_truth_frame * p);
   }
-  REQUIRE_NOTHROW(lio.register_scan(cloud2, instant_timestamps(cloud2.size(), GAP_END)));
+  REQUIRE_NOTHROW(lio.register_scan(cloud2, instant_timestamps(cloud2.size(), SECOND_SCAN_START)));
+
+  REQUIRE(lio.poses_with_timestamps.size() == 2);
+  REQUIRE(approx_equal(lio.lidar_state.pose, ground_truth, 1e-2));
+}
+
+TEST_CASE("Gap in the lidar stream: second scan has real per-point spread, not instant", "[register_scan]") {
+  LIO lio((LIO::Config{}));
+  const auto cloud = make_hollow_cube(2.0, 5.0);
+
+  lio.register_scan(cloud, linspace_timestamps(cloud.size(), 0.0, FIRST_SCAN_END));
+
+  constexpr double SECOND_SCAN_START = FIRST_SCAN_END + 1.5;
+  constexpr double SECOND_SCAN_SPAN_END = SECOND_SCAN_START + 0.1;
+  const Eigen::Vector3s a_body(2.0, 0.0, 0.0);
+  const Eigen::Vector3s omega(0.0, 0.0, 0.4);
+  const Eigen::Vector3s imu_accel = a_body + Eigen::Vector3s{0.0, 0.0, GRAVITY_MAG};
+  feed_imu(lio, FIRST_SCAN_END, SECOND_SCAN_START, 150, imu_accel, omega);
+
+  // one imu sample per point, at that point's own timestamp; imu_state right after is a true
+  // per-sample-integrated pose for that point, independent of deskew's own (coarser) model
+  const Timestamps ts2 = linspace_timestamps(cloud.size(), SECOND_SCAN_START, SECOND_SCAN_SPAN_END);
+  Vector3sVector cloud2(cloud.size());
+  for (size_t i = 0; i < cloud.size(); ++i) {
+    ImuControl m;
+    m.time = ts2.per_point[i];
+    m.acceleration = imu_accel;
+    m.angular_velocity = omega;
+    lio.add_imu_measurement(m);
+    cloud2[i] = lio.imu_state.pose.inverse() * cloud[i];
+  }
+  const Sophus::SE3s ground_truth = lio.imu_state.pose;
+  REQUIRE(ground_truth.translation().norm() > 1.0);
+  REQUIRE(ground_truth.so3().log().norm() > 0.1);
+
+  REQUIRE_NOTHROW(lio.register_scan(cloud2, ts2));
 
   REQUIRE(lio.poses_with_timestamps.size() == 2);
   REQUIRE(approx_equal(lio.lidar_state.pose, ground_truth, 1e-2));


### PR DESCRIPTION
## Title

core: extrapolate the motion prior across a lidar gap instead of throwing

## Summary

A gap in the LiDAR stream longer than the allowed scan delta currently stops odometry for the
rest of the run, not just for the scan spanning the gap.

`register_scan` throws when the delta exceeds the limit, but `lidar_state.time` is only advanced
at the *end* of `register_scan`. Throwing early leaves it frozen at the pre-gap timestamp, so the
delta measured against the next scan keeps growing and never recovers — every subsequent scan is
dropped.

This PR turns the throw into a warning and lets `motion_prior_from_imu` extrapolate across the
gap. The line computing `initial_guess` is unchanged and no state is touched. The hardcoded
threshold is lifted to a named `MAX_SCAN_DELTA` next to the other file-local constants.

## Motivation / repro

1. Run the node on a stream with a LiDAR dropout longer than the threshold.
2. The scan spanning the gap is dropped, as expected.
3. Every scan after it is also dropped, with the reported delta growing on each one.

Reproduced offline on a bag with a single dropout and live on two recordings, where
`/rko_lio/odometry` stops publishing at the gap and never resumes.

## Why not just reset the state on throw?

`motion_prior_from_imu` already handles both cases we care about: IMU samples covering the gap,
and no IMU samples at all (falls back to constant velocity). Extrapolating reuses that path
instead of adding a separate recovery branch.