### PR TITLE
core: timestamp struct handling cleanup, min max compute once

### DIFF
--- a/rko_lio/core/lio.cpp
+++ b/rko_lio/core/lio.cpp
@@ -452,12 +452,11 @@ void LIO::add_imu_measurement(const Sophus::SE3s& extrinsic_imu2base, const ImuC
 
 // ============================ lidar ===============================
 
-Vector3sVector LIO::register_scan(Vector3sVector scan, const TimestampVector& timestamps) {
-  if (timestamps.empty()) {
+Vector3sVector LIO::register_scan(Vector3sVector scan, const Timestamps& timestamps) {
+  if (timestamps.per_point.empty()) {
     throw std::invalid_argument("LIO::register_scan: timestamps must not be empty.");
   }
-  // TODO: redundant max compute as its available after process_timestamps
-  const Nsec current_lidar_time = *std::max_element(timestamps.cbegin(), timestamps.cend());
+  const Nsec current_lidar_time = timestamps.max;
 
   if (lidar_state.time < EPSILON_TIME) {
     return bootstrap_first_scan(scan, current_lidar_time);
@@ -483,7 +482,7 @@ Vector3sVector LIO::register_scan(Vector3sVector scan, const TimestampVector& ti
 
   if (config.deskew) {
     SCOPED_PROFILER("Deskew");
-    deskew_scan(scan, timestamps, current_lidar_time, motion);
+    deskew_scan(scan, timestamps.per_point, current_lidar_time, motion);
   }
   const std::size_t input_scan_size = scan.size();
   auto preproc_result = preprocess_scan(std::move(scan), config);
@@ -532,7 +531,7 @@ Vector3sVector LIO::register_scan(Vector3sVector scan, const TimestampVector& ti
 }
 
 Vector3sVector
-LIO::register_scan(const Sophus::SE3s& extrinsic_lidar2base, Vector3sVector scan, const TimestampVector& timestamps) {
+LIO::register_scan(const Sophus::SE3s& extrinsic_lidar2base, Vector3sVector scan, const Timestamps& timestamps) {
   if (extrinsic_lidar2base.log().norm() < NEGLIGIBLE_EXTRINSIC) {
     return register_scan(std::move(scan), timestamps);
   }

--- a/rko_lio/core/lio.hpp
+++ b/rko_lio/core/lio.hpp
@@ -28,6 +28,7 @@
  */
 
 #pragma once
+#include "process_timestamps.hpp"
 #include "util.hpp"
 #include "voxel_hash_map.hpp"
 
@@ -120,21 +121,23 @@ public:
    * Register a LiDAR scan, applying deskewing based on the initial motion guess
    * and clipping points beyond valid range.
    * @param scan Input raw point cloud.
-   * @param timestamps Absolute timestamps corresponding to each scan point.
+   * @param timestamps Absolute per-point timestamps, plus the scan's own min/max, as already
+   *   computed by process_timestamps.
    * @return Deskewed and clipped point cloud.
    */
-  Vector3sVector register_scan(Vector3sVector scan, const TimestampVector& timestamps);
+  Vector3sVector register_scan(Vector3sVector scan, const Timestamps& timestamps);
 
   /**
    * Register a LiDAR scan for which the extrinsic calibration from lidar to base
    * has already been applied.
    * @param extrinsic_lidar2base Extrinsic from lidar to base frame.
    * @param scan Input raw point cloud.
-   * @param timestamps Absolute timestamps corresponding to each scan point.
+   * @param timestamps Absolute per-point timestamps, plus the scan's own min/max, as already
+   *   computed by process_timestamps.
    * @return Deskewed and clipped scan in the original lidar frame.
    */
   Vector3sVector
-  register_scan(const Sophus::SE3s& extrinsic_lidar2base, Vector3sVector scan, const TimestampVector& timestamps);
+  register_scan(const Sophus::SE3s& extrinsic_lidar2base, Vector3sVector scan, const Timestamps& timestamps);
 
   /** Sequence of registered scan poses with corresponding timestamps. */
   std::vector<std::pair<Nsec, Sophus::SE3s>> poses_with_timestamps;

--- a/rko_lio/python/pybind/rko_lio_pybind.cpp
+++ b/rko_lio/python/pybind/rko_lio_pybind.cpp
@@ -97,23 +97,28 @@ PYBIND11_MODULE(rko_lio_pybind, m) {
           "extrinsic_imu2base"_a, "acceleration"_a, "angular_velocity"_a, "time"_a)
       .def(
           "register_scan",
-          [](LIO& self, const std::vector<Eigen::Vector3s>& scan, const std::vector<int64_t>& timestamps_ns) {
-            TimestampVector timestamps(timestamps_ns.size());
-            std::transform(timestamps_ns.cbegin(), timestamps_ns.cend(), timestamps.begin(),
+          [](LIO& self, const std::vector<Eigen::Vector3s>& scan, const std::vector<int64_t>& timestamps_ns,
+             const int64_t start_time_ns, const int64_t end_time_ns) {
+            TimestampVector per_point(timestamps_ns.size());
+            std::transform(timestamps_ns.cbegin(), timestamps_ns.cend(), per_point.begin(),
                            [](const int64_t t) { return Nsec(t); });
-            return self.register_scan(scan, timestamps);
+            return self.register_scan(
+                scan,
+                Timestamps{.min = Nsec(start_time_ns), .max = Nsec(end_time_ns), .per_point = std::move(per_point)});
           },
-          "scan"_a, "timestamps"_a)
+          "scan"_a, "timestamps"_a, "start_time_ns"_a, "end_time_ns"_a)
       .def(
           "register_scan",
           [](LIO& self, const Eigen::Matrix4s& extrinsic_lidar2base, const std::vector<Eigen::Vector3s>& scan,
-             const std::vector<int64_t>& timestamps_ns) {
-            TimestampVector timestamps(timestamps_ns.size());
-            std::transform(timestamps_ns.cbegin(), timestamps_ns.cend(), timestamps.begin(),
+             const std::vector<int64_t>& timestamps_ns, const int64_t start_time_ns, const int64_t end_time_ns) {
+            TimestampVector per_point(timestamps_ns.size());
+            std::transform(timestamps_ns.cbegin(), timestamps_ns.cend(), per_point.begin(),
                            [](const int64_t t) { return Nsec(t); });
-            return self.register_scan(Sophus::SE3s(extrinsic_lidar2base), scan, timestamps);
+            return self.register_scan(
+                Sophus::SE3s(extrinsic_lidar2base), scan,
+                Timestamps{.min = Nsec(start_time_ns), .max = Nsec(end_time_ns), .per_point = std::move(per_point)});
           },
-          "extrinsic_lidar2base"_a, "scan"_a, "timestamps"_a)
+          "extrinsic_lidar2base"_a, "scan"_a, "timestamps"_a, "start_time_ns"_a, "end_time_ns"_a)
       .def("map_point_cloud", [](LIO& self) { return self.map.points(); })
       .def("pose", [](LIO& self) { return self.lidar_state.pose.matrix(); })
       .def("imu_pose", [](LIO& self) { return self.imu_state.pose.matrix(); })

--- a/rko_lio/python/rko_lio/lio.py
+++ b/rko_lio/python/rko_lio/lio.py
@@ -153,6 +153,8 @@ class LIO:
         scan: np.ndarray,
         timestamps: np.ndarray,
         extrinsic_lidar2base: np.ndarray | None = None,
+        start_time_ns: int | None = None,
+        end_time_ns: int | None = None,
     ):
         scan_arr = np.asarray(scan, dtype=np.float64)
         times_arr = np.ascontiguousarray(np.asarray(timestamps), dtype=np.int64)
@@ -162,11 +164,13 @@ class LIO:
             raise ValueError(f"timestamps: expected ({scan_arr.shape[0]},), got {times_arr.shape}")
         scan_vec = _Vector3sVector(scan_arr)
         time_vec = _VectorInt64(times_arr)
+        start_ns = int(times_arr.min()) if start_time_ns is None else start_time_ns
+        end_ns = int(times_arr.max()) if end_time_ns is None else end_time_ns
         if extrinsic_lidar2base is None:
-            ret_scan = self._impl.register_scan(scan_vec, time_vec)
+            ret_scan = self._impl.register_scan(scan_vec, time_vec, start_ns, end_ns)
             return np.asarray(ret_scan)
         extr = _as_se3("extrinsic_lidar2base", extrinsic_lidar2base)
-        ret_scan = self._impl.register_scan(extr, scan_vec, time_vec)
+        ret_scan = self._impl.register_scan(extr, scan_vec, time_vec, start_ns, end_ns)
         return np.asarray(ret_scan)
 
     def poses_with_timestamps(self):

--- a/rko_lio/python/rko_lio/lio_pipeline.py
+++ b/rko_lio/python/rko_lio/lio_pipeline.py
@@ -157,6 +157,8 @@ class LIOPipeline:
                 scan,
                 timestamps,
                 extrinsic_lidar2base=self.extrinsic_lidar2base,
+                start_time_ns=start_time_ns,
+                end_time_ns=end_time_ns,
             )
         except ValueError as e:
             print(

--- a/rko_lio/ros/base_node.cpp
+++ b/rko_lio/ros/base_node.cpp
@@ -245,13 +245,12 @@ LidarScan BaseNode::process_lidar_msg(const sensor_msgs::msg::PointCloud2::Const
   return scan;
 }
 
-core::Vector3sVector BaseNode::register_scan_locked(core::Vector3sVector scan,
-                                                    const core::TimestampVector& time_vector) {
+core::Vector3sVector BaseNode::register_scan_locked(core::Vector3sVector scan, const core::Timestamps& timestamps) {
   std::unique_lock lock(local_map_mutex, std::defer_lock);
   if (publish_local_map) {
     lock.lock(); // map publish thread may access map simultaneously
   }
-  return lio->register_scan(extrinsic_lidar2base, std::move(scan), time_vector);
+  return lio->register_scan(extrinsic_lidar2base, std::move(scan), timestamps);
 }
 
 void BaseNode::publish_lidar_outputs(const core::Vector3sVector& deskewed_scan) const {

--- a/rko_lio/ros/base_node.hpp
+++ b/rko_lio/ros/base_node.hpp
@@ -113,7 +113,7 @@ public:
 
   LidarScan process_lidar_msg(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& lidar_msg) const;
 
-  core::Vector3sVector register_scan_locked(core::Vector3sVector scan, const core::TimestampVector& time_vector);
+  core::Vector3sVector register_scan_locked(core::Vector3sVector scan, const core::Timestamps& timestamps);
 
   void publish_lidar_outputs(const core::Vector3sVector& deskewed_scan) const;
 

--- a/rko_lio/ros/online_imu_rate_node.cpp
+++ b/rko_lio/ros/online_imu_rate_node.cpp
@@ -109,8 +109,7 @@ public:
 
     try {
       LidarScan scan = process_lidar_msg(lidar_msg);
-      const core::Vector3sVector deskewed_scan =
-          register_scan_locked(std::move(scan.points), scan.timestamps.per_point);
+      const core::Vector3sVector deskewed_scan = register_scan_locked(std::move(scan.points), scan.timestamps);
       if (deskewed_scan.empty()) {
         // first scan is skipped and an empty scan is returned. nothing to publish.
         return;

--- a/rko_lio/ros/threaded_node.cpp
+++ b/rko_lio/ros/threaded_node.cpp
@@ -106,8 +106,7 @@ void ThreadedNode::registration_loop() {
     buffer_lock.unlock(); // we dont touch the buffers anymore
 
     try {
-      const core::Vector3sVector deskewed_scan =
-          register_scan_locked(std::move(scan.points), scan.timestamps.per_point);
+      const core::Vector3sVector deskewed_scan = register_scan_locked(std::move(scan.points), scan.timestamps);
       if (!deskewed_scan.empty()) {
         // TODO: first scan is skipped and an empty scan is returned. improve how we handle this
         publish_lidar_outputs(deskewed_scan);

--- a/tests/core/test_imu_integration.cpp
+++ b/tests/core/test_imu_integration.cpp
@@ -12,6 +12,7 @@ using rko_lio::core::GRAVITY_MAG;
 using rko_lio::core::ImuControl;
 using rko_lio::core::LIO;
 using rko_lio::core::Nsec;
+using rko_lio::core::Timestamps;
 using rko_lio::core::TimestampVector;
 using rko_lio::core::to_seconds;
 using rko_lio::core::Vector3sVector;
@@ -223,12 +224,13 @@ TEST_CASE("register_scan resets imu_state to optimized pose", "[imu_integration]
   constexpr double SECOND_SCAN_END = FIRST_SCAN_END + DT;
 
   // Build per-point timestamps for the first scan (linspace from 0 to FIRST_SCAN_END).
-  TimestampVector ts1;
-  ts1.reserve(cloud.size());
+  TimestampVector ts1_per_point;
+  ts1_per_point.reserve(cloud.size());
   for (size_t i = 0; i < cloud.size(); ++i) {
     const double frac = cloud.size() == 1 ? 0.0 : static_cast<double>(i) / static_cast<double>(cloud.size() - 1);
-    ts1.emplace_back(ns_from_seconds(FIRST_SCAN_END * frac));
+    ts1_per_point.emplace_back(ns_from_seconds(FIRST_SCAN_END * frac));
   }
+  const Timestamps ts1{.min = ns_from_seconds(0.0), .max = ns_from_seconds(FIRST_SCAN_END), .per_point = ts1_per_point};
   lio.register_scan(cloud, ts1);
 
   // Static IMU samples between the two scans. Use enough samples that interval_stats
@@ -244,7 +246,9 @@ TEST_CASE("register_scan resets imu_state to optimized pose", "[imu_integration]
   }
 
   // Single-instant timestamps for the second scan -> deskewing is identity.
-  const TimestampVector ts2(cloud.size(), ns_from_seconds(SECOND_SCAN_END));
+  const Timestamps ts2{.min = ns_from_seconds(SECOND_SCAN_END),
+                       .max = ns_from_seconds(SECOND_SCAN_END),
+                       .per_point = TimestampVector(cloud.size(), ns_from_seconds(SECOND_SCAN_END))};
   lio.register_scan(cloud, ts2);
 
   REQUIRE(lio.poses_with_timestamps.size() == 2);

--- a/tests/core/test_register_scan.cpp
+++ b/tests/core/test_register_scan.cpp
@@ -13,6 +13,7 @@ using rko_lio::core::GRAVITY_MAG;
 using rko_lio::core::ImuControl;
 using rko_lio::core::LIO;
 using rko_lio::core::Nsec;
+using rko_lio::core::Timestamps;
 using rko_lio::core::TimestampVector;
 using rko_lio::core::to_seconds;
 using rko_lio::core::Vector3sVector;
@@ -32,19 +33,25 @@ constexpr double DT = 1.0;
 constexpr double FIRST_SCAN_END = 0.1;
 constexpr double SECOND_SCAN_END = FIRST_SCAN_END + DT;
 
-TimestampVector linspace_timestamps(size_t n, double t_start, double t_end) {
+Timestamps linspace_timestamps(size_t n, double t_start, double t_end) {
   TimestampVector ts;
   ts.reserve(n);
   for (size_t i = 0; i < n; ++i) {
     const double frac = n == 1 ? 0.0 : static_cast<double>(i) / static_cast<double>(n - 1);
     ts.emplace_back(ns_from_seconds(t_start + (t_end - t_start) * frac));
   }
-  return ts;
+  const Nsec t_start_ns = ns_from_seconds(t_start);
+  const Nsec t_end_ns = ns_from_seconds(t_end);
+  return Timestamps{
+      .min = std::min(t_start_ns, t_end_ns), .max = std::max(t_start_ns, t_end_ns), .per_point = std::move(ts)};
 }
 
 // Single-instant timestamps for the second scan: deskewing reduces to identity
 // when every point shares end_time.
-TimestampVector instant_timestamps(size_t n, double t) { return TimestampVector(n, ns_from_seconds(t)); }
+Timestamps instant_timestamps(size_t n, double t) {
+  return Timestamps{
+      .min = ns_from_seconds(t), .max = ns_from_seconds(t), .per_point = TimestampVector(n, ns_from_seconds(t))};
+}
 
 void feed_imu(LIO& lio,
               double t_start,
@@ -306,6 +313,6 @@ TEST_CASE("Noisy: full SE(3) translation + rotation", "[register_scan][!mayfail]
 TEST_CASE("register_scan: empty timestamps throws instead of UB", "[register_scan]") {
   LIO lio((LIO::Config{}));
   const auto cloud = make_hollow_cube();
-  const TimestampVector empty_timestamps;
+  const Timestamps empty_timestamps{};
   REQUIRE_THROWS_AS(lio.register_scan(cloud, empty_timestamps), std::invalid_argument);
 }


### PR DESCRIPTION
cleaning up how per point timestamps get passed around between core and the wrappers. avoids redundant minmax compute on the timestamp vector whenever one of the endpoints is needed. i held off on this earlier because it needs pybinding changes.

api break. 